### PR TITLE
support readme_url

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -26,7 +26,8 @@ GET /v0/servers?limit=5000&offset=0
         "version": "1.0.2",
         "release_date": "2023-06-15T10:30:00Z",
         "is_latest": true
-      }
+      },
+      "readme_url": "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/filesystem/README.md"
     }
   ],
   "next": "https://registry.modelcontextprotocol.io/servers?offset=50",
@@ -59,6 +60,7 @@ GET /v0/servers/a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1?version=0.0.3
     "release_date": "2023-06-15T10:30:00Z",
     "is_latest": true
   },
+  "readme_url": "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/filesystem/README.md"
   "package_canonical": "npm",
   "packages": [
     {
@@ -214,6 +216,7 @@ API Response:
     "release_date": "2023-06-15T10:30:00Z",
     "is_latest": true
   },
+  "readme_url": "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/brave-search/README.md"
   "package_canonical": "npm",
   "packages": [
     {
@@ -280,6 +283,7 @@ API Response:
     "release_date": "2023-06-15T10:30:00Z",
     "is_latest": true
   },
+  "readme_url": "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/filesystem/README.md"
   "package_canonical": "docker",
   "packages": [
     {
@@ -373,6 +377,7 @@ API Response:
     "release_date": "2023-06-15T10:30:00Z",
     "is_latest": true
   },
+  "readme_url": "https://raw.githubusercontent.com/example/remote-fs/refs/heads/main/README.md"
   "remotes": [
     {
       "transport_type": "sse",

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -110,6 +110,7 @@ components:
         - description
         - repository
         - version_detail
+        - readme_url
       properties:
         id:
           type: string
@@ -123,6 +124,10 @@ components:
           example: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
         repository:
           $ref: '#/components/schemas/Repository'
+        readme_url:
+          type: string
+          description: URL to the README markdown file of the server
+          example: "https://raw.githubusercontent.com/modelcontextprotocol/servers/refs/heads/main/src/filesystem/README.md"
         version_detail:
           type: object
           required:


### PR DESCRIPTION
Ref #39

Add readme_url property to the server object. This is url to the README markdown file of the server. Returns readme content in markdown format.