### PR TITLE
Removed `jsonSchemaDialect` so openapi.yaml would parse

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,6 @@ paths:
                     example: "Server not found"
 components:
   schemas:
-  jsonSchemaDialect: "https://json-schema.org/draft/2020-12/schema"
     Repository:
       type: object
       required:


### PR DESCRIPTION
Removed `jsonSchemaDialect` so openapi.yaml would parse in toolilng.