### PR TITLE
feat: use new seed file in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go build -o /build/registry ./cmd/registry
 FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /build/registry .
-COPY --from=builder /app/data/seed.json /app/data/seed.json
+COPY --from=builder /app/data/seed_2025_05_16.json /app/data/seed.json
 COPY --from=builder /app/internal/docs/swagger.yaml /app/internal/docs/swagger.yaml
 EXPOSE 8080
 


### PR DESCRIPTION
Updated the `Dockerfile` to use the new seed file `seed_2025_05_16.json` instead of the old `seed.json`.
