### PR TITLE
fix: ignore data directory in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+data
+!data/seed.json


### PR DESCRIPTION
## Motivation and Context

I get this error when building the docker image after running the server in docker compose:

```
ERROR: failed to solve: error from sender: open data/diagnostic.data: permission denied
```

The issue is that `docker-compose.yaml` mounts the data directory in the mongo container which creates files that my user doesn't have access too. Except for seed.json, there doesn't appear to be a reason for those files to be in the docker build layer anyway.

This adds a `.dockeringore` file to exclude everything in data except `seed.json`.

## How Has This Been Tested?
`docker build`

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
