### PR TITLE
Fix naming to use reverse DNS instead of deprecated `@` syntax

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@ GET /v0/servers?limit=5000&offset=0
   "servers": [
     {
       "id": "a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1",
-      "name": "@modelcontextprotocol/servers/src/filesystem",
+      "name": "io.modelcontextprotocol/filesystem",
       "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
       "repository": {
         "url": "https://github.com/modelcontextprotocol/servers",
@@ -47,7 +47,7 @@ GET /v0/servers/a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1?version=0.0.3
 ```json
 {
   "id": "a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1",
-  "name": "@modelcontextprotocol/servers/src/filesystem",
+  "name": "io.modelcontextprotocol/filesystem",
   "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
@@ -142,7 +142,7 @@ API Response:
 ```json
 {
   "id": "brave-search-12345",
-  "name": "@modelcontextprotocol/server-brave-search",
+  "name": "io.modelcontextprotocol/brave-search",
   "description": "MCP server for Brave Search API integration",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
@@ -195,7 +195,7 @@ API Response:
 ```json
 {
   "id": "filesystem-67890",
-  "name": "@modelcontextprotocol/servers/src/filesystem",
+  "name": "io.modelcontextprotocol/filesystem",
   "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -176,7 +176,7 @@ components:
           example: "npm"
         name:
           type: string
-          example: "@modelcontextprotocol/server-filesystem"
+          example: "io.modelcontextprotocol/filesystem"
         version:
           type: string
           example: "1.0.2"

--- a/tools/publisher/mcp.json
+++ b/tools/publisher/mcp.json
@@ -5,7 +5,7 @@
     "packages": [
         {
             "registry_name": "npm",
-            "name": "@<owner>/<server-name>",
+            "name": "io.github.<owner>/<server-name>",
             "version": "0.2.23",
             "package_arguments": [
                 {
@@ -26,7 +26,7 @@
             ]
         },{
             "registry_name": "docker>",
-            "name": "@<owner>/<server-name>-cli",
+            "name": "io.github.<owner>/<server-name>-cli",
             "version": "0.123.223",
             "runtime_hint": "docker",
             "runtime_arguments": [


### PR DESCRIPTION
I realized a handful of our examples were still using the old syntax that we are no longer using, which could cause confusion for folks who don't have the context that we are pushing forward with the reverse DNS scheme.