### PR TITLE
docs: update env var docs in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ data
 .mcpregistry*
 **/bin
 cmd/registry/registry
-registry

--- a/README.md
+++ b/README.md
@@ -197,11 +197,17 @@ The service can be configured using environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MCP_REGISTRY_ENVIRONMENT`     | Application environment (production, test) | `production` |
-| `MCP_REGISTRY_APP_VERSION`     | Application version | `dev` |
-| `MCP_REGISTRY_DATABASE_URL`    | MongoDB connection string | `mongodb://localhost:27017` |
-| `MCP_REGISTRY_DATABASE_NAME`   | MongoDB database name | `mcp-registry` |
-| `MCP_REGISTRY_COLLECTION_NAME` | MongoDB collection name for server registry | `servers_v2` |
+| `MCP_REGISTRY_APP_VERSION`           | Application version | `dev` |
+| `MCP_REGISTRY_COLLECTION_NAME`       | MongoDB collection name | `servers_v2` |
+| `MCP_REGISTRY_DATABASE_NAME`         | MongoDB database name | `mcp-registry` |
+| `MCP_REGISTRY_DATABASE_URL`          | MongoDB connection string | `mongodb://localhost:27017` |
+| `MCP_REGISTRY_GITHUB_CLIENT_ID`      | GitHub App Client ID |  |
+| `MCP_REGISTRY_GITHUB_CLIENT_SECRET`  | GitHub App Client Secret |  |
+| `MCP_REGISTRY_LOG_LEVEL`             | Log level | `info` |
+| `MCP_REGISTRY_SEED_FILE_PATH`        | Path to import seed file | `data/seed.json` |
+| `MCP_REGISTRY_SEED_IMPORT`           | Import `seed.json` on first run | `true` |
+| `MCP_REGISTRY_SERVER_ADDRESS`        | Listen address for the server | `:8080` |
+
 
 ## Testing
 

--- a/cmd/registry/main.go
+++ b/cmd/registry/main.go
@@ -64,7 +64,7 @@ func main() {
 		}
 	}()
 
-	if cfg.Import {
+	if cfg.SeedImport {
 		log.Println("Importing data...")
 		database.ImportSeedFile(mongoDB, cfg.SeedFilePath)
 		log.Println("Data import completed successfully")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,10 @@ type Config struct {
 	CollectionName     string `env:"COLLECTION_NAME" envDefault:"servers_v2"`
 	LogLevel           string `env:"LOG_LEVEL" envDefault:"info"`
 	SeedFilePath       string `env:"SEED_FILE_PATH" envDefault:"data/seed.json"`
+	SeedImport         bool   `env:"SEED_IMPORT" envDefault:"true"`
 	Version            string `env:"VERSION" envDefault:"dev"`
 	GithubClientID     string `env:"GITHUB_CLIENT_ID" envDefault:""`
 	GithubClientSecret string `env:"GITHUB_CLIENT_SECRET" envDefault:""`
-	Import             bool   `env:"IMPORT" envDefault:"true"`
 }
 
 // NewConfig creates a new configuration with default values


### PR DESCRIPTION
Updates the README with all of the env vars. I also changed `MCP_REGISTRY_IMPORT` to `MCP_REGISTRY_SEED_IMPORT` to be more descriptive and have it next to the `MCP_REGISTRY_SEED_FILE_PATH` env var in the README.

## Motivation and Context
The old docs were out of date.

## How Has This Been Tested?
I built it and tested locally (including with docker).

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
