### PR TITLE
DRAFT RFC - Supported URI Schemes for Server

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -325,7 +325,27 @@ components:
           type: string
           format: uri
           example: "https://mcp-fs.example.com/sse"
-    
+
+    UriScheme:
+      type: object
+      required:
+        - scheme
+        - description
+      properties:
+        scheme:
+          type: string
+          description: "The URI scheme without colon (e.g., 'mcp-filesystem', 'crm-contacts')"
+          example: "file"
+        description:
+          type: string
+          description: "Brief description of the URI scheme's purpose in this server"
+          example: "Local filesystem access"
+        reference_url:
+          type: string
+          format: uri
+          description: "URL to the specification or documentation for this URI scheme"
+          example: "(e.g. JSON Schema Store, IANA, PyPI/NPM, MCP Registry)"
+
     ServerDetail:
       allOf:
         - $ref: '#/components/schemas/Server'
@@ -339,7 +359,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Package'
-            remotes:
-              type: array
-              items:
-                $ref: '#/components/schemas/Remote'
+          remotes:
+            type: array
+            items:
+              $ref: '#/components/schemas/Remote'
+          supported_uri_schemes:
+            type: array
+            description: "URI schemes supported by this MCP server"
+            items:
+              $ref: '#/components/schemas/UriScheme'                


### PR DESCRIPTION
This draft adds a list of URI schemes supported by the MCP Server. 

It is only intended to be used for schemes that the author has good reason to believe will be widely adopted, or there is serious risk of interoperability issues unless the namespace is publicly declared.

When the registry is extended to Host/Client applications, this will allow Clients to offer extended features based on shared support for any particular scheme.

This has been opened for review and discussion on the utility and practical aspects of the idea.

## Motivation and Context

The [User Guide](https://modelcontextprotocol.io/docs/concepts/resources) and [Specification](https://modelcontextprotocol.io/specification/2025-03-26/server/resources) state that
 - Servers can define their own custom URI schemes.
 - (Best Practice) - When implementing resource support: ...Document your custom URI schemes
 - ...implementations are always free to use additional, custom URI schemes

This change enables MCP Server authors, and eventually MCP Client/Host authors to discover, choose and improve interoperability by sharing common resource usage patterns and SDKs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

It is expected that this should be a lightweight, community led effort but with enough oversight that vexatious usage is discouraged. Restricting documentation URLs to the hosting party or "known good" hosting locations would be expected.

Existing registries that may provide some inspiration:
- https://www.schemastore.org/json/
- https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
- PyPi / NPM
- The @modelcontextprotocol/registry project itself.

There's an argument that the @modelcontextprotocol/registry would be a good candidate itself for publishing a Resource URI scheme to allow standardised registry-read operations.