### PR TITLE
fix: Add default seed.json to match config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go build -o /build/registry ./cmd/registry
 FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /build/registry .
-COPY --from=builder /app/data/seed_2025_05_16.json /app/data/seed.json
+COPY --from=builder /app/data/seed.json /app/data/seed.json
 COPY --from=builder /app/internal/docs/swagger.yaml /app/internal/docs/swagger.yaml
 EXPOSE 8080
 

--- a/data/seed.json
+++ b/data/seed.json
@@ -1,0 +1,17446 @@
+[
+  {
+    "id": "4e9cf4cf-71f6-4aca-bae8-2d10a29ca2e0",
+    "name": "io.github.21st-dev/magic-mcp",
+    "description": "It's like v0 but in your Cursor/WindSurf/Cline. 21st dev Magic MCP server for working with your frontend like Magic",
+    "repository": {
+      "url": "https://github.com/21st-dev/magic-mcp",
+      "source": "github",
+      "id": "935450522"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:56:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@21st-dev/magic",
+        "version": "0.0.46",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d3669201-252f-403c-944b-c3ec0845782b",
+    "name": "io.github.adfin-engineering/mcp-server-adfin",
+    "description": "A Model Context Protocol Server for connecting with Adfin APIs ",
+    "repository": {
+      "url": "https://github.com/Adfin-Engineering/mcp-server-adfin",
+      "source": "github",
+      "id": "951338147"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:56:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "adfinmcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Directory to run the project from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory <absolute_path_to_adfin_mcp_folder>",
+            "default": "--directory <absolute_path_to_adfin_mcp_folder>",
+            "type": "named",
+            "name": "--directory <absolute_path_to_adfin_mcp_folder>",
+            "value_hint": "<absolute_path_to_adfin_mcp_folder>"
+          },
+          {
+            "description": "Script to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "main_adfin_mcp.py",
+            "default": "main_adfin_mcp.py",
+            "type": "positional",
+            "value_hint": "main_adfin_mcp.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<email>",
+            "name": "ADFIN_EMAIL"
+          },
+          {
+            "description": "<password>",
+            "name": "ADFIN_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d86f2098-0be9-4b52-b32e-9d0f17333197",
+    "name": "io.github.tinyfish-io/agentql-mcp",
+    "description": "Model Context Protocol server that integrates AgentQL's data extraction capabilities.",
+    "repository": {
+      "url": "https://github.com/tinyfish-io/agentql-mcp",
+      "source": "github",
+      "id": "906462272"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:56:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "agentql-mcp",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "YOUR_API_KEY",
+            "name": "AGENTQL_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c296f683-5578-474a-bbef-00cfc2716fbc",
+    "name": "io.github.agentrpc/agentrpc",
+    "description": "A universal RPC layer for AI agents. Connect to any function, any language, any framework, in minutes.",
+    "repository": {
+      "url": "https://github.com/agentrpc/agentrpc",
+      "source": "github",
+      "id": "949728461"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:56:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "agentrpc/agentrpc",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Positional argument",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_API_SECRET>",
+            "name": "AGENTRPC_API_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2a0775fa-ff8e-47ff-a5e3-8b7c9b0567a9",
+    "name": "io.github.aiven-open/mcp-aiven",
+    "description": "Model Context Protocol server for Aiven",
+    "repository": {
+      "url": "https://github.com/Aiven-Open/mcp-aiven",
+      "source": "github",
+      "id": "947751392"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-aiven",
+        "version": "0.1.4",
+        "package_arguments": [
+          {
+            "description": "$REPOSITORY_DIRECTORY",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory $REPOSITORY_DIRECTORY",
+            "default": "--directory $REPOSITORY_DIRECTORY",
+            "type": "named",
+            "name": "--directory $REPOSITORY_DIRECTORY",
+            "value_hint": "$REPOSITORY_DIRECTORY"
+          },
+          {
+            "description": "--with-editable $REPOSITORY_DIRECTORY",
+            "is_required": true,
+            "format": "string",
+            "value": "--with-editable $REPOSITORY_DIRECTORY",
+            "default": "--with-editable $REPOSITORY_DIRECTORY",
+            "type": "named",
+            "name": "--with-editable $REPOSITORY_DIRECTORY",
+            "value_hint": "$REPOSITORY_DIRECTORY"
+          },
+          {
+            "description": "--python 3.13",
+            "is_required": true,
+            "format": "string",
+            "value": "--python 3.13",
+            "default": "--python 3.13",
+            "type": "named",
+            "name": "--python 3.13",
+            "value_hint": "3.13"
+          },
+          {
+            "description": "mcp-aiven",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-aiven",
+            "default": "mcp-aiven",
+            "type": "positional",
+            "value_hint": "mcp-aiven"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://api.aiven.io",
+            "name": "AIVEN_BASE_URL"
+          },
+          {
+            "description": "$AIVEN_TOKEN",
+            "name": "AIVEN_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7f6e6610-4df3-490e-95e3-03ec954eb2ab",
+    "name": "io.github.aliyun/alibabacloud-adb-mysql-mcp-server",
+    "description": "AnalyticDB for MySQL MCP Server",
+    "repository": {
+      "url": "https://github.com/aliyun/alibabacloud-adb-mysql-mcp-server",
+      "source": "github",
+      "id": "956503834"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "adb-mysql-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "With flag and value",
+            "is_required": true,
+            "format": "string",
+            "value": "--with adb-mysql-mcp-server",
+            "default": "--with adb-mysql-mcp-server",
+            "type": "named",
+            "name": "--with adb-mysql-mcp-server",
+            "value_hint": "adb-mysql-mcp-server"
+          },
+          {
+            "description": "Script/module to run",
+            "is_required": true,
+            "format": "string",
+            "value": "adb-mysql-mcp-server",
+            "default": "adb-mysql-mcp-server",
+            "type": "positional",
+            "value_hint": "adb-mysql-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "host",
+            "name": "ADB_MYSQL_HOST"
+          },
+          {
+            "description": "port",
+            "name": "ADB_MYSQL_PORT"
+          },
+          {
+            "description": "database_user",
+            "name": "ADB_MYSQL_USER"
+          },
+          {
+            "description": "database_password",
+            "name": "ADB_MYSQL_PASSWORD"
+          },
+          {
+            "description": "database",
+            "name": "ADB_MYSQL_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "24303d73-1ee0-4119-b2f1-3a57c17de967",
+    "name": "io.github.aliyun/alibaba-cloud-ops-mcp-server",
+    "description": "AlibabaCloud CloudOps MCP Server",
+    "repository": {
+      "url": "https://github.com/aliyun/alibaba-cloud-ops-mcp-server",
+      "source": "github",
+      "id": "967873415"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "alibaba-cloud-ops-mcp-server",
+        "version": "0.8.6",
+        "environment_variables": [
+          {
+            "description": "Your Access Key ID",
+            "name": "ALIBABA_CLOUD_ACCESS_KEY_ID"
+          },
+          {
+            "description": "Your Access Key SECRET",
+            "name": "ALIBABA_CLOUD_ACCESS_KEY_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "31d9b130-4676-45d9-930f-a8bc2d5a3b9e",
+    "name": "io.github.apache/iotdb-mcp-server",
+    "description": "Apache IoTDB MCP Server",
+    "repository": {
+      "url": "https://github.com/apache/iotdb-mcp-server",
+      "source": "github",
+      "id": "959057712"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "iotdb-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "The working directory for the command",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory YOUR_REPO_PATH/src/iotdb_mcp_server",
+            "default": "--directory YOUR_REPO_PATH/src/iotdb_mcp_server",
+            "type": "named",
+            "name": "--directory YOUR_REPO_PATH/src/iotdb_mcp_server",
+            "value_hint": "YOUR_REPO_PATH/src/iotdb_mcp_server"
+          },
+          {
+            "description": "Python script to run",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "127.0.0.1",
+            "name": "IOTDB_HOST"
+          },
+          {
+            "description": "6667",
+            "name": "IOTDB_PORT"
+          },
+          {
+            "description": "root",
+            "name": "IOTDB_USER"
+          },
+          {
+            "description": "root",
+            "name": "IOTDB_PASSWORD"
+          },
+          {
+            "description": "test",
+            "name": "IOTDB_DATABASE"
+          },
+          {
+            "description": "table",
+            "name": "IOTDB_SQL_DIALECT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "330047d1-f8c2-4931-9347-d133f1717de3",
+    "name": "io.github.apache/iotdb",
+    "description": "Apache IoTDB",
+    "repository": {
+      "url": "https://github.com/apache/iotdb",
+      "source": "github",
+      "id": "158975124"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "apache/iotdb",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "195dfdbd-bb15-4752-80b6-abc9212cd80f",
+    "name": "io.github.apify/actors-mcp-server",
+    "description": "Model Context Protocol (MCP) Server for Apify's Actors",
+    "repository": {
+      "url": "https://github.com/apify/actors-mcp-server",
+      "source": "github",
+      "id": "911256711"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@apify/actors-mcp-server",
+        "version": "0.1.31",
+        "package_arguments": [
+          {
+            "description": "--actors lukaskrivka/google-maps-with-contact-details,apify/instagram-scraper",
+            "is_required": true,
+            "format": "string",
+            "value": "--actors lukaskrivka/google-maps-with-contact-details,apify/instagram-scraper",
+            "default": "--actors lukaskrivka/google-maps-with-contact-details,apify/instagram-scraper",
+            "type": "named",
+            "name": "--actors lukaskrivka/google-maps-with-contact-details,apify/instagram-scraper",
+            "value_hint": "lukaskrivka/google-maps-with-contact-details,apify/instagram-scraper"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "${input:apify_token}",
+            "name": "APIFY_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5c95a170-d394-4b21-a100-bb953b872922",
+    "name": "io.github.apimatic/apimatic-validator-mcp",
+    "description": "APIMatic Validator MCP Server for validating OpenAPI specs via APIMatic's API with MCP",
+    "repository": {
+      "url": "https://github.com/apimatic/apimatic-validator-mcp",
+      "source": "github",
+      "id": "951214203"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "apimatic-validator---mcp",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "<Add your APIMatic token here>",
+            "name": "APIMATIC_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "de2d7f51-ca20-4fac-abdb-85a912d26375",
+    "name": "io.github.arize-ai/phoenix",
+    "description": "AI Observability & Evaluation",
+    "repository": {
+      "url": "https://github.com/Arize-ai/phoenix",
+      "source": "github",
+      "id": "564072810"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "arize-phoenix",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "50f15d97-7d84-49f7-9232-f797e006358d",
+    "name": "io.github.datastax/astra-db-mcp",
+    "description": "An MCP server for Astra DB workloads",
+    "repository": {
+      "url": "https://github.com/datastax/astra-db-mcp",
+      "source": "github",
+      "id": "943241240"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@datastax/astra-db-mcp",
+        "version": "1.2.0"
+      }
+    ]
+  },
+  {
+    "id": "c4888f33-5e27-449c-ba93-edf383b91686",
+    "name": "io.github.atlanhq/agent-toolkit",
+    "description": "Atlan AI Agent Toolkit",
+    "repository": {
+      "url": "https://github.com/atlanhq/agent-toolkit",
+      "source": "github",
+      "id": "959799376"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "atlanhq/agent-toolkit",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "d85fa87b-48e1-4b81-8408-9d0c446f7de3",
+    "name": "io.github.audienseco/mcp-audiense-insights",
+    "description": "Audiense Insights MCP Server is a server based on the Model Context Protocol (MCP) that allows Claude and other MCP-compatible clients to interact with your Audiense Insights account",
+    "repository": {
+      "url": "https://github.com/AudienseCo/mcp-audiense-insights",
+      "source": "github",
+      "id": "925304505"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:26Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-audiense-insights",
+        "version": "0.2.0",
+        "environment_variables": [
+          {
+            "description": "your_client_id_here",
+            "name": "AUDIENSE_CLIENT_ID"
+          },
+          {
+            "description": "your_client_secret_here",
+            "name": "AUDIENSE_CLIENT_SECRET"
+          },
+          {
+            "description": "your_token_here",
+            "name": "TWITTER_BEARER_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "ac19206d-f465-4c38-b62f-23635837b239",
+    "name": "io.github.axiomhq/mcp-server-axiom",
+    "description": "Axiom Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/axiomhq/mcp-server-axiom",
+      "source": "github",
+      "id": "899010918"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "axiomhq/mcp-server-axiom",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Specifies a configuration file",
+            "is_required": true,
+            "format": "string",
+            "value": "--config /path/to/your/config.txt",
+            "default": "--config /path/to/your/config.txt",
+            "type": "named",
+            "name": "--config /path/to/your/config.txt",
+            "value_hint": "/path/to/your/config.txt"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "xaat-your-token",
+            "name": "AXIOM_TOKEN"
+          },
+          {
+            "description": "https://api.axiom.co",
+            "name": "AXIOM_URL"
+          },
+          {
+            "description": "your-org-id",
+            "name": "AXIOM_ORG_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a5f21d1d-1267-4a62-9deb-1bb961dc5b13",
+    "name": "io.github.azure/azure-mcp",
+    "description": "The Azure MCP Server, bringing the power of Azure to your agents.",
+    "repository": {
+      "url": "https://github.com/Azure/azure-mcp",
+      "source": "github",
+      "id": "967503541"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "Azure/azure-mcp",
+        "version": ""
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "http://localhost:5008/sse"
+      }
+    ]
+  },
+  {
+    "id": "2535daf3-637b-40d1-a4c2-41ef60a726b8",
+    "name": "io.github.bankless/onchain-mcp",
+    "description": "Bringing the bankless onchain API to MCP",
+    "repository": {
+      "url": "https://github.com/Bankless/onchain-mcp",
+      "source": "github",
+      "id": "946011336"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:37Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@bankless/onchain-mcp",
+        "version": "1.0.6",
+        "environment_variables": [
+          {
+            "description": "your_api_token_here",
+            "name": "BANKLESS_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "36e14e79-6228-442f-b3c7-c7080b6282f0",
+    "name": "io.github.ahnlabio/bicscan-mcp",
+    "description": "BICScan MCP Server",
+    "repository": {
+      "url": "https://github.com/ahnlabio/bicscan-mcp",
+      "source": "github",
+      "id": "954410951"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "bicscan-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "use repo url",
+            "is_required": true,
+            "format": "string",
+            "value": "--from git+https://github.com/ahnlabio/bicscan-mcp",
+            "default": "--from git+https://github.com/ahnlabio/bicscan-mcp",
+            "type": "named",
+            "name": "--from git+https://github.com/ahnlabio/bicscan-mcp",
+            "value_hint": "git+https://github.com/ahnlabio/bicscan-mcp"
+          },
+          {
+            "description": "subcommand or positional argument",
+            "is_required": true,
+            "format": "string",
+            "value": "bicscan-mcp",
+            "default": "bicscan-mcp",
+            "type": "positional",
+            "value_hint": "bicscan-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_BICSCAN_API_KEY_HERE",
+            "name": "BICSCAN_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9e07df79-22e2-464d-a842-06f08b875196",
+    "name": "io.github.bitrise-io/bitrise-mcp",
+    "description": "MCP Server for the Bitrise API, enabling app management, build operations, artifact management and more.",
+    "repository": {
+      "url": "https://github.com/bitrise-io/bitrise-mcp",
+      "source": "github",
+      "id": "958502546"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "bitrise-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "source package location",
+            "is_required": true,
+            "format": "string",
+            "value": "--from git+https://github.com/bitrise-io/bitrise-mcp@v1.1.0",
+            "default": "--from git+https://github.com/bitrise-io/bitrise-mcp@v1.1.0",
+            "type": "named",
+            "name": "--from git+https://github.com/bitrise-io/bitrise-mcp@v1.1.0",
+            "value_hint": "git+https://github.com/bitrise-io/bitrise-mcp@v1.1.0"
+          },
+          {
+            "description": "local entrypoint command",
+            "is_required": true,
+            "format": "string",
+            "value": "bitrise-mcp",
+            "default": "bitrise-mcp",
+            "type": "positional",
+            "value_hint": "bitrise-mcp"
+          },
+          {
+            "description": "list of enabled API groups",
+            "is_required": true,
+            "format": "string",
+            "value": "--enabled-api-groups cache-items,pipelines",
+            "default": "--enabled-api-groups cache-items,pipelines",
+            "type": "named",
+            "name": "--enabled-api-groups cache-items,pipelines",
+            "value_hint": "cache-items,pipelines"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_PAT>",
+            "name": "BITRISE_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "46bcb36f-ede9-412e-8181-7c7ece41fa04",
+    "name": "io.github.box-community/mcp-server-box",
+    "description": "An MCP server capable of interacting with the Box API",
+    "repository": {
+      "url": "https://github.com/box-community/mcp-server-box",
+      "source": "github",
+      "id": "938387717"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-box",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "src/mcp_server_box.py",
+            "default": "src/mcp_server_box.py",
+            "type": "positional",
+            "value_hint": "src/mcp_server_box.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "84dcab53-bfa3-4375-b69e-d519eb00af0f",
+    "name": "io.github.browserbase/mcp-server-browserbase",
+    "description": "Allow LLMs to control a browser with Browserbase and Stagehand",
+    "repository": {
+      "url": "https://github.com/browserbase/mcp-server-browserbase",
+      "source": "github",
+      "id": "899184149"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "browserbase/mcp-server-browserbase",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "59a97c76-20ff-48a2-8c1d-89cc66b57697",
+    "name": "io.github.chargebee/agentkit",
+    "description": "Seamlessly integrate AI agents with Chargebee using AgentKit for smarter billing and subscription workflows.",
+    "repository": {
+      "url": "https://github.com/chargebee/agentkit",
+      "source": "github",
+      "id": "946416125"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@chargebee/agentkit-repo",
+        "version": "0.0.0"
+      }
+    ]
+  },
+  {
+    "id": "97de67c4-a78f-4ea7-9233-4da9fe6752cf",
+    "name": "io.github.chroma-core/chroma-mcp",
+    "description": "A Model Context Protocol (MCP) server implementation that provides database capabilities for Chroma",
+    "repository": {
+      "url": "https://github.com/chroma-core/chroma-mcp",
+      "source": "github",
+      "id": "930632525"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "chroma-mcp",
+        "version": "0.2.2"
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "a48ff624-6d95-4b8e-a0ed-498c4d838411",
+    "name": "io.github.circleci-public/mcp-server-circleci",
+    "description": "A specialized server implementation for the Model Context Protocol (MCP) designed to integrate with CircleCI's development workflow. This project serves as a bridge between CircleCI's infrastructure and the Model Context Protocol, enabling enhanced AI-powered development experiences.",
+    "repository": {
+      "url": "https://github.com/CircleCI-Public/mcp-server-circleci",
+      "source": "github",
+      "id": "955501958"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:57:58Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@circleci/mcp-server-circleci",
+        "version": "0.7.1",
+        "environment_variables": [
+          {
+            "description": "your-circleci-token",
+            "name": "CIRCLECI_TOKEN"
+          },
+          {
+            "description": "https://circleci.com",
+            "name": "CIRCLECI_BASE_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "98259539-3c6f-4462-b2b6-9a2567ff0545",
+    "name": "io.github.clickhouse/mcp-clickhouse",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/ClickHouse/mcp-clickhouse",
+      "source": "github",
+      "id": "908231244"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-clickhouse",
+        "version": "0.1.7",
+        "package_arguments": [
+          {
+            "description": "Use the specified runtime feature",
+            "is_required": true,
+            "format": "string",
+            "value": "--with mcp-clickhouse",
+            "default": "--with mcp-clickhouse",
+            "type": "named",
+            "name": "--with mcp-clickhouse",
+            "value_hint": "mcp-clickhouse"
+          },
+          {
+            "description": "Specify Python version",
+            "is_required": true,
+            "format": "string",
+            "value": "--python 3.13",
+            "default": "--python 3.13",
+            "type": "named",
+            "name": "--python 3.13",
+            "value_hint": "3.13"
+          },
+          {
+            "description": "Positional argument to run (script or module)",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-clickhouse",
+            "default": "mcp-clickhouse",
+            "type": "positional",
+            "value_hint": "mcp-clickhouse"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<clickhouse-host>",
+            "name": "CLICKHOUSE_HOST"
+          },
+          {
+            "description": "<clickhouse-user>",
+            "name": "CLICKHOUSE_USER"
+          },
+          {
+            "description": "<clickhouse-password>",
+            "name": "CLICKHOUSE_PASSWORD"
+          },
+          {
+            "description": "<optional-database>",
+            "name": "CLICKHOUSE_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2ad7c503-7daa-46c8-9295-8a1ed53271a6",
+    "name": "io.github.cloudflare/mcp-server-cloudflare",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/cloudflare/mcp-server-cloudflare",
+      "source": "github",
+      "id": "895268756"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@cloudflare/mcp-server-cloudflare",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "URL to SSE endpoint for observability",
+            "is_required": true,
+            "format": "string",
+            "value": "https://observability.mcp.cloudflare.com/sse",
+            "default": "https://observability.mcp.cloudflare.com/sse",
+            "type": "positional",
+            "value_hint": "https://observability.mcp.cloudflare.com/sse"
+          }
+        ]
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "https://observability.mcp.cloudflare.com/sse"
+      },
+      {
+        "transport_type": "sse",
+        "url": "https://bindings.mcp.cloudflare.com/sse"
+      }
+    ]
+  },
+  {
+    "id": "c746fe90-e3f6-4328-82c1-aeef49a2b6d9",
+    "name": "io.github.codacy/codacy-mcp-server",
+    "description": "Codacy's MCP Server implementation",
+    "repository": {
+      "url": "https://github.com/codacy/codacy-mcp-server",
+      "source": "github",
+      "id": "954645052"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@codacy/codacy-mcp",
+        "version": "0.0.1",
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "CODACY_ACCOUNT_TOKEN"
+          },
+          {
+            "description": "<VERSION>",
+            "name": "CODACY_CLI_VERSION"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6e6e3083-47bf-47da-9d0f-14805de093a9",
+    "name": "io.github.codelogicincengineering/codelogic-mcp-server",
+    "description": "An MCP Server to utilize Codelogic's rich software dependency data in your AI programming assistant.",
+    "repository": {
+      "url": "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server",
+      "source": "github",
+      "id": "959229901"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "codelogic-mcp-server",
+        "version": "1.0.2"
+      }
+    ]
+  },
+  {
+    "id": "61b3cbd8-8eee-4bef-a0ef-5fcaf6449201",
+    "name": "io.github.comet-ml/opik-mcp",
+    "description": "Model Context Protocol (MCP) implementation for Opik enabling seamless IDE integration and unified access to prompts, projects, traces, and metrics. ",
+    "repository": {
+      "url": "https://github.com/comet-ml/opik-mcp",
+      "source": "github",
+      "id": "946763772"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "test-opik-mcp",
+        "version": "0.0.1",
+        "package_arguments": [
+          {
+            "description": "API URL for the opik MCP server",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiUrl https://www.comet.com/opik/api",
+            "default": "--apiUrl https://www.comet.com/opik/api",
+            "type": "named",
+            "name": "--apiUrl https://www.comet.com/opik/api",
+            "value_hint": "https://www.comet.com/opik/api"
+          },
+          {
+            "description": "API Key for authentication",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiKey YOUR_API_KEY",
+            "default": "--apiKey YOUR_API_KEY",
+            "type": "named",
+            "name": "--apiKey YOUR_API_KEY",
+            "value_hint": "YOUR_API_KEY"
+          },
+          {
+            "description": "Workspace name",
+            "is_required": true,
+            "format": "string",
+            "value": "--workspace default",
+            "default": "--workspace default",
+            "type": "named",
+            "name": "--workspace default",
+            "value_hint": "default"
+          },
+          {
+            "description": "Enable debug mode",
+            "is_required": true,
+            "format": "string",
+            "value": "--debug true",
+            "default": "--debug true",
+            "type": "named",
+            "name": "--debug true",
+            "value_hint": "true"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://www.comet.com/opik/api",
+            "name": "OPIK_API_BASE_URL"
+          },
+          {
+            "description": "YOUR_API_KEY",
+            "name": "OPIK_API_KEY"
+          },
+          {
+            "description": "default",
+            "name": "OPIK_WORKSPACE_NAME"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c8be6fef-88d0-41e0-9906-8670233d81f8",
+    "name": "io.github.comet-ml/opik",
+    "description": "Debug, evaluate, and monitor your LLM applications, RAG systems, and agentic workflows with comprehensive tracing, automated evaluations, and production-ready dashboards.",
+    "repository": {
+      "url": "https://github.com/comet-ml/opik",
+      "source": "github",
+      "id": "638951438"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:15Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "comet-ml/opik",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "3f49614c-5424-4875-92ef-9697923375cf",
+    "name": "io.github.couchbase-ecosystem/mcp-server-couchbase",
+    "description": "MCP Server to interact with data in Couchbase Clusters",
+    "repository": {
+      "url": "https://github.com/Couchbase-Ecosystem/mcp-server-couchbase",
+      "source": "github",
+      "id": "955488295"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-couchbase",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "Specify directory to work in.",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/cloned/repo/mcp-server-couchbase/",
+            "default": "--directory path/to/cloned/repo/mcp-server-couchbase/",
+            "type": "named",
+            "name": "--directory path/to/cloned/repo/mcp-server-couchbase/",
+            "value_hint": "path/to/cloned/repo/mcp-server-couchbase/"
+          },
+          {
+            "description": "Positional argument for Python script to execute.",
+            "is_required": true,
+            "format": "string",
+            "value": "src/mcp_server.py",
+            "default": "src/mcp_server.py",
+            "type": "positional",
+            "value_hint": "src/mcp_server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "couchbases://connection-string",
+            "name": "CB_CONNECTION_STRING"
+          },
+          {
+            "description": "username",
+            "name": "CB_USERNAME"
+          },
+          {
+            "description": "password",
+            "name": "CB_PASSWORD"
+          },
+          {
+            "description": "bucket_name",
+            "name": "CB_BUCKET_NAME"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9c2d91f0-76c4-4292-a19f-e81e962954b5",
+    "name": "io.github.its-dart/dart-mcp-server",
+    "description": "Dart AI Model Context Protocol (MCP) server",
+    "repository": {
+      "url": "https://github.com/its-dart/dart-mcp-server",
+      "source": "github",
+      "id": "936960342"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:23Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "dart-mcp-server",
+        "version": "0.1.13",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "positional",
+            "value_hint": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "positional",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "-e",
+            "is_required": true,
+            "format": "string",
+            "value": "-e DART_TOKEN",
+            "default": "-e DART_TOKEN",
+            "type": "named",
+            "name": "-e DART_TOKEN",
+            "value_hint": "DART_TOKEN"
+          },
+          {
+            "description": "mcp/dart",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp/dart",
+            "default": "mcp/dart",
+            "type": "positional",
+            "value_hint": "mcp/dart"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "dsa_...",
+            "name": "DART_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1743c861-7e1a-42b2-a300-6059fcd82cb9",
+    "name": "io.github.devhub/devhub-cms-mcp",
+    "description": "DevHub CMS LLM integration through the Model Context Protocol",
+    "repository": {
+      "url": "https://github.com/devhub/devhub-cms-mcp",
+      "source": "github",
+      "id": "950064178"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "devhub-cms-mcp",
+        "version": "0.3.0"
+      }
+    ]
+  },
+  {
+    "id": "3afff2d4-d77f-42c2-bf39-ce786ecb0ecf",
+    "name": "io.github.dynatrace-oss/dynatrace-mcp",
+    "description": "MCP server for Dynatrace Observability",
+    "repository": {
+      "url": "https://github.com/dynatrace-oss/dynatrace-mcp",
+      "source": "github",
+      "id": "971357826"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:26Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@dynatrace-oss/dynatrace-mcp-server",
+        "version": "0.1.2"
+      }
+    ]
+  },
+  {
+    "id": "1f25c28f-9afe-4f34-9e29-d18aab507255",
+    "name": "io.github.e2b-dev/mcp-server",
+    "description": "Giving Claude ability to run code with E2B via MCP (Model Context Protocol)",
+    "repository": {
+      "url": "https://github.com/e2b-dev/mcp-server",
+      "source": "github",
+      "id": "896943331"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "e2b-mcp-root",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "7c870985-c457-4221-8088-977680764f70",
+    "name": "io.github.edgee-cloud/mcp-server-edgee",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/edgee-cloud/mcp-server-edgee",
+      "source": "github",
+      "id": "957822597"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@edgee/mcp-server-edgee",
+        "version": "0.1.3",
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "EDGEE_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "33102362-9e44-442f-8aa9-4443ce50c396",
+    "name": "io.github.edubase/mcp",
+    "description": "The EduBase MCP server enables Claude and other LLMs to interact with EduBase's comprehensive e-learning platform through the Model Context Protocol (MCP).",
+    "repository": {
+      "url": "https://github.com/EduBase/MCP",
+      "source": "github",
+      "id": "940803959"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@edubase/mcp",
+        "version": "1.0.10",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "-e EDUBASE_API_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e EDUBASE_API_URL",
+            "default": "-e EDUBASE_API_URL",
+            "type": "named",
+            "name": "-e EDUBASE_API_URL",
+            "value_hint": "EDUBASE_API_URL"
+          },
+          {
+            "description": "-e EDUBASE_API_APP",
+            "is_required": true,
+            "format": "string",
+            "value": "-e EDUBASE_API_APP",
+            "default": "-e EDUBASE_API_APP",
+            "type": "named",
+            "name": "-e EDUBASE_API_APP",
+            "value_hint": "EDUBASE_API_APP"
+          },
+          {
+            "description": "-e EDUBASE_API_KEY",
+            "is_required": true,
+            "format": "string",
+            "value": "-e EDUBASE_API_KEY",
+            "default": "-e EDUBASE_API_KEY",
+            "type": "named",
+            "name": "-e EDUBASE_API_KEY",
+            "value_hint": "EDUBASE_API_KEY"
+          },
+          {
+            "description": "edubase/mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "edubase/mcp",
+            "default": "edubase/mcp",
+            "type": "positional",
+            "value_hint": "edubase/mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://domain.edubase.net/api",
+            "name": "EDUBASE_API_URL"
+          },
+          {
+            "description": "your_integration_app_id",
+            "name": "EDUBASE_API_APP"
+          },
+          {
+            "description": "your_integration_secret_key",
+            "name": "EDUBASE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1b8a16d9-0648-4790-b853-d919a6be16e9",
+    "name": "io.github.elastic/mcp-server-elasticsearch",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/elastic/mcp-server-elasticsearch",
+      "source": "github",
+      "id": "953992846"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:37Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@elastic/mcp-server-elasticsearch",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "/path/to/your/project/dist/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/your/project/dist/index.js",
+            "default": "/path/to/your/project/dist/index.js",
+            "type": "positional",
+            "value_hint": "/path/to/your/project/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-elasticsearch-url",
+            "name": "ES_URL"
+          },
+          {
+            "description": "your-api-key",
+            "name": "ES_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d689b152-64e8-4f5d-a937-91331fa3a771",
+    "name": "io.github.esignaturescom/mcp-server-esignatures",
+    "description": "MCP server for eSignatures (https://esignatures.com)",
+    "repository": {
+      "url": "https://github.com/esignaturescom/mcp-server-esignatures",
+      "source": "github",
+      "id": "922105354"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-esignatures",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "2a2aa283-57c8-474f-8a27-27954214cb6b",
+    "name": "io.github.exa-labs/exa-mcp-server",
+    "description": "Claude can perform Web Search | Exa with MCP (Model Context Protocol)",
+    "repository": {
+      "url": "https://github.com/exa-labs/exa-mcp-server",
+      "source": "github",
+      "id": "895291604"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "exa-mcp-server",
+        "version": "0.3.10",
+        "package_arguments": [
+          {
+            "description": "Comma-separated list of tools",
+            "is_required": true,
+            "format": "string",
+            "value": "--tools=web_search_exa,research_paper_search,company_research,crawling,competitor_finder,linkedin_search,wikipedia_search_exa,github_search",
+            "default": "--tools=web_search_exa,research_paper_search,company_research,crawling,competitor_finder,linkedin_search,wikipedia_search_exa,github_search",
+            "type": "named",
+            "name": "--tools=web_search_exa,research_paper_search,company_research,crawling,competitor_finder,linkedin_search,wikipedia_search_exa,github_search",
+            "value_hint": "web_search_exa,research_paper_search,company_research,crawling,competitor_finder,linkedin_search,wikipedia_search_exa,github_search"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-key-here",
+            "name": "EXA_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0e7533d0-5925-4e06-a6bf-5da4e4e21aec",
+    "name": "io.github.fewsats/fewsats-mcp",
+    "description": "Fewsats MCP server",
+    "repository": {
+      "url": "https://github.com/Fewsats/fewsats-mcp",
+      "source": "github",
+      "id": "947211439"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fewsats-mcp",
+        "version": "0.1.4",
+        "environment_variables": [
+          {
+            "description": "YOUR_FEWSATS_API_KEY",
+            "name": "FEWSATS_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "78c126ff-906a-4596-9bf4-db2cf61796b8",
+    "name": "io.github.fibery-inc/fibery-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Fibery-inc/fibery-mcp-server",
+      "source": "github",
+      "id": "947810349"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "fibery-mcp-server",
+        "version": "0.1.3",
+        "package_arguments": [
+          {
+            "description": "directory to run from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/cloned/fibery-mcp-server",
+            "default": "--directory path/to/cloned/fibery-mcp-server",
+            "type": "named",
+            "name": "--directory path/to/cloned/fibery-mcp-server",
+            "value_hint": "path/to/cloned/fibery-mcp-server"
+          },
+          {
+            "description": "server entry point",
+            "is_required": true,
+            "format": "string",
+            "value": "fibery-mcp-server",
+            "default": "fibery-mcp-server",
+            "type": "positional",
+            "value_hint": "fibery-mcp-server"
+          },
+          {
+            "description": "Fibery host domain",
+            "is_required": true,
+            "format": "string",
+            "value": "--fibery-host your-domain.fibery.io",
+            "default": "--fibery-host your-domain.fibery.io",
+            "type": "named",
+            "name": "--fibery-host your-domain.fibery.io",
+            "value_hint": "your-domain.fibery.io"
+          },
+          {
+            "description": "Fibery API Token",
+            "is_required": true,
+            "format": "string",
+            "value": "--fibery-api-token your-api-token",
+            "default": "--fibery-api-token your-api-token",
+            "type": "named",
+            "name": "--fibery-api-token your-api-token",
+            "value_hint": "your-api-token"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2d870a4e-d521-4d66-a471-abce884ea07b",
+    "name": "io.github.financial-datasets/mcp-server",
+    "description": "An MCP server for interacting with the Financial Datasets stock market API.",
+    "repository": {
+      "url": "https://github.com/financial-datasets/mcp-server",
+      "source": "github",
+      "id": "944516885"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "13b91785-9041-468d-a136-e6c9e9dd7be9",
+    "name": "io.github.mendableai/firecrawl-mcp-server",
+    "description": "Official Firecrawl MCP Server - Adds powerful web scraping to Cursor, Claude and any other LLM clients.",
+    "repository": {
+      "url": "https://github.com/mendableai/firecrawl-mcp-server",
+      "source": "github",
+      "id": "899407931"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "firecrawl-mcp",
+        "version": "1.9.0"
+      }
+    ]
+  },
+  {
+    "id": "0bee6074-d16a-4482-a315-5b8f0f1abcf1",
+    "name": "io.github.fireproof-storage/mcp-database-server",
+    "description": "Store and load JSON documents from LLM tool use",
+    "repository": {
+      "url": "https://github.com/fireproof-storage/mcp-database-server",
+      "source": "github",
+      "id": "904432283"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:58:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "todos",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "f4b01928-545f-4f65-a9b4-2bcc4f4a7204",
+    "name": "io.github.gibsonai/mcp",
+    "description": "GibsonAI's MCP server",
+    "repository": {
+      "url": "https://github.com/GibsonAI/mcp",
+      "source": "github",
+      "id": "967696769"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "GibsonAI/mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "gibson",
+            "is_required": true,
+            "format": "string",
+            "value": "gibson",
+            "default": "gibson",
+            "type": "positional",
+            "value_hint": "gibson"
+          },
+          {
+            "description": "mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "88f1bf70-a3ea-4bf4-933e-25ae6ea3003c",
+    "name": "io.github.oschina/mcp-gitee",
+    "description": "mcp-gitee is a Model Context Protocol (MCP) server implementation for Gitee. It provides a set of tools that interact with Gitee's API, allowing AI assistants to manage repository, issues, pull requests, etc.",
+    "repository": {
+      "url": "https://github.com/oschina/mcp-gitee",
+      "source": "github",
+      "id": "947190076"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "oschina/mcp-gitee",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "https://gitee.com/api/v5",
+            "name": "GITEE_API_BASE"
+          },
+          {
+            "description": "<your personal access token>",
+            "name": "GITEE_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "3e50df21-8223-440d-bad9-dfc9ce117af4",
+    "name": "io.github.gleanwork/mcp-server",
+    "description": "MCP server for Glean API integration",
+    "repository": {
+      "url": "https://github.com/gleanwork/mcp-server",
+      "source": "github",
+      "id": "946754858"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@gleanwork/mcp-server",
+        "version": "0.6.1",
+        "environment_variables": [
+          {
+            "description": "<glean instance name>",
+            "name": "GLEAN_INSTANCE"
+          },
+          {
+            "description": "<glean api token>",
+            "name": "GLEAN_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "11e3a5f5-867c-4f1e-ba79-1b803550fb1a",
+    "name": "io.github.nota/gyazo-mcp-server",
+    "description": "Official Model Context Protocol server for Gyazo",
+    "repository": {
+      "url": "https://github.com/nota/gyazo-mcp-server",
+      "source": "github",
+      "id": "922406701"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@notainc/gyazo-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "docker named argument for stdin",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "docker named argument for removing the container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "docker named argument to set environment variable",
+            "is_required": true,
+            "format": "string",
+            "value": "-e",
+            "default": "-e",
+            "type": "named",
+            "name": "-e",
+            "value_hint": "-e"
+          },
+          {
+            "description": "docker positional argument indicating the image name",
+            "is_required": true,
+            "format": "string",
+            "value": "GYAZO_ACCESS_TOKEN",
+            "default": "GYAZO_ACCESS_TOKEN",
+            "type": "positional",
+            "value_hint": "GYAZO_ACCESS_TOKEN"
+          },
+          {
+            "description": "docker positional argument indicating the package to run",
+            "is_required": true,
+            "format": "string",
+            "value": "gyazo-mcp-server",
+            "default": "gyazo-mcp-server",
+            "type": "positional",
+            "value_hint": "gyazo-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-access-token-here",
+            "name": "GYAZO_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0f970fc6-418a-45c7-a665-00e725e8338d",
+    "name": "io.github.gotohuman/gotohuman-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/gotohuman/gotohuman-mcp-server",
+      "source": "github",
+      "id": "952612861"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:13Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gotohuman/mcp-server",
+        "version": "0.1.2",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "GOTOHUMAN_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1329d108-67d0-488a-85a1-cc65b58cf5cd",
+    "name": "io.github.grafana/mcp-grafana",
+    "description": "MCP server for Grafana",
+    "repository": {
+      "url": "https://github.com/grafana/mcp-grafana",
+      "source": "github",
+      "id": "907869862"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "grafana/mcp-grafana",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Remove container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Publish a container's port(s) to the host",
+            "is_required": true,
+            "format": "string",
+            "value": "-p 8000:8000",
+            "default": "-p 8000:8000",
+            "type": "named",
+            "name": "-p 8000:8000",
+            "value_hint": "8000:8000"
+          },
+          {
+            "description": "Set environment variable GRAFANA_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e GRAFANA_URL",
+            "default": "-e GRAFANA_URL",
+            "type": "named",
+            "name": "-e GRAFANA_URL",
+            "value_hint": "GRAFANA_URL"
+          },
+          {
+            "description": "Set environment variable GRAFANA_API_KEY",
+            "is_required": true,
+            "format": "string",
+            "value": "-e GRAFANA_API_KEY",
+            "default": "-e GRAFANA_API_KEY",
+            "type": "named",
+            "name": "-e GRAFANA_API_KEY",
+            "value_hint": "GRAFANA_API_KEY"
+          },
+          {
+            "description": "Container image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp/grafana",
+            "default": "mcp/grafana",
+            "type": "positional",
+            "value_hint": "mcp/grafana"
+          },
+          {
+            "description": "Enable debug mode",
+            "format": "string",
+            "value": "-debug",
+            "default": "-debug",
+            "type": "named",
+            "name": "-debug"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://localhost:3000",
+            "name": "GRAFANA_URL"
+          },
+          {
+            "description": "<your service account token>",
+            "name": "GRAFANA_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e44b5cad-3801-4403-b8ee-67f3ea1cd909",
+    "name": "io.github.graphlit/graphlit-mcp-server",
+    "description": "Model Context Protocol (MCP) Server for Graphlit Platform",
+    "repository": {
+      "url": "https://github.com/graphlit/graphlit-mcp-server",
+      "source": "github",
+      "id": "940989522"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:21Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "graphlit-mcp-server",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "${input:organization_id}",
+            "name": "GRAPHLIT_ORGANIZATION_ID"
+          },
+          {
+            "description": "${input:environment_id}",
+            "name": "GRAPHLIT_ENVIRONMENT_ID"
+          },
+          {
+            "description": "${input:jwt_secret}",
+            "name": "GRAPHLIT_JWT_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7974b19d-8030-428b-a016-168c65058b41",
+    "name": "io.github.greptimeteam/greptimedb-mcp-server",
+    "description": "A Model Context Protocol (MCP) server implementation for GreptimeDB",
+    "repository": {
+      "url": "https://github.com/GreptimeTeam/greptimedb-mcp-server",
+      "source": "github",
+      "id": "947171153"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "greptimedb-mcp-server",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "localhost",
+            "name": "GREPTIMEDB_HOST"
+          },
+          {
+            "description": "4002",
+            "name": "GREPTIMEDB_PORT"
+          },
+          {
+            "description": "root",
+            "name": "GREPTIMEDB_USER"
+          },
+          {
+            "description": "public",
+            "name": "GREPTIMEDB_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "68d8d603-4f42-4ee3-b49d-ef890fb745c0",
+    "name": "io.github.greptimeteam/greptimedb",
+    "description": "Open-source, cloud-native, unified observability database for metrics, logs and traces, supporting SQL/PromQL/Streaming. Available on GreptimeCloud.",
+    "repository": {
+      "url": "https://github.com/GreptimeTeam/greptimedb",
+      "source": "github",
+      "id": "480217156"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "GreptimeTeam/greptimedb",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "cb1a844b-0145-433b-9a6f-f8ef19b2b3f4",
+    "name": "io.github.heroku/heroku-mcp-server",
+    "description": "Heroku Platform MCP Server using the Heroku CLI",
+    "repository": {
+      "url": "https://github.com/heroku/heroku-mcp-server",
+      "source": "github",
+      "id": "955359601"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@heroku/mcp-server",
+        "version": "1.0.4"
+      }
+    ]
+  },
+  {
+    "id": "e67dda78-7d99-43e5-9e98-c80267f34940",
+    "name": "io.github.aliyun/alibabacloud-hologres-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/aliyun/alibabacloud-hologres-mcp-server",
+      "source": "github",
+      "id": "951662313"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "hologres-mcp-server",
+        "version": "0.1.9",
+        "environment_variables": [
+          {
+            "description": "host",
+            "name": "HOLOGRES_HOST"
+          },
+          {
+            "description": "port",
+            "name": "HOLOGRES_PORT"
+          },
+          {
+            "description": "access_id",
+            "name": "HOLOGRES_USER"
+          },
+          {
+            "description": "access_key",
+            "name": "HOLOGRES_PASSWORD"
+          },
+          {
+            "description": "database",
+            "name": "HOLOGRES_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "19aa503d-7b8e-42d8-a1e5-3bc918d36382",
+    "name": "io.github.honeycombio/honeycomb-mcp",
+    "description": "Allows Honeycomb Enterprise customers to use AI to query and analyze their data, alerts, dashboards, and more; and cross-reference production behavior with the codebase.",
+    "repository": {
+      "url": "https://github.com/honeycombio/honeycomb-mcp",
+      "source": "github",
+      "id": "906807010"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@honeycombio/honeycomb-mcp",
+        "version": "0.0.1"
+      }
+    ]
+  },
+  {
+    "id": "feb2b365-5fab-461e-a8d3-89e9349ee743",
+    "name": "io.github.hyperbrowserai/mcp",
+    "description": "A MCP server implementation for hyperbrowser",
+    "repository": {
+      "url": "https://github.com/hyperbrowserai/mcp",
+      "source": "github",
+      "id": "938957096"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "hyperbrowser-mcp",
+        "version": "1.0.25",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "HYPERBROWSER_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "16dc9c56-47bb-4604-9f37-221dd07510ed",
+    "name": "io.github.ibm/wxflows",
+    "description": "Examples and tutorials for building AI applications with watsonx.ai Flows Engine",
+    "repository": {
+      "url": "https://github.com/IBM/wxflows",
+      "source": "github",
+      "id": "822793282"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "IBM/wxflows",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "8df45968-12aa-4c35-ae54-62973243334a",
+    "name": "io.github.jamsocket/forevervm",
+    "description": "Securely run AI-generated code in stateful sandboxes that run forever.",
+    "repository": {
+      "url": "https://github.com/jamsocket/forevervm",
+      "source": "github",
+      "id": "918657398"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "jamsocket/forevervm",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "afd9f984-ea69-4a8c-86ac-fdb58f3ab37c",
+    "name": "io.github.elie222/inbox-zero",
+    "description": "The world's best AI personal assistant for email. Open source app to help you reach inbox zero fast.",
+    "repository": {
+      "url": "https://github.com/elie222/inbox-zero",
+      "source": "github",
+      "id": "665613753"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "inbox-zero",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "bfcde7fb-0ea1-499f-bca0-17ffcba95a0c",
+    "name": "io.github.inkeep/mcp-server-python",
+    "description": "Inkeep MCP Server",
+    "repository": {
+      "url": "https://github.com/inkeep/mcp-server-python",
+      "source": "github",
+      "id": "947631175"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "inkeep-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Directory for the inkeep-mcp-server",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory <YOUR_INKEEP_MCP_SERVER_ABSOLUTE_PATH>",
+            "default": "--directory <YOUR_INKEEP_MCP_SERVER_ABSOLUTE_PATH>",
+            "type": "named",
+            "name": "--directory <YOUR_INKEEP_MCP_SERVER_ABSOLUTE_PATH>",
+            "value_hint": "<YOUR_INKEEP_MCP_SERVER_ABSOLUTE_PATH>"
+          },
+          {
+            "description": "Run python module",
+            "is_required": true,
+            "format": "string",
+            "value": "-m inkeep_mcp_server",
+            "default": "-m inkeep_mcp_server",
+            "type": "named",
+            "name": "-m inkeep_mcp_server",
+            "value_hint": "inkeep_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://api.inkeep.com/v1",
+            "name": "INKEEP_API_BASE_URL"
+          },
+          {
+            "description": "<YOUR_INKEEP_API_KEY>",
+            "name": "INKEEP_API_KEY"
+          },
+          {
+            "description": "inkeep-rag",
+            "name": "INKEEP_API_MODEL"
+          },
+          {
+            "description": "search-product-content",
+            "name": "INKEEP_MCP_TOOL_NAME"
+          },
+          {
+            "description": "Retrieves product documentation about Inkeep. The query should be framed as a conversational question about Inkeep.",
+            "name": "INKEEP_MCP_TOOL_DESCRIPTION"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "584b368d-b659-4bac-9036-dc319cf8d88d",
+    "name": "io.github.integration-app/mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/integration-app/mcp-server",
+      "source": "github",
+      "id": "916850434"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@integration-app/mcp-server",
+        "version": "1.0.3",
+        "environment_variables": [
+          {
+            "description": "<your-integration-app-token>",
+            "name": "INTEGRATION_APP_TOKEN"
+          },
+          {
+            "description": "hubspot",
+            "name": "INTEGRATION_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a51c6dec-56ed-403e-831b-fa5f155f8696",
+    "name": "io.github.jetbrains/mcp-jetbrains",
+    "description": "A model context protocol server to work with JetBrains IDEs: IntelliJ, PyCharm, WebStorm, etc. Also, works with Android Studio",
+    "repository": {
+      "url": "https://github.com/JetBrains/mcp-jetbrains",
+      "source": "github",
+      "id": "900744587"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@jetbrains/mcp-proxy",
+        "version": "1.8.0",
+        "environment_variables": [
+          {
+            "description": "true",
+            "name": "LOG_ENABLED"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "77963df5-3dc8-4961-ae0c-03e448b8713c",
+    "name": "io.github.kagisearch/kagimcp",
+    "description": "A Model Context Protocol (MCP) server for Kagi search & other tools.",
+    "repository": {
+      "url": "https://github.com/kagisearch/kagimcp",
+      "source": "github",
+      "id": "902662933"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "kagimcp",
+        "version": "0.1.3",
+        "package_arguments": [
+          {
+            "description": "Specifies the working directory",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/kagimcp",
+            "default": "--directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/kagimcp",
+            "type": "named",
+            "name": "--directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/kagimcp",
+            "value_hint": "/ABSOLUTE/PATH/TO/PARENT/FOLDER/kagimcp"
+          },
+          {
+            "description": "Name of the package or executable to run",
+            "is_required": true,
+            "format": "string",
+            "value": "kagimcp",
+            "default": "kagimcp",
+            "type": "positional",
+            "value_hint": "kagimcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_API_KEY_HERE",
+            "name": "KAGI_API_KEY"
+          },
+          {
+            "description": "YOUR_ENGINE_CHOICE_HERE",
+            "name": "KAGI_SUMMARIZER_ENGINE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "eba4813b-2591-4264-b7bc-c485b7652e92",
+    "name": "io.github.keboola/keboola-mcp-server",
+    "description": "Model Context Protocol (MCP) Server for the Keboola Platform",
+    "repository": {
+      "url": "https://github.com/keboola/mcp-server",
+      "source": "github",
+      "id": "915789942"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "keboola-mcp-server",
+        "version": "0.17.4",
+        "package_arguments": [
+          {
+            "description": "Module to run",
+            "is_required": true,
+            "format": "string",
+            "value": "-m keboola_mcp_server.cli",
+            "default": "-m keboola_mcp_server.cli",
+            "type": "positional",
+            "value_hint": "keboola_mcp_server.cli"
+          },
+          {
+            "description": "Specify the transport type",
+            "is_required": true,
+            "format": "string",
+            "value": "--transport stdio",
+            "default": "--transport stdio",
+            "type": "named",
+            "name": "--transport stdio",
+            "value_hint": "stdio"
+          },
+          {
+            "description": "API URL for Keboola Connection",
+            "is_required": true,
+            "format": "string",
+            "value": "--api-url https://connection.YOUR_REGION.keboola.com",
+            "default": "--api-url https://connection.YOUR_REGION.keboola.com",
+            "type": "named",
+            "name": "--api-url https://connection.YOUR_REGION.keboola.com",
+            "value_hint": "https://connection.YOUR_REGION.keboola.com"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_keboola_storage_token",
+            "name": "KBC_STORAGE_TOKEN"
+          },
+          {
+            "description": "your_workspace_schema",
+            "name": "KBC_WORKSPACE_SCHEMA"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0bc33e11-876e-4b0f-9c72-75c126d89978",
+    "name": "io.github.klavis-ai/klavis",
+    "description": "Klavis AI (YC X25):  Open Source MCP integration for AI applications",
+    "repository": {
+      "url": "https://github.com/Klavis-AI/klavis",
+      "source": "github",
+      "id": "965974441"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T18:59:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "Klavis-AI/klavis",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "5026f1b0-0426-4ea2-8ec2-fab1fabb0a7e",
+    "name": "io.github.translated/lara-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/translated/lara-mcp",
+      "source": "github",
+      "id": "957768661"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@translated/lara-mcp",
+        "version": "0.0.10",
+        "package_arguments": [
+          {
+            "description": "Run the docker container in interactive mode",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "Automatically remove the container when it exits",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Set environment variable LARA_ACCESS_KEY_ID in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e LARA_ACCESS_KEY_ID",
+            "default": "-e LARA_ACCESS_KEY_ID",
+            "type": "named",
+            "name": "-e LARA_ACCESS_KEY_ID",
+            "value_hint": "LARA_ACCESS_KEY_ID"
+          },
+          {
+            "description": "Set environment variable LARA_ACCESS_KEY_SECRET in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e LARA_ACCESS_KEY_SECRET",
+            "default": "-e LARA_ACCESS_KEY_SECRET",
+            "type": "named",
+            "name": "-e LARA_ACCESS_KEY_SECRET",
+            "value_hint": "LARA_ACCESS_KEY_SECRET"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_ACCESS_KEY_ID>",
+            "name": "LARA_ACCESS_KEY_ID"
+          },
+          {
+            "description": "<YOUR_ACCESS_KEY_SECRET>",
+            "name": "LARA_ACCESS_KEY_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6e66e04c-86cc-43ec-90ed-1a91a0e4eb76",
+    "name": "io.github.pydantic/logfire-mcp",
+    "description": "The Logfire MCP Server is here! :tada:",
+    "repository": {
+      "url": "https://github.com/pydantic/logfire-mcp",
+      "source": "github",
+      "id": "943883428"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "logfire-mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "SELECT trace_id, message, created_at, attributes->>'service.name' as service FROM records WHERE severity_text = 'ERROR' ORDER BY created_at DESC LIMIT 10",
+            "is_required": true,
+            "format": "string",
+            "value": "SELECT trace_id, message, created_at, attributes->>'service.name' as service FROM records WHERE severity_text = 'ERROR' ORDER BY created_at DESC LIMIT 10",
+            "default": "SELECT trace_id, message, created_at, attributes->>'service.name' as service FROM records WHERE severity_text = 'ERROR' ORDER BY created_at DESC LIMIT 10",
+            "type": "named",
+            "name": "SELECT trace_id, message, created_at, attributes->>'service.name' as service FROM records WHERE severity_text = 'ERROR' ORDER BY created_at DESC LIMIT 10",
+            "value_hint": "SELECT trace_id, message, created_at, attributes->>'service.name' as service FROM records WHERE severity_text = 'ERROR' ORDER BY created_at DESC LIMIT 10"
+          },
+          {
+            "description": "1440",
+            "is_required": true,
+            "format": "string",
+            "value": "1440",
+            "default": "1440",
+            "type": "named",
+            "name": "1440",
+            "value_hint": "1440"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f88b50da-f452-452b-9f22-1c7da7542b36",
+    "name": "io.github.langfuse/mcp-server-langfuse",
+    "description": "Model Context Protocol (MCP) Server for Langfuse Prompt Management. This server allows you to access and manage your Langfuse prompts through the Model Context Protocol.",
+    "repository": {
+      "url": "https://github.com/langfuse/mcp-server-langfuse",
+      "source": "github",
+      "id": "933201974"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-langfuse",
+        "version": "0.0.1",
+        "environment_variables": [
+          {
+            "description": "your-public-key",
+            "name": "LANGFUSE_PUBLIC_KEY"
+          },
+          {
+            "description": "your-secret-key",
+            "name": "LANGFUSE_SECRET_KEY"
+          },
+          {
+            "description": "https://cloud.langfuse.com",
+            "name": "LANGFUSE_BASEURL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1e2d718a-95b0-460b-8e57-86feec5356ce",
+    "name": "io.github.lingodotdev/lingo.dev",
+    "description": "⚡️ Open-source AI-powered CLI for web & mobile localization. Bring your own LLM or use Lingo.dev-managed localization engine.",
+    "repository": {
+      "url": "https://github.com/lingodotdev/lingo.dev",
+      "source": "github",
+      "id": "771479895"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@lingo.dev",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "c0151c41-3d77-43a9-b887-dd9fd035b9aa",
+    "name": "io.github.mailgun/mailgun-mcp-server",
+    "description": "Implementation of Model Context Protocol server for Mailgun APIs",
+    "repository": {
+      "url": "https://github.com/mailgun/mailgun-mcp-server",
+      "source": "github",
+      "id": "950200227"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mailgun/mailgun-mcp-server",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "YOUR-mailgun-api-key",
+            "name": "MAILGUN_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f4fca7d7-fbab-4174-ba76-1396c3451cf1",
+    "name": "io.github.integromat/make-mcp-server",
+    "description": "Make MCP Server",
+    "repository": {
+      "url": "https://github.com/integromat/make-mcp-server",
+      "source": "github",
+      "id": "946079810"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@makehq/mcp-server",
+        "version": "0.5.0",
+        "environment_variables": [
+          {
+            "description": "<your-api-key>",
+            "name": "MAKE_API_KEY"
+          },
+          {
+            "description": "<your-zone>",
+            "name": "MAKE_ZONE"
+          },
+          {
+            "description": "<your-team-id>",
+            "name": "MAKE_TEAM"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "09f19715-3a0c-4900-932b-1ff0035aff11",
+    "name": "io.github.googleapis/genai-toolbox",
+    "description": "MCP Toolbox for Databases is an open source MCP server for databases.",
+    "repository": {
+      "url": "https://github.com/googleapis/genai-toolbox",
+      "source": "github",
+      "id": "812044182"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "googleapis/genai-toolbox",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "11d467e3-6001-4e60-ba90-494ad9eb7ad2",
+    "name": "io.github.meilisearch/meilisearch-mcp",
+    "description": "A Model Context Protocol (MCP) server for interacting with Meilisearch through LLM interfaces.",
+    "repository": {
+      "url": "https://github.com/meilisearch/meilisearch-mcp",
+      "source": "github",
+      "id": "907425333"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "meilisearch-mcp",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  {
+    "id": "dd730dba-107c-40f0-b172-85500a22b5c2",
+    "name": "io.github.memgraph/mcp-memgraph",
+    "description": "Memgraph MCP Server",
+    "repository": {
+      "url": "https://github.com/memgraph/mcp-memgraph",
+      "source": "github",
+      "id": "946087272"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-memgraph",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "95047d21-596b-4c32-b206-2ebd171733aa",
+    "name": "io.github.metoro-io/metoro-mcp-server",
+    "description": "Metoro MCP Server",
+    "repository": {
+      "url": "https://github.com/metoro-io/metoro-mcp-server",
+      "source": "github",
+      "id": "900333594"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "metoro-io/metoro-mcp-server",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b21lcklkIjoiOThlZDU1M2QtYzY4ZC00MDRhLWFhZjItNDM2ODllNWJiMGUzIiwiZW1haWwiOiJ0ZXN0QGNocmlzYmF0dGFyYmVlLmNvbSIsImV4cCI6MTgyMTI0NzIzN30.7G6alDpcZh_OThYj293Jce5rjeOBqAhOlANR_Fl5auw",
+            "name": "METORO_AUTH_TOKEN"
+          },
+          {
+            "description": "https://demo.us-east.metoro.io",
+            "name": "METORO_API_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e458676a-2727-4daf-84c5-d607932fa000",
+    "name": "io.github.zilliztech/mcp-server-milvus",
+    "description": "Model Context Protocol Servers for Milvus",
+    "repository": {
+      "url": "https://github.com/zilliztech/mcp-server-milvus",
+      "source": "github",
+      "id": "943619628"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-milvus",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "Directory argument",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/mcp-server-milvus/src/mcp_server_milvus",
+            "default": "--directory /path/to/mcp-server-milvus/src/mcp_server_milvus",
+            "type": "named",
+            "name": "--directory /path/to/mcp-server-milvus/src/mcp_server_milvus",
+            "value_hint": "/path/to/mcp-server-milvus/src/mcp_server_milvus"
+          },
+          {
+            "description": "Python server entry file",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          },
+          {
+            "description": "Milvus URI",
+            "is_required": true,
+            "format": "string",
+            "value": "--milvus-uri http://127.0.0.1:19530",
+            "default": "--milvus-uri http://127.0.0.1:19530",
+            "type": "named",
+            "name": "--milvus-uri http://127.0.0.1:19530",
+            "value_hint": "http://127.0.0.1:19530"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b99e5603-6346-4b2c-bae8-876c9b71e18b",
+    "name": "io.github.momentohq/mcp-momento",
+    "description": "A model context protocol server for Momento",
+    "repository": {
+      "url": "https://github.com/momentohq/mcp-momento",
+      "source": "github",
+      "id": "960008375"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@gomomento/mcp-momento",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "MOMENTO_API_KEY"
+          },
+          {
+            "description": "your-cache-name",
+            "name": "MOMENTO_CACHE_NAME"
+          },
+          {
+            "description": "60",
+            "name": "DEFAULT_TTL_SECONDS"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9fd2c1fb-b8a6-4411-89cf-d4612cc3a539",
+    "name": "io.github.mongodb-js/mongodb-mcp-server",
+    "description": "A Model Context Protocol server to connect to MongoDB databases and MongoDB Atlas Clusters.",
+    "repository": {
+      "url": "https://github.com/mongodb-js/mongodb-mcp-server",
+      "source": "github",
+      "id": "960484071"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mongodb-mcp-server",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "your-atlas-service-accounts-client-id",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiClientId your-atlas-service-accounts-client-id",
+            "default": "--apiClientId your-atlas-service-accounts-client-id",
+            "type": "named",
+            "name": "--apiClientId your-atlas-service-accounts-client-id",
+            "value_hint": "your-atlas-service-accounts-client-id"
+          },
+          {
+            "description": "your-atlas-service-accounts-client-secret",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiClientSecret your-atlas-service-accounts-client-secret",
+            "default": "--apiClientSecret your-atlas-service-accounts-client-secret",
+            "type": "named",
+            "name": "--apiClientSecret your-atlas-service-accounts-client-secret",
+            "value_hint": "your-atlas-service-accounts-client-secret"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b3fa3fa4-901d-4584-82cf-d027dbdf290b",
+    "name": "io.github.motherduckdb/mcp-server-motherduck",
+    "description": "MCP server for DuckDB and MotherDuck",
+    "repository": {
+      "url": "https://github.com/motherduckdb/mcp-server-motherduck",
+      "source": "github",
+      "id": "902619224"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-motherduck",
+        "version": "0.4.2",
+        "package_arguments": [
+          {
+            "description": "--directory /path/to/your/local/mcp-server-motherduck",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/your/local/mcp-server-motherduck",
+            "default": "--directory /path/to/your/local/mcp-server-motherduck",
+            "type": "named",
+            "name": "--directory /path/to/your/local/mcp-server-motherduck",
+            "value_hint": "/path/to/your/local/mcp-server-motherduck"
+          },
+          {
+            "description": "mcp-server-motherduck",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-motherduck",
+            "default": "mcp-server-motherduck",
+            "type": "positional",
+            "value_hint": "mcp-server-motherduck"
+          },
+          {
+            "description": "--db-path md:",
+            "is_required": true,
+            "format": "string",
+            "value": "--db-path md:",
+            "default": "--db-path md:",
+            "type": "named",
+            "name": "--db-path md:",
+            "value_hint": "md:"
+          },
+          {
+            "description": "--motherduck-token <YOUR_MOTHERDUCK_TOKEN_HERE>",
+            "is_required": true,
+            "format": "string",
+            "value": "--motherduck-token <YOUR_MOTHERDUCK_TOKEN_HERE>",
+            "default": "--motherduck-token <YOUR_MOTHERDUCK_TOKEN_HERE>",
+            "type": "named",
+            "name": "--motherduck-token <YOUR_MOTHERDUCK_TOKEN_HERE>",
+            "value_hint": "<YOUR_MOTHERDUCK_TOKEN_HERE>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "be6eb263-3492-4073-b28f-0fd33d070982",
+    "name": "io.github.needle-ai/needle-mcp",
+    "description": "Integration of Needle in modelcontextprotocol",
+    "repository": {
+      "url": "https://github.com/needle-ai/needle-mcp",
+      "source": "github",
+      "id": "903772115"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "needle-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "/path/to/needle-mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/needle-mcp",
+            "default": "/path/to/needle-mcp",
+            "type": "positional",
+            "value_hint": "/path/to/needle-mcp"
+          },
+          {
+            "description": "needle-mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "needle-mcp",
+            "default": "needle-mcp",
+            "type": "positional",
+            "value_hint": "needle-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_needle_api_key",
+            "name": "NEEDLE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ee33c4cb-5bdf-45c0-88a8-ba2d237189f9",
+    "name": "io.github.neo4j-contrib/mcp-neo4j",
+    "description": "Model Context Protocol with Neo4j",
+    "repository": {
+      "url": "https://github.com/neo4j-contrib/mcp-neo4j",
+      "source": "github",
+      "id": "897992568"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "neo4j-contrib/mcp-neo4j",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "9a6bd437-fe20-4f40-b776-5507f2871441",
+    "name": "io.github.neondatabase/mcp-server-neon",
+    "description": "MCP server for interacting with Neon Management API and databases",
+    "repository": {
+      "url": "https://github.com/neondatabase-labs/mcp-server-neon",
+      "source": "github",
+      "id": "896203400"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@neondatabase/mcp-server-neon",
+        "version": "0.4.0",
+        "package_arguments": [
+          {
+            "description": "Start the Neon MCP server",
+            "is_required": true,
+            "format": "string",
+            "value": "start",
+            "default": "start",
+            "type": "positional",
+            "value_hint": "start"
+          },
+          {
+            "description": "Your Neon API key",
+            "is_required": true,
+            "format": "string",
+            "value": "<YOUR_NEON_API_KEY>",
+            "default": "<YOUR_NEON_API_KEY>",
+            "type": "positional",
+            "value_hint": "<YOUR_NEON_API_KEY>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "afe07206-691c-4bfb-bf17-8a39014cf4a7",
+    "name": "io.github.oceanbase/mcp-oceanbase",
+    "description": "MCP Server for OceanBase database and its tools",
+    "repository": {
+      "url": "https://github.com/oceanbase/mcp-oceanbase",
+      "source": "github",
+      "id": "951176417"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-oceanbase",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "2d53cc39-27e0-446f-96b5-1324bab9eb21",
+    "name": "io.github.octagonai/octagon-mcp-server",
+    "description": "A free MCP server to analyze and extract insights from public filings, earnings transcripts, financial metrics, stock market data, private market transactions, and deep web-based research within Claude Desktop and other popular MCP clients.",
+    "repository": {
+      "url": "https://github.com/OctagonAI/octagon-mcp-server",
+      "source": "github",
+      "id": "947569884"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "octagon-mcp",
+        "version": "1.0.18",
+        "environment_variables": [
+          {
+            "description": "YOUR_API_KEY_HERE",
+            "name": "OCTAGON_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "27560049-5f82-4445-8969-d527da4d8936",
+    "name": "io.github.opslevel/opslevel-mcp",
+    "description": "Model Context Protocol (MCP) server for OpsLevel",
+    "repository": {
+      "url": "https://github.com/OpsLevel/opslevel-mcp",
+      "source": "github",
+      "id": "968273511"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "OpsLevel/opslevel-mcp",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "XXXXXX",
+            "name": "OPSLEVEL_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4632fbcb-d313-4e26-ad1d-aea8f57524f7",
+    "name": "io.github.oxylabs/oxylabs-mcp",
+    "description": "Official Oxylabs MCP integration",
+    "repository": {
+      "url": "https://github.com/oxylabs/oxylabs-mcp",
+      "source": "github",
+      "id": "918221533"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "oxylabs-mcp",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "Set the working directory",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /<Absolute-path-to-folder>/oxylabs-mcp",
+            "default": "--directory /<Absolute-path-to-folder>/oxylabs-mcp",
+            "type": "named",
+            "name": "--directory /<Absolute-path-to-folder>/oxylabs-mcp",
+            "value_hint": "/<Absolute-path-to-folder>/oxylabs-mcp"
+          },
+          {
+            "description": "Python application/module to run",
+            "is_required": true,
+            "format": "string",
+            "value": "oxylabs-mcp",
+            "default": "oxylabs-mcp",
+            "type": "positional",
+            "value_hint": "oxylabs-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "OXYLABS_USERNAME",
+            "name": "OXYLABS_USERNAME"
+          },
+          {
+            "description": "OXYLABS_PASSWORD",
+            "name": "OXYLABS_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "be79836b-8a99-4e4e-9487-c81c02833f4a",
+    "name": "io.github.paddlehq/paddle-mcp-server",
+    "description": "Interact with the Paddle API using AI assistants like Claude, or in AI-powered IDEs like Cursor. Manage product catalog, billing and subscriptions, and reports.",
+    "repository": {
+      "url": "https://github.com/PaddleHQ/paddle-mcp-server",
+      "source": "github",
+      "id": "955461567"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:00:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@paddle/paddle-mcp",
+        "version": "0.1.2",
+        "package_arguments": [
+          {
+            "description": "Path to the mcp server entry point",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/paddle-mcp-server/build/index.js",
+            "default": "path/to/paddle-mcp-server/build/index.js",
+            "type": "positional",
+            "value_hint": "path/to/paddle-mcp-server/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key",
+            "name": "PADDLE_API_KEY"
+          },
+          {
+            "description": "sandbox",
+            "name": "PADDLE_ENVIRONMENT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9eab3795-a96d-4fad-8521-921599e85240",
+    "name": "io.github.ppl-ai/modelcontextprotocol",
+    "description": "A Model Context Protocol Server connector for Perplexity API, to enable web search without leaving the MCP ecosystem.",
+    "repository": {
+      "url": "https://github.com/ppl-ai/modelcontextprotocol",
+      "source": "github",
+      "id": "946214670"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "ppl-ai/modelcontextprotocol",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "YOUR_API_KEY_HERE",
+            "name": "PERPLEXITY_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ed4c9613-5046-4570-8d15-209f7294ba75",
+    "name": "io.github.pinecone-io/pinecone-mcp",
+    "description": "Connect your Pinecone projects to Cursor, Claude, and other AI assistants",
+    "repository": {
+      "url": "https://github.com/pinecone-io/pinecone-mcp",
+      "source": "github",
+      "id": "963450460"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@pinecone-database/mcp",
+        "version": "0.1.14"
+      }
+    ]
+  },
+  {
+    "id": "08668c6a-c2f6-47b0-a4e0-75a8ee9bcf10",
+    "name": "io.github.pinecone-io/assistant-mcp",
+    "description": "Pinecone Assistant MCP server",
+    "repository": {
+      "url": "https://github.com/pinecone-io/assistant-mcp",
+      "source": "github",
+      "id": "940446625"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "pinecone-io/assistant-mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "-e PINECONE_API_KEY",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PINECONE_API_KEY",
+            "default": "-e PINECONE_API_KEY",
+            "type": "named",
+            "name": "-e PINECONE_API_KEY",
+            "value_hint": "PINECONE_API_KEY"
+          },
+          {
+            "description": "-e PINECONE_ASSISTANT_HOST",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PINECONE_ASSISTANT_HOST",
+            "default": "-e PINECONE_ASSISTANT_HOST",
+            "type": "named",
+            "name": "-e PINECONE_ASSISTANT_HOST",
+            "value_hint": "PINECONE_ASSISTANT_HOST"
+          },
+          {
+            "description": "pinecone/assistant-mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "pinecone/assistant-mcp",
+            "default": "pinecone/assistant-mcp",
+            "type": "positional",
+            "value_hint": "pinecone/assistant-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_PINECONE_API_KEY_HERE>",
+            "name": "PINECONE_API_KEY"
+          },
+          {
+            "description": "<YOUR_PINECONE_ASSISTANT_HOST_HERE>",
+            "name": "PINECONE_ASSISTANT_HOST"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "324d6879-eb6f-4565-bdeb-6c4b00d91384",
+    "name": "io.github.ragieai/ragie-mcp-server",
+    "description": "Ragie Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/ragieai/ragie-mcp-server",
+      "source": "github",
+      "id": "940305209"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@ragieai/mcp-server",
+        "version": "0.0.7",
+        "package_arguments": [
+          {
+            "description": "Partition identifier (optional)",
+            "is_required": true,
+            "format": "string",
+            "value": "--partition optional_partition_id",
+            "default": "--partition optional_partition_id",
+            "type": "named",
+            "name": "--partition optional_partition_id",
+            "value_hint": "optional_partition_id"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key",
+            "name": "RAGIE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "87f325e6-a742-43e4-b8ae-069f7301475d",
+    "name": "io.github.redis/mcp-redis",
+    "description": "The official Redis MCP Server is a natural language interface designed for agentic applications to manage and search data in Redis efficiently",
+    "repository": {
+      "url": "https://github.com/redis/mcp-redis",
+      "source": "github",
+      "id": "959084910"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "redis-mcp-server",
+        "version": "0.2.0",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b8c0e12b-0c04-486d-95a7-caa33b9eefeb",
+    "name": "io.github.redis/mcp-redis-cloud",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/redis/mcp-redis-cloud",
+      "source": "github",
+      "id": "956477944"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:13Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-redis-cloud",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "-e API_KEY=<your_redis_cloud_api_key>",
+            "is_required": true,
+            "format": "string",
+            "value": "-e API_KEY=<your_redis_cloud_api_key>",
+            "default": "-e API_KEY=<your_redis_cloud_api_key>",
+            "type": "named",
+            "name": "-e API_KEY=<your_redis_cloud_api_key>",
+            "value_hint": "API_KEY=<your_redis_cloud_api_key>"
+          },
+          {
+            "description": "-e SECRET_KEY=<your_redis_cloud_api_secret_key>",
+            "is_required": true,
+            "format": "string",
+            "value": "-e SECRET_KEY=<your_redis_cloud_api_secret_key>",
+            "default": "-e SECRET_KEY=<your_redis_cloud_api_secret_key>",
+            "type": "named",
+            "name": "-e SECRET_KEY=<your_redis_cloud_api_secret_key>",
+            "value_hint": "SECRET_KEY=<your_redis_cloud_api_secret_key>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8e5b8c2e-6751-4567-b367-4e24e5c7fb8c",
+    "name": "io.github.snyk/snyk-ls",
+    "description": "Language Server used by IDEs as Snyk Backend for Frontends",
+    "repository": {
+      "url": "https://github.com/snyk/snyk-ls",
+      "source": "github",
+      "id": "431904794"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "snyk/snyk-ls",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Enables Snyk Open Source - defaults to true",
+            "is_required": true,
+            "format": "string",
+            "value": "--activateSnykOpenSource true",
+            "default": "--activateSnykOpenSource true",
+            "type": "named",
+            "name": "--activateSnykOpenSource true",
+            "value_hint": "true"
+          },
+          {
+            "description": "Enables Snyk Code, if enabled for your organization - defaults to false, deprecated in favor of specific Snyk Code analysis types",
+            "is_required": true,
+            "format": "string",
+            "value": "--activateSnykCode false",
+            "default": "--activateSnykCode false",
+            "type": "named",
+            "name": "--activateSnykCode false",
+            "value_hint": "false"
+          },
+          {
+            "description": "Enables Infrastructure as Code - defaults to true",
+            "is_required": true,
+            "format": "string",
+            "value": "--activateSnykIac true",
+            "default": "--activateSnykIac true",
+            "type": "named",
+            "name": "--activateSnykIac true",
+            "value_hint": "true"
+          },
+          {
+            "description": "Allows custom CAs (Certification Authorities)",
+            "is_required": true,
+            "format": "string",
+            "value": "--insecure false",
+            "default": "--insecure false",
+            "type": "named",
+            "name": "--insecure false",
+            "value_hint": "false"
+          },
+          {
+            "description": "Snyk API Endpoint required for non-default multi-tenant and single-tenant setups",
+            "is_required": true,
+            "format": "string",
+            "value": "--endpoint https://api.eu.snyk.io",
+            "default": "--endpoint https://api.eu.snyk.io",
+            "type": "named",
+            "name": "--endpoint https://api.eu.snyk.io",
+            "value_hint": "https://api.eu.snyk.io"
+          },
+          {
+            "description": "The name of your organization, e.g. the output of: curl -H \"Authorization: token $(snyk config get api)\"  https://api.snyk.io/v1/cli-config/settings/sast | jq .org",
+            "is_required": true,
+            "format": "string",
+            "value": "--organization a string",
+            "default": "--organization a string",
+            "type": "named",
+            "name": "--organization a string",
+            "value_hint": "a string"
+          },
+          {
+            "description": "Adds to the system path used by the CLI",
+            "is_required": true,
+            "format": "string",
+            "value": "--path /usr/local/bin",
+            "default": "--path /usr/local/bin",
+            "type": "named",
+            "name": "--path /usr/local/bin",
+            "value_hint": "/usr/local/bin"
+          },
+          {
+            "description": "The path where the CLI can be found, or where it should be downloaded to",
+            "is_required": true,
+            "format": "string",
+            "value": "--cliPath /a/patch/snyk-cli",
+            "default": "--cliPath /a/patch/snyk-cli",
+            "type": "named",
+            "name": "--cliPath /a/patch/snyk-cli",
+            "value_hint": "/a/patch/snyk-cli"
+          },
+          {
+            "description": "The Snyk token, e.g.: snyk config get api or a token from authentication flow",
+            "is_required": true,
+            "format": "string",
+            "value": "--token secret-token",
+            "default": "--token secret-token",
+            "type": "named",
+            "name": "--token secret-token",
+            "value_hint": "secret-token"
+          },
+          {
+            "description": "The name of the IDE or editor the LS is running in",
+            "is_required": true,
+            "format": "string",
+            "value": "--integrationName ECLIPSE",
+            "default": "--integrationName ECLIPSE",
+            "type": "named",
+            "name": "--integrationName ECLIPSE",
+            "value_hint": "ECLIPSE"
+          },
+          {
+            "description": "The version of the IDE or editor the LS is running in",
+            "is_required": true,
+            "format": "string",
+            "value": "--integrationVersion 1.0.0",
+            "default": "--integrationVersion 1.0.0",
+            "type": "named",
+            "name": "--integrationVersion 1.0.0",
+            "value_hint": "1.0.0"
+          },
+          {
+            "description": "Whether LS will automatically authenticate on scan start (default: true)",
+            "is_required": true,
+            "format": "string",
+            "value": "--automaticAuthentication true",
+            "default": "--automaticAuthentication true",
+            "type": "named",
+            "name": "--automaticAuthentication true",
+            "value_hint": "true"
+          },
+          {
+            "description": "A unique ID from the running the LS, used for telemetry",
+            "is_required": true,
+            "format": "string",
+            "value": "--deviceId a UUID",
+            "default": "--deviceId a UUID",
+            "type": "named",
+            "name": "--deviceId a UUID",
+            "value_hint": "a UUID"
+          },
+          {
+            "description": "Optional filter to be applied for the determined issues (if omitted: no filtering)",
+            "format": "string",
+            "value": "--filterSeverity critical:true,high:true,medium:true,low:true",
+            "default": "--filterSeverity critical:true,high:true,medium:true,low:true",
+            "type": "named",
+            "name": "--filterSeverity critical:true,high:true,medium:true,low:true",
+            "value_hint": "critical:true,high:true,medium:true,low:true"
+          },
+          {
+            "description": "Optional filter to be applied for the determined issues (if omitted: no filtering)",
+            "format": "string",
+            "value": "--issueViewOptions openIssues:true,ignoredIssues:false",
+            "default": "--issueViewOptions openIssues:true,ignoredIssues:false",
+            "type": "named",
+            "name": "--issueViewOptions openIssues:true,ignoredIssues:false",
+            "value_hint": "openIssues:true,ignoredIssues:false"
+          },
+          {
+            "description": "Whether to report errors to Snyk - defaults to true",
+            "is_required": true,
+            "format": "string",
+            "value": "--sendErrorReports true",
+            "default": "--sendErrorReports true",
+            "type": "named",
+            "name": "--sendErrorReports true",
+            "value_hint": "true"
+          },
+          {
+            "description": "Whether CLI/LS binaries will be downloaded & updated automatically",
+            "is_required": true,
+            "format": "string",
+            "value": "--manageBinariesAutomatically true",
+            "default": "--manageBinariesAutomatically true",
+            "type": "named",
+            "name": "--manageBinariesAutomatically true",
+            "value_hint": "true"
+          },
+          {
+            "description": "Whether LS will prompt to trust a folder (default: true)",
+            "is_required": true,
+            "format": "string",
+            "value": "--enableTrustedFoldersFeature true",
+            "default": "--enableTrustedFoldersFeature true",
+            "type": "named",
+            "name": "--enableTrustedFoldersFeature true",
+            "value_hint": "true"
+          },
+          {
+            "description": "Enables Snyk Code Security reporting",
+            "is_required": true,
+            "format": "string",
+            "value": "--activateSnykCodeSecurity false",
+            "default": "--activateSnykCodeSecurity false",
+            "type": "named",
+            "name": "--activateSnykCodeSecurity false",
+            "value_hint": "false"
+          },
+          {
+            "description": "Enable Snyk Code Quality issue reporting (Beta, only in IDEs and LS)",
+            "is_required": true,
+            "format": "string",
+            "value": "--activateSnykCodeQuality false",
+            "default": "--activateSnykCodeQuality false",
+            "type": "named",
+            "name": "--activateSnykCodeQuality false",
+            "value_hint": "false"
+          },
+          {
+            "description": "Specifies the mode for scans: \"auto\" for background scans or \"manual\" for scans on command",
+            "is_required": true,
+            "format": "string",
+            "value": "--scanningMode auto",
+            "default": "--scanningMode auto",
+            "type": "named",
+            "name": "--scanningMode auto",
+            "value_hint": "auto"
+          },
+          {
+            "description": "Specifies the authentication method to use: \"token\" for Snyk API token or \"oauth\" for Snyk OAuth flow. Default is token.",
+            "is_required": true,
+            "format": "string",
+            "value": "--authenticationMethod oauth",
+            "default": "--authenticationMethod oauth",
+            "type": "named",
+            "name": "--authenticationMethod oauth",
+            "value_hint": "oauth"
+          },
+          {
+            "description": "Specifies the Snyk Code API endpoint to use. Default is https://deeproxy.snyk.io",
+            "is_required": true,
+            "format": "string",
+            "value": "--snykCodeApi https://deeproxy.snyk.io",
+            "default": "--snykCodeApi https://deeproxy.snyk.io",
+            "type": "named",
+            "name": "--snykCodeApi https://deeproxy.snyk.io",
+            "value_hint": "https://deeproxy.snyk.io"
+          },
+          {
+            "description": "show snyk learns code actions",
+            "is_required": true,
+            "format": "string",
+            "value": "--enableSnykLearnCodeActions true",
+            "default": "--enableSnykLearnCodeActions true",
+            "type": "named",
+            "name": "--enableSnykLearnCodeActions true",
+            "value_hint": "true"
+          },
+          {
+            "description": "show quickfixes for supported OSS package manager issues",
+            "is_required": true,
+            "format": "string",
+            "value": "--enableSnykOSSQuickFixCodeActions true",
+            "default": "--enableSnykOSSQuickFixCodeActions true",
+            "type": "named",
+            "name": "--enableSnykOSSQuickFixCodeActions true",
+            "value_hint": "true"
+          },
+          {
+            "description": "show code actions to open issue descriptions",
+            "is_required": true,
+            "format": "string",
+            "value": "--enableSnykOpenBrowserActions false",
+            "default": "--enableSnykOpenBrowserActions false",
+            "type": "named",
+            "name": "--enableSnykOpenBrowserActions false",
+            "value_hint": "false"
+          },
+          {
+            "description": "only display issues that are not new and thus not on the base branch",
+            "is_required": true,
+            "format": "string",
+            "value": "--enableDeltaFindings false",
+            "default": "--enableDeltaFindings false",
+            "type": "named",
+            "name": "--enableDeltaFindings false",
+            "value_hint": "false"
+          },
+          {
+            "description": "the protocol version a client needs",
+            "is_required": true,
+            "format": "string",
+            "value": "--requiredProtocolVersion 14",
+            "default": "--requiredProtocolVersion 14",
+            "type": "named",
+            "name": "--requiredProtocolVersion 14",
+            "value_hint": "14"
+          },
+          {
+            "description": "0-3 with 0 the lowest verbosity. 0: off, 1: only description, 2: description & details 3: complete (default)",
+            "is_required": true,
+            "format": "string",
+            "value": "--hoverVerbosity 1",
+            "default": "--hoverVerbosity 1",
+            "type": "named",
+            "name": "--hoverVerbosity 1",
+            "value_hint": "1"
+          },
+          {
+            "description": "plain = plain, markdown = md (default) or html = HTML",
+            "is_required": true,
+            "format": "string",
+            "value": "--outputFormat md",
+            "default": "--outputFormat md",
+            "type": "named",
+            "name": "--outputFormat md",
+            "value_hint": "md"
+          },
+          {
+            "description": "Any extra params for Open Source scans using the Snyk CLI, separated by spaces",
+            "format": "string",
+            "value": "--additionalParams --all-projects",
+            "default": "--additionalParams --all-projects",
+            "type": "named",
+            "name": "--additionalParams --all-projects",
+            "value_hint": "--all-projects"
+          },
+          {
+            "description": "Additional environment variables, separated by semicolons",
+            "format": "string",
+            "value": "--additionalEnv MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR",
+            "default": "--additionalEnv MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR",
+            "type": "named",
+            "name": "--additionalEnv MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR",
+            "value_hint": "MAVEN_OPTS=-Djava.awt.headless=true;FOO=BAR"
+          },
+          {
+            "description": "An array of folder that should be trusted",
+            "format": "string",
+            "value": "--trustedFolders /a/trusted/path,/another/trusted/path",
+            "default": "--trustedFolders /a/trusted/path,/another/trusted/path",
+            "type": "named",
+            "name": "--trustedFolders /a/trusted/path,/another/trusted/path",
+            "value_hint": "/a/trusted/path,/another/trusted/path"
+          },
+          {
+            "description": "an array of folder configurations, defining the desired base branch of a workspaceFolder",
+            "format": "string",
+            "value": "--folderConfigs baseBranch:main,folderPath:a/b/c,additionalParameters:--file=pom.xml",
+            "default": "--folderConfigs baseBranch:main,folderPath:a/b/c,additionalParameters:--file=pom.xml",
+            "type": "named",
+            "name": "--folderConfigs baseBranch:main,folderPath:a/b/c,additionalParameters:--file=pom.xml",
+            "value_hint": "baseBranch:main,folderPath:a/b/c,additionalParameters:--file=pom.xml"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "823afe6f-4494-4fc1-a2ab-2ca989e59d21",
+    "name": "io.github.qdrant/mcp-server-qdrant",
+    "description": "An official Qdrant Model Context Protocol (MCP) server implementation",
+    "repository": {
+      "url": "https://github.com/qdrant/mcp-server-qdrant",
+      "source": "github",
+      "id": "897308110"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-server-qdrant",
+        "version": "0.7.1",
+        "package_arguments": [
+          {
+            "description": "Publish port 8000:8000",
+            "is_required": true,
+            "format": "string",
+            "value": "-p 8000:8000",
+            "default": "-p 8000:8000",
+            "type": "named",
+            "name": "-p 8000:8000",
+            "value_hint": "8000:8000"
+          },
+          {
+            "description": "Run in interactive mode",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "Remove container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Set environment variable QDRANT_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e QDRANT_URL",
+            "default": "-e QDRANT_URL",
+            "type": "named",
+            "name": "-e QDRANT_URL",
+            "value_hint": "QDRANT_URL"
+          },
+          {
+            "description": "Set environment variable QDRANT_API_KEY",
+            "is_required": true,
+            "format": "string",
+            "value": "-e QDRANT_API_KEY",
+            "default": "-e QDRANT_API_KEY",
+            "type": "named",
+            "name": "-e QDRANT_API_KEY",
+            "value_hint": "QDRANT_API_KEY"
+          },
+          {
+            "description": "Set environment variable COLLECTION_NAME",
+            "is_required": true,
+            "format": "string",
+            "value": "-e COLLECTION_NAME",
+            "default": "-e COLLECTION_NAME",
+            "type": "named",
+            "name": "-e COLLECTION_NAME",
+            "value_hint": "COLLECTION_NAME"
+          },
+          {
+            "description": "Docker image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-qdrant",
+            "default": "mcp-server-qdrant",
+            "type": "positional",
+            "value_hint": "mcp-server-qdrant"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "${input:qdrantUrl}",
+            "name": "QDRANT_URL"
+          },
+          {
+            "description": "${input:qdrantApiKey}",
+            "name": "QDRANT_API_KEY"
+          },
+          {
+            "description": "${input:collectionName}",
+            "name": "COLLECTION_NAME"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "687591a4-a5da-44df-8d55-f32e19d5658a",
+    "name": "io.github.ramp-public/ramp-mcp",
+    "description": "ramp_mcp",
+    "repository": {
+      "url": "https://github.com/ramp-public/ramp_mcp",
+      "source": "github",
+      "id": "951969645"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "ramp-mcp",
+        "version": "0.0.1",
+        "package_arguments": [
+          {
+            "description": "Specify the directory to use",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /<ABSOLUTE-PATH-TO>/ramp-mcp",
+            "default": "--directory /<ABSOLUTE-PATH-TO>/ramp-mcp",
+            "type": "named",
+            "name": "--directory /<ABSOLUTE-PATH-TO>/ramp-mcp",
+            "value_hint": "/<ABSOLUTE-PATH-TO>/ramp-mcp"
+          },
+          {
+            "description": "Application name",
+            "is_required": true,
+            "format": "string",
+            "value": "ramp-mcp",
+            "default": "ramp-mcp",
+            "type": "positional",
+            "value_hint": "ramp-mcp"
+          },
+          {
+            "description": "Run in silent mode",
+            "is_required": true,
+            "format": "string",
+            "value": "-s",
+            "default": "-s",
+            "type": "named",
+            "name": "-s"
+          },
+          {
+            "description": "Specify resource permissions",
+            "is_required": true,
+            "format": "string",
+            "value": "transactions:read,reimbursements:read",
+            "default": "transactions:read,reimbursements:read",
+            "type": "positional",
+            "value_hint": "transactions:read,reimbursements:read"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<CLIENT_ID>",
+            "name": "RAMP_CLIENT_ID"
+          },
+          {
+            "description": "<CLIENT_SECRET>",
+            "name": "RAMP_CLIENT_SECRET"
+          },
+          {
+            "description": "<demo|qa|prd>",
+            "name": "RAMP_ENV"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f6ee7600-c27a-4210-9a94-29a35c41c274",
+    "name": "io.github.mindscapehq/mcp-server-raygun",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/MindscapeHQ/mcp-server-raygun",
+      "source": "github",
+      "id": "895741231"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@raygun.io/mcp-server-raygun",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your-pat-token-ken",
+            "name": "RAYGUN_PAT_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5e354d7f-e19e-40ba-a760-342d5c93e9aa",
+    "name": "io.github.rember/rember-mcp",
+    "description": "A Model Context Protocol (MCP) server for Rember.",
+    "repository": {
+      "url": "https://github.com/rember/rember-mcp",
+      "source": "github",
+      "id": "940533374"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@getrember/mcp",
+        "version": "1.1.3",
+        "package_arguments": [
+          {
+            "description": "Rember API Key",
+            "is_required": true,
+            "format": "string",
+            "value": "--api-key=YOUR_REMBER_API_KEY",
+            "default": "--api-key=YOUR_REMBER_API_KEY",
+            "type": "named",
+            "name": "--api-key=YOUR_REMBER_API_KEY",
+            "value_hint": "YOUR_REMBER_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7b93304c-5a49-45a7-a37c-84e82707d81d",
+    "name": "io.github.riza-io/riza-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/riza-io/riza-mcp",
+      "source": "github",
+      "id": "902093354"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "riza-io/riza-mcp",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "RIZA_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cb1647e0-2df7-4f2a-b63b-cfaea1e5e98a",
+    "name": "io.github.fatwang2/search1api-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/fatwang2/search1api-mcp",
+      "source": "github",
+      "id": "894382523"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "search1api-mcp",
+        "version": "0.2.0",
+        "environment_variables": [
+          {
+            "description": "YOUR_SEARCH1API_KEY",
+            "name": "SEARCH1API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "87c7dec1-1b0c-414b-9f7b-7a113e67989d",
+    "name": "io.github.screenshotone/mcp",
+    "description": "A simple implementation of an MCP server for the ScreenshotOne API",
+    "repository": {
+      "url": "https://github.com/screenshotone/mcp",
+      "source": "github",
+      "id": "934098377"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "screenshotone-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Positional argument for 'path/to/screenshotone/mcp/build/index.js'",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/screenshotone/mcp/build/index.js",
+            "default": "path/to/screenshotone/mcp/build/index.js",
+            "type": "positional",
+            "value_hint": "path/to/screenshotone/mcp/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<your api key>",
+            "name": "SCREENSHOTONE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d012ea8c-2f32-43e4-9583-7418d750193e",
+    "name": "io.github.semgrep/mcp",
+    "description": "A MCP server for using Semgrep to scan code for security vulnerabilities.",
+    "repository": {
+      "url": "https://github.com/semgrep/mcp",
+      "source": "github",
+      "id": "950213855"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "semgrep-mcp",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "901e1b1c-7414-4240-89b8-1def9aca4708",
+    "name": "io.github.singlestore-labs/mcp-server-singlestore",
+    "description": "MCP server for interacting with SingleStore Management API and services",
+    "repository": {
+      "url": "https://github.com/singlestore-labs/mcp-server-singlestore",
+      "source": "github",
+      "id": "941979361"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:01:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "singlestore_mcp_server",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Start the single store MCP server",
+            "is_required": true,
+            "format": "string",
+            "value": "start",
+            "default": "start",
+            "type": "positional",
+            "value_hint": "start"
+          },
+          {
+            "description": "SingleStore API Key",
+            "is_required": true,
+            "format": "string",
+            "value": "<SINGLESTORE_API_KEY>",
+            "default": "<SINGLESTORE_API_KEY>",
+            "type": "positional",
+            "value_hint": "<SINGLESTORE_API_KEY>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "5200c733-db46-48ba-a870-c1de02cf3e07",
+    "name": "io.github.stripe/agent-toolkit",
+    "description": "Python and TypeScript library for integrating the Stripe API into agentic workflows",
+    "repository": {
+      "url": "https://github.com/stripe/agent-toolkit",
+      "source": "github",
+      "id": "886826524"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "stripe/agent-toolkit",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "ba8028f7-73e6-4d3d-9974-790d438a1446",
+    "name": "io.github.tavily-ai/tavily-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/tavily-ai/tavily-mcp",
+      "source": "github",
+      "id": "923109265"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "tavily-mcp",
+        "version": "0.2.0",
+        "environment_variables": [
+          {
+            "description": "your-api-key-here",
+            "name": "TAVILY_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f5349be9-5e04-4e93-bf2f-2dae8db4a9e9",
+    "name": "io.github.thirdweb-dev/ai",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/thirdweb-dev/ai",
+      "source": "github",
+      "id": "947697435"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "thirdweb-dev/ai",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "9dd7f908-4c1b-4ba3-a33f-86be881cc8b6",
+    "name": "io.github.msgbyte/tianji",
+    "description": "Tianji: Insight into everything, Website Analytics + Uptime Monitor + Server Status. not only another GA alternatives",
+    "repository": {
+      "url": "https://github.com/msgbyte/tianji",
+      "source": "github",
+      "id": "685392779"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "tianji",
+        "version": "1.20.9"
+      }
+    ]
+  },
+  {
+    "id": "adb9a058-774f-4505-aa80-1afa9bab8cb9",
+    "name": "io.github.tinybirdco/mcp-tinybird",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/tinybirdco/mcp-tinybird",
+      "source": "github",
+      "id": "894960290"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-tinybird",
+        "version": "1.0.2"
+      }
+    ]
+  },
+  {
+    "id": "9941c18c-f247-4b88-a6ff-7b001f806acf",
+    "name": "io.github.unifai-network/unifai-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/unifai-network/unifai-mcp-server",
+      "source": "github",
+      "id": "946711580"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "unifai-network/unifai-mcp-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "8b01f838-0cb6-4c17-b381-108713321d6d",
+    "name": "io.github.unstructured-io/uns-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Unstructured-IO/UNS-MCP",
+      "source": "github",
+      "id": "947454003"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:15Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "uns_mcp",
+        "version": "0.1.6",
+        "package_arguments": [
+          {
+            "description": "Directory to use",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory ABSOLUTE/PATH/TO/YOUR-UNS-MCP-REPO/uns_mcp",
+            "default": "--directory ABSOLUTE/PATH/TO/YOUR-UNS-MCP-REPO/uns_mcp",
+            "type": "named",
+            "name": "--directory ABSOLUTE/PATH/TO/YOUR-UNS-MCP-REPO/uns_mcp",
+            "value_hint": "ABSOLUTE/PATH/TO/YOUR-UNS-MCP-REPO/uns_mcp"
+          },
+          {
+            "description": "Python script file",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c1b727f7-1570-465f-8153-585840de260a",
+    "name": "io.github.vectorize-io/vectorize-mcp-server",
+    "description": "Official Vectorize MCP Server",
+    "repository": {
+      "url": "https://github.com/vectorize-io/vectorize-mcp-server",
+      "source": "github",
+      "id": "946057362"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@vectorize-io/vectorize-mcp-server",
+        "version": "0.4.3",
+        "package_arguments": [
+          {
+            "description": "Generate a financial status report about the company",
+            "is_required": true,
+            "format": "string",
+            "value": "Generate a financial status report about the company",
+            "default": "Generate a financial status report about the company",
+            "type": "named",
+            "name": "Generate a financial status report about the company",
+            "value_hint": "Generate a financial status report about the company"
+          },
+          {
+            "description": "true",
+            "is_required": true,
+            "format": "string",
+            "value": "true",
+            "default": "true",
+            "type": "named",
+            "name": "true",
+            "value_hint": "true"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c0c30db1-cc08-426e-886f-0bdbcd31d101",
+    "name": "io.github.verodat/verodat-mcp-server",
+    "description": "Verodat MCP Server Implementation",
+    "repository": {
+      "url": "https://github.com/Verodat/verodat-mcp-server",
+      "source": "github",
+      "id": "924683561"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "verodat-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to script file to run",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/verodat-mcp-server/build/src/consume.js",
+            "default": "path/to/verodat-mcp-server/build/src/consume.js",
+            "type": "positional",
+            "value_hint": "path/to/verodat-mcp-server/build/src/consume.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "VERODAT_AI_API_KEY"
+          },
+          {
+            "description": "https://verodat.io/api/v3",
+            "name": "VERODAT_API_BASE_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2cc83e0a-3ca5-4e21-b346-83254cc72e1f",
+    "name": "io.github.veyrax/veyrax-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/VeyraX/veyrax-mcp",
+      "source": "github",
+      "id": "942928935"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "veyrax-mcp",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "4bc3b6d3-666e-4bb7-8ad7-6b38bc9c5ab8",
+    "name": "io.github.xeroapi/xero-mcp-server",
+    "description": "An MCP server that integrates with the MCP protocol. https://modelcontextprotocol.io/introduction",
+    "repository": {
+      "url": "https://github.com/XeroAPI/xero-mcp-server",
+      "source": "github",
+      "id": "949710667"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@xeroapi/xero-mcp-server",
+        "version": "0.0.12",
+        "package_arguments": [
+          {
+            "description": "Path to MCP server entry file",
+            "is_required": true,
+            "format": "string",
+            "value": "insert-your-file-path-here/xero-mcp-server/dist/index.js",
+            "default": "insert-your-file-path-here/xero-mcp-server/dist/index.js",
+            "type": "positional",
+            "value_hint": "insert-your-file-path-here/xero-mcp-server/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_client_id_here",
+            "name": "XERO_CLIENT_ID"
+          },
+          {
+            "description": "your_client_secret_here",
+            "name": "XERO_CLIENT_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "64fdea5a-9fe3-4492-b9fb-6260e6c3dc34",
+    "name": "io.github.zenml-io/mcp-zenml",
+    "description": "MCP server to connect an MCP client (Cursor, Claude Desktop etc) with your ZenML MLOps and LLMOps pipelines",
+    "repository": {
+      "url": "https://github.com/zenml-io/mcp-zenml",
+      "source": "github",
+      "id": "937211343"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "zenml-io/mcp-zenml",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Python script to run",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/zenml_server.py",
+            "default": "path/to/zenml_server.py",
+            "type": "positional",
+            "value_hint": "path/to/zenml_server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "INFO",
+            "name": "LOGLEVEL"
+          },
+          {
+            "description": "1",
+            "name": "NO_COLOR"
+          },
+          {
+            "description": "1",
+            "name": "PYTHONUNBUFFERED"
+          },
+          {
+            "description": "UTF-8",
+            "name": "PYTHONIOENCODING"
+          },
+          {
+            "description": "https://your-zenml-server-goes-here.com",
+            "name": "ZENML_STORE_URL"
+          },
+          {
+            "description": "your-api-key-here",
+            "name": "ZENML_STORE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "60b95692-579f-4de4-8095-1efdca5d8591",
+    "name": "io.github.simon-kansara/ableton-live-mcp-server",
+    "description": "MCP Server implementation for Ableton Live OSC control",
+    "repository": {
+      "url": "https://github.com/Simon-Kansara/ableton-live-mcp-server",
+      "source": "github",
+      "id": "938133354"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "ableton-live-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "98b8992b-77cc-43a5-825e-d14270fd9ca5",
+    "name": "io.github.ahujasid/ableton-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/ahujasid/ableton-mcp",
+      "source": "github",
+      "id": "951429064"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ableton-mcp",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "1101c394-e912-42b6-85be-d2479b72d27f",
+    "name": "io.github.openbnb-org/mcp-server-airbnb",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/openbnb-org/mcp-server-airbnb",
+      "source": "github",
+      "id": "945678498"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@openbnb/mcp-server-airbnb",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "Ignore robots.txt directives",
+            "is_required": true,
+            "format": "string",
+            "value": "--ignore-robots-txt",
+            "default": "--ignore-robots-txt",
+            "type": "named",
+            "name": "--ignore-robots-txt"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ffe051ab-1088-4040-9bbb-8a1bf3fd2a7b",
+    "name": "io.github.ai-agent-hub/ai-agent-marketplace-index-mcp",
+    "description": "MCP Server for AI Agent Marketplace Index from DeepNLP",
+    "repository": {
+      "url": "https://github.com/AI-Agent-Hub/ai-agent-marketplace-index-mcp",
+      "source": "github",
+      "id": "958905017"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:37Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "ai-agent-marketplace-index-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4813a35a-7d43-42fa-999d-86e68b2aca1a",
+    "name": "io.github.goplausible/algorand-mcp",
+    "description": "Algorand Model Context Protocol (Server & Client)",
+    "repository": {
+      "url": "https://github.com/GoPlausible/algorand-mcp",
+      "source": "github",
+      "id": "946072706"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "algorand-mcp",
+        "version": "2.7.7"
+      }
+    ]
+  },
+  {
+    "id": "ae6d4cd8-c930-4737-9aba-93609f53cde1",
+    "name": "io.github.yangkyeongmo/mcp-server-apache-airflow",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/yangkyeongmo/mcp-server-apache-airflow",
+      "source": "github",
+      "id": "931916510"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-apache-airflow",
+        "version": "0.2.2",
+        "package_arguments": [
+          {
+            "description": "Directory to run the server from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/mcp-server-apache-airflow",
+            "default": "--directory /path/to/mcp-server-apache-airflow",
+            "type": "named",
+            "name": "--directory /path/to/mcp-server-apache-airflow",
+            "value_hint": "/path/to/mcp-server-apache-airflow"
+          },
+          {
+            "description": "Name of the Airflow MCP server",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-apache-airflow",
+            "default": "mcp-server-apache-airflow",
+            "type": "positional",
+            "value_hint": "mcp-server-apache-airflow"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://your-airflow-host",
+            "name": "AIRFLOW_HOST"
+          },
+          {
+            "description": "your-username",
+            "name": "AIRFLOW_USERNAME"
+          },
+          {
+            "description": "your-password",
+            "name": "AIRFLOW_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a4902ee8-060c-47d1-9dfc-ec6af1a9c398",
+    "name": "io.github.domdomegg/airtable-mcp-server",
+    "description": "🗂️🤖 Airtable Model Context Protocol Server, for allowing AI systems to interact with your Airtable bases",
+    "repository": {
+      "url": "https://github.com/domdomegg/airtable-mcp-server",
+      "source": "github",
+      "id": "902495626"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "airtable-mcp-server",
+        "version": "1.4.1",
+        "environment_variables": [
+          {
+            "description": "pat123.abc123",
+            "name": "AIRTABLE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "04216a87-0760-4f25-b809-42ffbfbb8962",
+    "name": "io.github.felores/airtable-mcp",
+    "description": "Search, create and update Airtable bases, tables, fields, and records using Claude Desktop and MCP (Model Context Protocol) clients",
+    "repository": {
+      "url": "https://github.com/felores/airtable-mcp",
+      "source": "github",
+      "id": "904238387"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@felores/airtable-mcp-server",
+        "version": "0.3.0",
+        "package_arguments": [
+          {
+            "description": "Positional argument for the package entry point",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/airtable-mcp/build/index.js",
+            "default": "path/to/airtable-mcp/build/index.js",
+            "type": "positional",
+            "value_hint": "path/to/airtable-mcp/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "AIRTABLE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cac9fd2a-2c08-441f-a94d-16c67821221f",
+    "name": "io.github.calvernaz/alphavantage",
+    "description": "A MCP server for the stock market data API, Alphavantage API.",
+    "repository": {
+      "url": "https://github.com/calvernaz/alphavantage",
+      "source": "github",
+      "id": "899668514"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "alphavantage",
+        "version": "0.3.10"
+      }
+    ]
+  },
+  {
+    "id": "ad6e04de-5f80-4274-9464-c6bbff533ad3",
+    "name": "io.github.donghyun-chae/mcp-amadeus",
+    "description": "Amadeus MCP(Model Context Protocol) Server",
+    "repository": {
+      "url": "https://github.com/donghyun-chae/mcp-amadeus",
+      "source": "github",
+      "id": "963136865"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-amadeus",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "1cc26407-7ab5-44dd-b5a2-99efd6fcb757",
+    "name": "io.github.scorzeth/anki-mcp-server",
+    "description": "An MCP server for Anki",
+    "repository": {
+      "url": "https://github.com/scorzeth/anki-mcp-server",
+      "source": "github",
+      "id": "901609361"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:02:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@scorzeth/anki-mcp-server",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "fee5894b-e255-408d-9cd2-e6ee29d78d78",
+    "name": "io.github.datastrato/mcp-server-gravitino",
+    "description": "MCP server for Apache Gravitino(incubating)",
+    "repository": {
+      "url": "https://github.com/datastrato/mcp-server-gravitino",
+      "source": "github",
+      "id": "966588444"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-gravitino",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Set working directory",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /Users/user/workspace/mcp-server-gravitino",
+            "default": "--directory /Users/user/workspace/mcp-server-gravitino",
+            "type": "named",
+            "name": "--directory /Users/user/workspace/mcp-server-gravitino",
+            "value_hint": "/Users/user/workspace/mcp-server-gravitino"
+          },
+          {
+            "description": "Add fastmcp",
+            "is_required": true,
+            "format": "string",
+            "value": "--with fastmcp",
+            "default": "--with fastmcp",
+            "type": "named",
+            "name": "--with fastmcp",
+            "value_hint": "fastmcp"
+          },
+          {
+            "description": "Add httpx",
+            "is_required": true,
+            "format": "string",
+            "value": "--with httpx",
+            "default": "--with httpx",
+            "type": "named",
+            "name": "--with httpx",
+            "value_hint": "httpx"
+          },
+          {
+            "description": "Add mcp-server-gravitino",
+            "is_required": true,
+            "format": "string",
+            "value": "--with mcp-server-gravitino",
+            "default": "--with mcp-server-gravitino",
+            "type": "named",
+            "name": "--with mcp-server-gravitino",
+            "value_hint": "mcp-server-gravitino"
+          },
+          {
+            "description": "Run python",
+            "is_required": true,
+            "format": "string",
+            "value": "python",
+            "default": "python",
+            "type": "positional",
+            "value_hint": "python"
+          },
+          {
+            "description": "Run module",
+            "is_required": true,
+            "format": "string",
+            "value": "-m mcp_server_gravitino.server",
+            "default": "-m mcp_server_gravitino.server",
+            "type": "named",
+            "name": "-m mcp_server_gravitino.server",
+            "value_hint": "mcp_server_gravitino.server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://localhost:8090",
+            "name": "GRAVITINO_URI"
+          },
+          {
+            "description": "admin",
+            "name": "GRAVITINO_USERNAME"
+          },
+          {
+            "description": "admin",
+            "name": "GRAVITINO_PASSWORD"
+          },
+          {
+            "description": "metalake_demo",
+            "name": "GRAVITINO_METALAKE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0d7bc864-fdf3-4afd-8b44-48468b12d550",
+    "name": "io.github.omar-v2/mcp-ical",
+    "description": "A Model Context Protocol Server that allows you to interact with your MacOS Calendar through natural language.",
+    "repository": {
+      "url": "https://github.com/Omar-V2/mcp-ical",
+      "source": "github",
+      "id": "930007673"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-ical",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-ical",
+            "default": "mcp-ical",
+            "type": "positional",
+            "value_hint": "mcp-ical"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8a38266e-dee5-41ce-8228-2b51a307785f",
+    "name": "io.github.peakmojo/applescript-mcp",
+    "description": "MCP server that execute applescript giving you full control of your Mac",
+    "repository": {
+      "url": "https://github.com/peakmojo/applescript-mcp",
+      "source": "github",
+      "id": "970501693"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-server-applescript",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "775bd83c-b33a-471c-9deb-8a444fb4ac79",
+    "name": "io.github.diegobit/aranet4-mcp-server",
+    "description": "SImple MCP server to manage your aranet4 device and local db.",
+    "repository": {
+      "url": "https://github.com/diegobit/aranet4-mcp-server",
+      "source": "github",
+      "id": "965063885"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "aranet4-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Directory flag and its value",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory {{PATH_TO_SRC}}/aranet4-mcp-server/",
+            "default": "--directory {{PATH_TO_SRC}}/aranet4-mcp-server/",
+            "type": "named",
+            "name": "--directory {{PATH_TO_SRC}}/aranet4-mcp-server/",
+            "value_hint": "{{PATH_TO_SRC}}/aranet4-mcp-server/"
+          },
+          {
+            "description": "Python server file",
+            "is_required": true,
+            "format": "string",
+            "value": "src/server.py",
+            "default": "src/server.py",
+            "type": "positional",
+            "value_hint": "src/server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1e97b930-031a-47b6-afb1-8af61dd81ec0",
+    "name": "io.github.ravenwits/mcp-server-arangodb",
+    "description": "This is a TypeScript-based MCP server that provides database interaction capabilities through ArangoDB. It implements core database operations and allows seamless integration with ArangoDB through MCP tools. You can use it wih Claude app and also extension for VSCode that works with mcp like Cline!",
+    "repository": {
+      "url": "https://github.com/ravenwits/mcp-server-arangodb",
+      "source": "github",
+      "id": "909459279"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:13Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "arango-server",
+        "version": "0.4.4",
+        "environment_variables": [
+          {
+            "description": "your_database_url",
+            "name": "ARANGO_URL"
+          },
+          {
+            "description": "your_database_name",
+            "name": "ARANGO_DB"
+          },
+          {
+            "description": "your_username",
+            "name": "ARANGO_USERNAME"
+          },
+          {
+            "description": "your_password",
+            "name": "ARANGO_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "466926d1-72a6-42be-b2c1-ef94d44e5a67",
+    "name": "io.github.vishalmysore/choturobo",
+    "description": "Integrate Arduino-based robotics (using the NodeMCU ESP32 or Arduino Nano 368 board) with AI using the MCP (Model Context Protocol) framework from Claude Anthropic",
+    "repository": {
+      "url": "https://github.com/vishalmysore/choturobo",
+      "source": "github",
+      "id": "947567270"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "choturoboserver",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "4df1406c-1bb1-4495-96e8-8c25de454b5d",
+    "name": "io.github.sooperset/mcp-atlassian",
+    "description": "MCP server for Atlassian tools (Confluence, Jira)",
+    "repository": {
+      "url": "https://github.com/sooperset/mcp-atlassian",
+      "source": "github",
+      "id": "897809208"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-atlassian",
+        "version": "0.10.6"
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "http://localhost:9000/sse"
+      }
+    ]
+  },
+  {
+    "id": "05ca6ccc-d6e1-47ab-ab8d-25949db9ada7",
+    "name": "io.github.co-browser/attestable-mcp-server",
+    "description": "Verify that any MCP server is running the intended and untampered code via hardware attestation.",
+    "repository": {
+      "url": "https://github.com/co-browser/attestable-mcp-server",
+      "source": "github",
+      "id": "955641588"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "attestable-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "e9799403-3917-4c38-9638-c69aebf1ac08",
+    "name": "io.github.rishikavikondala/mcp-server-aws",
+    "description": "A Model Context Protocol server implementation for operations on AWS resources",
+    "repository": {
+      "url": "https://github.com/rishikavikondala/mcp-server-aws",
+      "source": "github",
+      "id": "898207013"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-aws",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "d3139564-f4c3-44f9-902a-8d172038af01",
+    "name": "io.github.lishenxydlgzs/aws-athena-mcp",
+    "description": "MCP server to run AWS Athena queries",
+    "repository": {
+      "url": "https://github.com/lishenxydlgzs/aws-athena-mcp",
+      "source": "github",
+      "id": "938923691"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:23Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@lishenxydlgzs/aws-athena-mcp",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Named argument for query identifier",
+            "is_required": true,
+            "format": "string",
+            "value": "--namedQueryId abcd-1234-efgh-5678",
+            "default": "--namedQueryId abcd-1234-efgh-5678",
+            "type": "named",
+            "name": "--namedQueryId abcd-1234-efgh-5678",
+            "value_hint": "abcd-1234-efgh-5678"
+          },
+          {
+            "description": "Named argument for maximum rows",
+            "is_required": true,
+            "format": "string",
+            "value": "--maxRows 100",
+            "default": "--maxRows 100",
+            "type": "named",
+            "name": "--maxRows 100",
+            "value_hint": "100"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9ddac40e-d776-4232-a00f-7e698eb2dca8",
+    "name": "io.github.aarora79/aws-cost-explorer-mcp-server",
+    "description": "MCP server for understanding AWS spend",
+    "repository": {
+      "url": "https://github.com/aarora79/aws-cost-explorer-mcp-server",
+      "source": "github",
+      "id": "945535318"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "aws-cost-explorer-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Path to the directory.",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/aws-cost-explorer-mcp-server",
+            "default": "--directory /path/to/aws-cost-explorer-mcp-server",
+            "type": "named",
+            "name": "--directory /path/to/aws-cost-explorer-mcp-server",
+            "value_hint": "/path/to/aws-cost-explorer-mcp-server"
+          },
+          {
+            "description": "Python script to run.",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_ACCESS_KEY_ID",
+            "name": "AWS_ACCESS_KEY_ID"
+          },
+          {
+            "description": "YOUR_SECRET_ACCESS_KEY",
+            "name": "AWS_SECRET_ACCESS_KEY"
+          },
+          {
+            "description": "us-east-1",
+            "name": "AWS_REGION"
+          },
+          {
+            "description": "YOUR_CLOUDWATCH_BEDROCK_MODEL_INVOCATION_LOG_GROUP_NAME",
+            "name": "BEDROCK_LOG_GROUP_NAME"
+          },
+          {
+            "description": "ROLE_NAME_FOR_THE_ROLE_TO_ASSUME_IN_OTHER_ACCOUNTS",
+            "name": "CROSS_ACCOUNT_ROLE_NAME"
+          },
+          {
+            "description": "stdio",
+            "name": "MCP_TRANSPORT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6dd26dd7-d5c3-4aa8-bb9a-3aba328790ad",
+    "name": "io.github.baryhuang/mcp-server-aws-resources-python",
+    "description": "A Python-based MCP server that lets Claude run boto3 code to query and manage AWS resources. Execute powerful AWS operations directly through Claude with proper sandboxing and containerization. No need for complex setups - just pass your AWS credentials and start interacting with all AWS services.",
+    "repository": {
+      "url": "https://github.com/baryhuang/mcp-server-aws-resources-python",
+      "source": "github",
+      "id": "916512524"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-server-aws-resources",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Keep STDIN open even if not attached",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "Automatically remove the container when it exits",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Set environment variables in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e AWS_PROFILE=default",
+            "default": "-e AWS_PROFILE=default",
+            "type": "named",
+            "name": "-e AWS_PROFILE=default",
+            "value_hint": "AWS_PROFILE=default"
+          },
+          {
+            "description": "Bind mount a volume",
+            "is_required": true,
+            "format": "string",
+            "value": "-v ~/.aws:/root/.aws",
+            "default": "-v ~/.aws:/root/.aws",
+            "type": "named",
+            "name": "-v ~/.aws:/root/.aws",
+            "value_hint": "~/.aws:/root/.aws"
+          },
+          {
+            "description": "Docker image name with tag",
+            "is_required": true,
+            "format": "string",
+            "value": "buryhuang/mcp-server-aws-resources:latest",
+            "default": "buryhuang/mcp-server-aws-resources:latest",
+            "type": "positional",
+            "value_hint": "buryhuang/mcp-server-aws-resources:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f7f8acea-8725-48ec-a2f8-08ee16c738db",
+    "name": "io.github.aws-samples/sample-mcp-server-s3",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/aws-samples/sample-mcp-server-s3",
+      "source": "github",
+      "id": "907453245"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "s3-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "bb734a22-a274-48ee-9740-d4a6a9a0a367",
+    "name": "io.github.pab1it0/adx-mcp-server",
+    "description": "A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Azure Data Explorer databases through standardized interfaces.",
+    "repository": {
+      "url": "https://github.com/pab1it0/adx-mcp-server",
+      "source": "github",
+      "id": "945904536"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "adx_mcp_server",
+        "version": "1.0.9",
+        "package_arguments": [
+          {
+            "description": "Remove container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Keep STDIN open even if not attached",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "Set environment variable in container: ADX_CLUSTER_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e ADX_CLUSTER_URL",
+            "default": "-e ADX_CLUSTER_URL",
+            "type": "named",
+            "name": "-e ADX_CLUSTER_URL",
+            "value_hint": "ADX_CLUSTER_URL"
+          },
+          {
+            "description": "Set environment variable in container: ADX_DATABASE",
+            "is_required": true,
+            "format": "string",
+            "value": "-e ADX_DATABASE",
+            "default": "-e ADX_DATABASE",
+            "type": "named",
+            "name": "-e ADX_DATABASE",
+            "value_hint": "ADX_DATABASE"
+          },
+          {
+            "description": "Set environment variable in container: AZURE_TENANT_ID",
+            "is_required": true,
+            "format": "string",
+            "value": "-e AZURE_TENANT_ID",
+            "default": "-e AZURE_TENANT_ID",
+            "type": "named",
+            "name": "-e AZURE_TENANT_ID",
+            "value_hint": "AZURE_TENANT_ID"
+          },
+          {
+            "description": "Set environment variable in container: AZURE_CLIENT_ID",
+            "is_required": true,
+            "format": "string",
+            "value": "-e AZURE_CLIENT_ID",
+            "default": "-e AZURE_CLIENT_ID",
+            "type": "named",
+            "name": "-e AZURE_CLIENT_ID",
+            "value_hint": "AZURE_CLIENT_ID"
+          },
+          {
+            "description": "Set environment variable in container: ADX_TOKEN_FILE_PATH",
+            "is_required": true,
+            "format": "string",
+            "value": "-e ADX_TOKEN_FILE_PATH",
+            "default": "-e ADX_TOKEN_FILE_PATH",
+            "type": "named",
+            "name": "-e ADX_TOKEN_FILE_PATH",
+            "value_hint": "ADX_TOKEN_FILE_PATH"
+          },
+          {
+            "description": "Container image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "adx-mcp-server",
+            "default": "adx-mcp-server",
+            "type": "positional",
+            "value_hint": "adx-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://yourcluster.region.kusto.windows.net",
+            "name": "ADX_CLUSTER_URL"
+          },
+          {
+            "description": "your_database",
+            "name": "ADX_DATABASE"
+          },
+          {
+            "description": "your_tenant_id",
+            "name": "AZURE_TENANT_ID"
+          },
+          {
+            "description": "your_client_id",
+            "name": "AZURE_CLIENT_ID"
+          },
+          {
+            "description": "/var/run/secrets/azure/tokens/azure-identity-token",
+            "name": "ADX_TOKEN_FILE_PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4502246b-f419-4879-a179-149c6d87a871",
+    "name": "io.github.vortiago/mcp-azure-devops",
+    "description": "A Model Context Protocol (MCP) server enabling AI assistants to interact with Azure DevOps services via Python SDK.",
+    "repository": {
+      "url": "https://github.com/Vortiago/mcp-azure-devops",
+      "source": "github",
+      "id": "948085438"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-azure-devops",
+        "version": "0.6.0"
+      }
+    ]
+  },
+  {
+    "id": "b7e8b7c6-548b-49a7-9001-2bf1733ca539",
+    "name": "io.github.baidubce/app-builder",
+    "description": "appbuilder-sdk, 千帆AppBuilder-SDK帮助开发者灵活、快速的搭建AI原生应用",
+    "repository": {
+      "url": "https://github.com/baidubce/app-builder",
+      "source": "github",
+      "id": "727502310"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "baidubce/app-builder",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c3123664-33b3-4f29-bc08-40b88300f57c",
+    "name": "io.github.magnetai/mcp-free-usdc-transfer",
+    "description": "MCP (Model Context Protocol) server - free usdc transfer powered by Coinbase CDP",
+    "repository": {
+      "url": "https://github.com/magnetai/mcp-free-usdc-transfer",
+      "source": "github",
+      "id": "914708046"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@magnetai/free-usdc-transfer",
+        "version": "0.1.5",
+        "environment_variables": [
+          {
+            "description": "YOUR_COINBASE_CDP_API_KEY_NAME",
+            "name": "COINBASE_CDP_API_KEY_NAME"
+          },
+          {
+            "description": "YOUR_COINBASE_CDP_PRIVATE_KEY",
+            "name": "COINBASE_CDP_PRIVATE_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "377dba9b-63cc-4ca9-bb39-97f5e12497b4",
+    "name": "io.github.basicmachines-co/basic-memory",
+    "description": "Basic Memory is a knowledge management system that allows you to build a persistent semantic graph from conversations with AI assistants, stored in standard Markdown files on your computer. Integrates directly with Obsidan.md",
+    "repository": {
+      "url": "https://github.com/basicmachines-co/basic-memory",
+      "source": "github",
+      "id": "897595329"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "basic-memory",
+        "version": "0.12.3",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0e517488-6e73-41c3-a297-7602f5937079",
+    "name": "io.github.lucashild/mcp-server-bigquery",
+    "description": "A Model Context Protocol server that provides access to BigQuery",
+    "repository": {
+      "url": "https://github.com/LucasHild/mcp-server-bigquery",
+      "source": "github",
+      "id": "898062517"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-bigquery",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "e3053bd5-1a4d-473c-a41b-f83ab1a46174",
+    "name": "io.github.ergut/mcp-bigquery-server",
+    "description": "A Model Context Protocol (MCP) server that provides secure, read-only access to BigQuery datasets. Enables Large Language Models (LLMs) to safely query and analyze data through a standardized interface.",
+    "repository": {
+      "url": "https://github.com/ergut/mcp-bigquery-server",
+      "source": "github",
+      "id": "898108083"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@ergut/mcp-bigquery-server",
+        "version": "1.0.3",
+        "package_arguments": [
+          {
+            "description": "--project-id your-project-id",
+            "is_required": true,
+            "format": "string",
+            "value": "--project-id your-project-id",
+            "default": "--project-id your-project-id",
+            "type": "named",
+            "name": "--project-id your-project-id",
+            "value_hint": "your-project-id"
+          },
+          {
+            "description": "--location us-central1",
+            "is_required": true,
+            "format": "string",
+            "value": "--location us-central1",
+            "default": "--location us-central1",
+            "type": "named",
+            "name": "--location us-central1",
+            "value_hint": "us-central1"
+          },
+          {
+            "description": "--key-file /path/to/service-account-key.json",
+            "is_required": true,
+            "format": "string",
+            "value": "--key-file /path/to/service-account-key.json",
+            "default": "--key-file /path/to/service-account-key.json",
+            "type": "named",
+            "name": "--key-file /path/to/service-account-key.json",
+            "value_hint": "/path/to/service-account-key.json"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a0db598f-81d1-44d6-9008-e9a71e742cd3",
+    "name": "io.github.leehanchung/bing-search-mcp",
+    "description": "MCP Server for Bing Search API",
+    "repository": {
+      "url": "https://github.com/leehanchung/bing-search-mcp",
+      "source": "github",
+      "id": "949213032"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp_server_bing",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your-bing-api-key",
+            "name": "BING_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4a33ebab-f5cf-48b3-adb3-3f7094ea706c",
+    "name": "io.github.lloydzhou/bitable-mcp",
+    "description": "This MCP server provides access to Lark Bitable through the Model Context Protocol. It allows users to interact with Bitable tables using predefined tools.",
+    "repository": {
+      "url": "https://github.com/lloydzhou/bitable-mcp",
+      "source": "github",
+      "id": "951621343"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:03:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "bitable-mcp",
+        "version": "0.2.1",
+        "package_arguments": [
+          {
+            "description": "-m bitable_mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "-m bitable_mcp",
+            "default": "-m bitable_mcp",
+            "type": "named",
+            "name": "-m bitable_mcp",
+            "value_hint": "bitable_mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-personal-base-token",
+            "name": "PERSONAL_BASE_TOKEN"
+          },
+          {
+            "description": "your-app-token",
+            "name": "APP_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fd341719-247e-45e8-a911-ad7c336eb163",
+    "name": "io.github.ahujasid/blender-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/ahujasid/blender-mcp",
+      "source": "github",
+      "id": "944414751"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "blender-mcp",
+        "version": "1.1.3",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "uvx",
+            "default": "uvx",
+            "type": "positional",
+            "value_hint": "uvx"
+          },
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "blender-mcp",
+            "default": "blender-mcp",
+            "type": "positional",
+            "value_hint": "blender-mcp"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b9bf1c69-4a64-47ec-a781-fb81d1922695",
+    "name": "io.github.agree-able/room-mcp",
+    "description": "Allow MCP clients like claude-desktop to use rooms to coordinate with other agents",
+    "repository": {
+      "url": "https://github.com/agree-able/room-mcp",
+      "source": "github",
+      "id": "939073414"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@agree-able/room-mcp",
+        "version": "1.0.3"
+      }
+    ]
+  },
+  {
+    "id": "27b05d20-fd9c-437d-a86c-923629491ff5",
+    "name": "io.github.co-browser/browser-use-mcp-server",
+    "description": "Browse the web, directly from Cursor etc.",
+    "repository": {
+      "url": "https://github.com/co-browser/browser-use-mcp-server",
+      "source": "github",
+      "id": "943806192"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "browser-use-mcp-server",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "server",
+            "is_required": true,
+            "format": "string",
+            "value": "server",
+            "default": "server",
+            "type": "positional",
+            "value_hint": "server"
+          },
+          {
+            "description": "--port 8000",
+            "is_required": true,
+            "format": "string",
+            "value": "--port 8000",
+            "default": "--port 8000",
+            "type": "named",
+            "name": "--port 8000",
+            "value_hint": "8000"
+          },
+          {
+            "description": "--stdio",
+            "is_required": true,
+            "format": "string",
+            "value": "--stdio",
+            "default": "--stdio",
+            "type": "named",
+            "name": "--stdio"
+          },
+          {
+            "description": "--proxy-port 9000",
+            "is_required": true,
+            "format": "string",
+            "value": "--proxy-port 9000",
+            "default": "--proxy-port 9000",
+            "type": "named",
+            "name": "--proxy-port 9000",
+            "value_hint": "9000"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "OPENAI_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "36156772-6775-4b79-b560-b72ccaaca085",
+    "name": "io.github.termix-official/bsc-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/TermiX-official/bsc-mcp",
+      "source": "github",
+      "id": "949735444"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "bnbchain-mcp",
+        "version": "1.0.12"
+      }
+    ]
+  },
+  {
+    "id": "87cf029b-441f-439a-aae9-9ef27ddd4322",
+    "name": "io.github.githejie/mcp-server-calculator",
+    "description": "A Model Context Protocol server for calculating.",
+    "repository": {
+      "url": "https://github.com/githejie/mcp-server-calculator",
+      "source": "github",
+      "id": "951246115"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-calculator",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "9fcb3e74-e8af-4b55-9bfc-808fa2560148",
+    "name": "io.github.lenwood/cfbd-mcp-server",
+    "description": "An MCP server enabling CFBD API queries within Claude Desktop.",
+    "repository": {
+      "url": "https://github.com/lenwood/cfbd-mcp-server",
+      "source": "github",
+      "id": "906271992"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "cfbd-mcp-server",
+        "version": "0.5.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "cfbd-mcp-server",
+            "default": "cfbd-mcp-server",
+            "type": "positional",
+            "value_hint": "cfbd-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "xxx",
+            "name": "CFB_API_KEY"
+          },
+          {
+            "description": "/full/path/to/python",
+            "name": "PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "16fc441d-0d72-4b14-afd7-d5c9dd25c909",
+    "name": "io.github.ai-ql/chat-mcp",
+    "description": "A Desktop Chat App that leverages MCP(Model Context Protocol) to interface with other LLMs.",
+    "repository": {
+      "url": "https://github.com/AI-QL/chat-mcp",
+      "source": "github",
+      "id": "896905855"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "aiql-desktop",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to the working directory",
+            "is_required": true,
+            "format": "string",
+            "value": "D:/Github/mcp-test",
+            "default": "D:/Github/mcp-test",
+            "type": "positional",
+            "value_hint": "D:/Github/mcp-test"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "196a8cbd-8234-4336-a4d7-f6dda870bcfb",
+    "name": "io.github.mcpso/mcp-server-chatsum",
+    "description": "Query and Summarize your chat messages.",
+    "repository": {
+      "url": "https://github.com/chatmcp/mcp-server-chatsum",
+      "source": "github",
+      "id": "898004429"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-chatsum",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "path-to/mcp-server-chatsum/chatbot/data/chat.db",
+            "name": "CHAT_DB_PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "12ca72e6-3bbf-4c79-94d5-91016543f8ca",
+    "name": "io.github.pab1it0/chess-mcp",
+    "description": "A Model Context Protocol server for Chess.com's Published Data API.  This provides access to Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.",
+    "repository": {
+      "url": "https://github.com/pab1it0/chess-mcp",
+      "source": "github",
+      "id": "956967521"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "chess_mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "The directory to use for the operation",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory <full path to chess-mcp directory>",
+            "default": "--directory <full path to chess-mcp directory>",
+            "type": "named",
+            "name": "--directory <full path to chess-mcp directory>",
+            "value_hint": "<full path to chess-mcp directory>"
+          },
+          {
+            "description": "Script to run with python",
+            "is_required": true,
+            "format": "string",
+            "value": "run src/chess_mcp/main.py",
+            "default": "run src/chess_mcp/main.py",
+            "type": "positional",
+            "value_hint": "run src/chess_mcp/main.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4b637a92-c1af-463d-afc1-e0ce65d7c057",
+    "name": "io.github.privetin/chroma",
+    "description": "MCP server for Chroma",
+    "repository": {
+      "url": "https://github.com/privetin/chroma",
+      "source": "github",
+      "id": "909977348"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "chroma",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Named argument",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory C:/MCP/server/community/chroma",
+            "default": "--directory C:/MCP/server/community/chroma",
+            "type": "named",
+            "name": "--directory C:/MCP/server/community/chroma",
+            "value_hint": "C:/MCP/server/community/chroma"
+          },
+          {
+            "description": "Positional argument",
+            "is_required": true,
+            "format": "string",
+            "value": "chroma",
+            "default": "chroma",
+            "type": "positional",
+            "value_hint": "chroma"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "3b404956-9bad-4bd9-89a9-17534b4bd22e",
+    "name": "io.github.zilongxue/claude-post",
+    "description": "ClaudePost enables seamless email management through natural language conversations with Claude, offering secure features like email search, reading, and sending.",
+    "repository": {
+      "url": "https://github.com/ZilongXue/claude-post",
+      "source": "github",
+      "id": "913146173"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "email_client",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Directory to execute the command in",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/claude-post/src/email_client",
+            "default": "--directory /path/to/claude-post/src/email_client",
+            "type": "named",
+            "name": "--directory /path/to/claude-post/src/email_client",
+            "value_hint": "/path/to/claude-post/src/email_client"
+          },
+          {
+            "description": "Name of the email client script",
+            "is_required": true,
+            "format": "string",
+            "value": "email-client",
+            "default": "email-client",
+            "type": "positional",
+            "value_hint": "email-client"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "34b93e72-0fa8-4dbe-ae9b-82a9e40de735",
+    "name": "io.github.taazkareem/clickup-mcp-server",
+    "description": "ClickUp MCP Server - Integrate ClickUp task management with AI through Model Context Protocol",
+    "repository": {
+      "url": "https://github.com/taazkareem/clickup-mcp-server",
+      "source": "github",
+      "id": "930539984"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@taazkareem/clickup-mcp-server",
+        "version": "0.7.2",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "CLICKUP_API_KEY"
+          },
+          {
+            "description": "your-team-id",
+            "name": "CLICKUP_TEAM_ID"
+          },
+          {
+            "description": "true",
+            "name": "ENABLE_SSE"
+          },
+          {
+            "description": "8000",
+            "name": "PORT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7baddfbe-3618-41d8-befe-40fc2aabcd8e",
+    "name": "io.github.felores/cloudinary-mcp-server",
+    "description": "MCP (Model Context Protocol) server for uploading media to Cloudinary using Claude Desktop",
+    "repository": {
+      "url": "https://github.com/felores/cloudinary-mcp-server",
+      "source": "github",
+      "id": "913564273"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@felores/cloudinary-mcp-server",
+        "version": "1.1.3",
+        "package_arguments": [
+          {
+            "description": "Path to the package entrypoint",
+            "is_required": true,
+            "format": "string",
+            "value": "c:/path/to/cloudinary-mcp-server/dist/index.js",
+            "default": "c:/path/to/cloudinary-mcp-server/dist/index.js",
+            "type": "positional",
+            "value_hint": "c:/path/to/cloudinary-mcp-server/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_cloud_name",
+            "name": "CLOUDINARY_CLOUD_NAME"
+          },
+          {
+            "description": "your_api_key",
+            "name": "CLOUDINARY_API_KEY"
+          },
+          {
+            "description": "your_api_secret",
+            "name": "CLOUDINARY_API_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ae6e66c8-bfef-42dd-b1c5-c69f35bfab36",
+    "name": "io.github.stippi/code-assistant",
+    "description": "An LLM-powered, autonomous coding assistant. Also offers an MCP mode.",
+    "repository": {
+      "url": "https://github.com/stippi/code-assistant",
+      "source": "github",
+      "id": "882757178"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "stippi/code-assistant",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "second positional argument passed to the command",
+            "is_required": true,
+            "format": "string",
+            "value": "server",
+            "default": "server",
+            "type": "positional",
+            "value_hint": "server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "pplx-...",
+            "name": "PERPLEXITY_API_KEY"
+          },
+          {
+            "description": "/bin/zsh",
+            "name": "SHELL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0cdfed38-6495-42a3-a837-3788f35aadd3",
+    "name": "io.github.bazinga012/mcp_code_executor",
+    "description": "The MCP Code Executor is an MCP server that allows LLMs to execute Python code within a specified Conda environment.",
+    "repository": {
+      "url": "https://github.com/bazinga012/mcp_code_executor",
+      "source": "github",
+      "id": "928420039"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:37Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "code_execution_server",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "file_path positional argument for the code file to be read",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/code/storage/my_script_abc123.py",
+            "default": "/path/to/code/storage/my_script_abc123.py",
+            "type": "positional",
+            "value_hint": "/path/to/code/storage/my_script_abc123.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7e1d97cc-ef73-480a-a9f3-c9d94c05a481",
+    "name": "io.github.automata-labs-team/code-sandbox-mcp",
+    "description": "An MCP server to create secure code sandbox environment for executing code within Docker containers. This MCP server provides AI applications with a safe and isolated environment for running code while maintaining security through containerization.",
+    "repository": {
+      "url": "https://github.com/Automata-Labs-team/code-sandbox-mcp",
+      "source": "github",
+      "id": "922445184"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "Automata-Labs-team/code-sandbox-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "a9fe34f1-7c82-4f7d-8fbe-20bb8ca29e7b",
+    "name": "io.github.kocierik/consul-mcp-server",
+    "description": "A consul MCP Server (modelcontextprotocol) ",
+    "repository": {
+      "url": "https://github.com/kocierik/consul-mcp-server",
+      "source": "github",
+      "id": "969129017"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "consul-mcp",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "ae9ce022-800d-4a10-a452-5bc396d25430",
+    "name": "io.github.topoteretes/cognee",
+    "description": "Memory for AI Agents in 5 lines of code",
+    "repository": {
+      "url": "https://github.com/topoteretes/cognee",
+      "source": "github",
+      "id": "679343504"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "cognee",
+        "version": "0.1.40"
+      }
+    ]
+  },
+  {
+    "id": "28fc08e1-1afc-42cb-8eca-0b500e23c73e",
+    "name": "io.github.longmans/coin_api_mcp",
+    "description": "A Model Context Protocol server that provides access to CoinMarketCap's cryptocurrency data. This server enables AI-powered applications to retrieve cryptocurrency listings, quotes, and detailed information about various coins.",
+    "repository": {
+      "url": "https://github.com/longmans/coin_api_mcp",
+      "source": "github",
+      "id": "903449956"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "coin-api-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "-m coin_api_mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "-m coin_api_mcp",
+            "default": "-m coin_api_mcp",
+            "type": "named",
+            "name": "-m coin_api_mcp",
+            "value_hint": "coin_api_mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "COINMARKETCAP_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7e3a17ce-fbbd-48cb-b29f-34a4b8c6ca55",
+    "name": "io.github.shinzo-labs/coinmarketcap-mcp",
+    "description": "MCP Implementation for CoinMarketCap",
+    "repository": {
+      "url": "https://github.com/shinzo-labs/coinmarketcap-mcp",
+      "source": "github",
+      "id": "952163210"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@shinzolabs/coinmarketcap-mcp",
+        "version": "1.3.7"
+      }
+    ]
+  },
+  {
+    "id": "5e32ec37-7a46-4e84-9f19-845cd6b151f4",
+    "name": "io.github.baryhuang/mcp-remote-macos-use",
+    "description": "The only general AI agent that does NOT requires extra API key, giving you full control on your local and remote MacOs from Claude Desktop App",
+    "repository": {
+      "url": "https://github.com/baryhuang/mcp-remote-macos-use",
+      "source": "github",
+      "id": "952732612"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp_remote_macos_use",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Pass environment variable MACOS_USERNAME",
+            "is_required": true,
+            "format": "string",
+            "value": "-e MACOS_USERNAME=your_macos_username",
+            "default": "-e MACOS_USERNAME=your_macos_username",
+            "type": "named",
+            "name": "-e MACOS_USERNAME=your_macos_username",
+            "value_hint": "MACOS_USERNAME=your_macos_username"
+          },
+          {
+            "description": "Pass environment variable MACOS_PASSWORD",
+            "is_required": true,
+            "format": "string",
+            "value": "-e MACOS_PASSWORD=your_macos_password",
+            "default": "-e MACOS_PASSWORD=your_macos_password",
+            "type": "named",
+            "name": "-e MACOS_PASSWORD=your_macos_password",
+            "value_hint": "MACOS_PASSWORD=your_macos_password"
+          },
+          {
+            "description": "Pass environment variable MACOS_HOST",
+            "is_required": true,
+            "format": "string",
+            "value": "-e MACOS_HOST=your_macos_hostname_or_ip",
+            "default": "-e MACOS_HOST=your_macos_hostname_or_ip",
+            "type": "named",
+            "name": "-e MACOS_HOST=your_macos_hostname_or_ip",
+            "value_hint": "MACOS_HOST=your_macos_hostname_or_ip"
+          },
+          {
+            "description": "Remove container when it exits",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Docker image to use",
+            "is_required": true,
+            "format": "string",
+            "value": "buryhuang/mcp-remote-macos-use:latest",
+            "default": "buryhuang/mcp-remote-macos-use:latest",
+            "type": "positional",
+            "value_hint": "buryhuang/mcp-remote-macos-use:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "347d6881-c509-4dca-9ece-95e25098436b",
+    "name": "io.github.ivo-toby/contentful-mcp",
+    "description": "MCP (Model Context Protocol) server for the Contentful Management API",
+    "repository": {
+      "url": "https://github.com/ivo-toby/contentful-mcp",
+      "source": "github",
+      "id": "898628964"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@ivotoby/contentful-management-mcp-server",
+        "version": "1.14.0",
+        "package_arguments": [
+          {
+            "description": "Management token for Contentful",
+            "is_required": true,
+            "format": "string",
+            "value": "--management-token <your token>",
+            "default": "--management-token <your token>",
+            "type": "named",
+            "name": "--management-token <your token>",
+            "value_hint": "<your token>"
+          },
+          {
+            "description": "Contentful API host address",
+            "is_required": true,
+            "format": "string",
+            "value": "--host http://api.contentful.com",
+            "default": "--host http://api.contentful.com",
+            "type": "named",
+            "name": "--host http://api.contentful.com",
+            "value_hint": "http://api.contentful.com"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8d24741f-2cdf-481a-932b-06517c8f9aeb",
+    "name": "io.github.spgoodman/createveai-nexus-server",
+    "description": "Createve.AI Nexus Server: MCP and API bridge for ComfyUI-node compatible LLM and agent use",
+    "repository": {
+      "url": "https://github.com/spgoodman/createveai-nexus-server",
+      "source": "github",
+      "id": "945610929"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "spgoodman/createveai-nexus-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "45ee52ba-1e4c-48a5-9eef-de7a234997db",
+    "name": "io.github.kukapay/crypto-feargreed-mcp",
+    "description": "Providing real-time and historical Crypto Fear & Greed Index data",
+    "repository": {
+      "url": "https://github.com/kukapay/crypto-feargreed-mcp",
+      "source": "github",
+      "id": "948974664"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:04:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "crypto-feargreed-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "0852caec-a861-4f9c-9e94-a7c8b67a1641",
+    "name": "io.github.kukapay/crypto-indicators-mcp",
+    "description": "An MCP server providing a range of cryptocurrency technical analysis indicators and strategies.",
+    "repository": {
+      "url": "https://github.com/kukapay/crypto-indicators-mcp",
+      "source": "github",
+      "id": "953321792"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "crypto-indicators-mcp",
+        "version": "1.0.1",
+        "package_arguments": [
+          {
+            "description": "Positional argument: path/to/crypto-indicators-mcp/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/crypto-indicators-mcp/index.js",
+            "default": "path/to/crypto-indicators-mcp/index.js",
+            "type": "positional",
+            "value_hint": "path/to/crypto-indicators-mcp/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "binance",
+            "name": "EXCHANGE_NAME"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bb7a2190-2e72-4ccf-9603-226e0fde174c",
+    "name": "io.github.kukapay/crypto-sentiment-mcp",
+    "description": "An MCP server that delivers cryptocurrency sentiment analysis to AI agents.",
+    "repository": {
+      "url": "https://github.com/kukapay/crypto-sentiment-mcp",
+      "source": "github",
+      "id": "953543740"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "crypto-sentiment-mcp",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "91f75500-0051-4d05-a5b2-9a87aa52ec3a",
+    "name": "io.github.kukapay/cryptopanic-mcp-server",
+    "description": "Provide latest cryptocurrency news to AI agents.",
+    "repository": {
+      "url": "https://github.com/kukapay/cryptopanic-mcp-server",
+      "source": "github",
+      "id": "946301386"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "cryptopanic-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "58b5f6c8-1ad7-4378-9921-7b9b7982c84c",
+    "name": "io.github.dappierai/dappier-mcp",
+    "description": "Enable fast, free real-time web search and access premium data from trusted media brands—news, financial markets, sports, entertainment, weather, and more. Build powerful AI agents with Dappier.",
+    "repository": {
+      "url": "https://github.com/DappierAI/dappier-mcp",
+      "source": "github",
+      "id": "923666627"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "dappier-mcp",
+        "version": "0.3.2",
+        "environment_variables": [
+          {
+            "description": "YOUR_API_KEY_HERE",
+            "name": "DAPPIER_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5061131f-b74a-4997-a349-99e7789b0eb3",
+    "name": "io.github.jordineil/mcp-databricks-server",
+    "description": "MCP Server for Databricks",
+    "repository": {
+      "url": "https://github.com/JordiNeil/mcp-databricks-server",
+      "source": "github",
+      "id": "952279762"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "JordiNeil/mcp-databricks-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "24f2d280-583d-4511-af0c-47910fc52c4d",
+    "name": "io.github.geli2001/datadog-mcp-server",
+    "description": "MCP server interacts with the official Datadog API",
+    "repository": {
+      "url": "https://github.com/GeLi2001/datadog-mcp-server",
+      "source": "github",
+      "id": "960104719"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "datadog-mcp-server",
+        "version": "1.0.8",
+        "package_arguments": [
+          {
+            "description": "<YOUR_API_KEY>",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiKey <YOUR_API_KEY>",
+            "default": "--apiKey <YOUR_API_KEY>",
+            "type": "named",
+            "name": "--apiKey <YOUR_API_KEY>",
+            "value_hint": "<YOUR_API_KEY>"
+          },
+          {
+            "description": "<YOUR_APP_KEY>",
+            "is_required": true,
+            "format": "string",
+            "value": "--appKey <YOUR_APP_KEY>",
+            "default": "--appKey <YOUR_APP_KEY>",
+            "type": "named",
+            "name": "--appKey <YOUR_APP_KEY>",
+            "value_hint": "<YOUR_APP_KEY>"
+          },
+          {
+            "description": "<YOUR_DD_SITE>",
+            "is_required": true,
+            "format": "string",
+            "value": "--site <YOUR_DD_SITE>",
+            "default": "--site <YOUR_DD_SITE>",
+            "type": "named",
+            "name": "--site <YOUR_DD_SITE>",
+            "value_hint": "<YOUR_DD_SITE>"
+          },
+          {
+            "description": "<YOUR_LOGS_SITE>",
+            "is_required": true,
+            "format": "string",
+            "value": "--logsSite <YOUR_LOGS_SITE>",
+            "default": "--logsSite <YOUR_LOGS_SITE>",
+            "type": "named",
+            "name": "--logsSite <YOUR_LOGS_SITE>",
+            "value_hint": "<YOUR_LOGS_SITE>"
+          },
+          {
+            "description": "<YOUR_METRICS_SITE>",
+            "is_required": true,
+            "format": "string",
+            "value": "--metricsSite <YOUR_METRICS_SITE>",
+            "default": "--metricsSite <YOUR_METRICS_SITE>",
+            "type": "named",
+            "name": "--metricsSite <YOUR_METRICS_SITE>",
+            "value_hint": "<YOUR_METRICS_SITE>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "14074b80-f3a7-4b45-97ba-7204c92c5f6e",
+    "name": "io.github.reading-plus-ai/mcp-server-data-exploration",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/reading-plus-ai/mcp-server-data-exploration",
+      "source": "github",
+      "id": "899661027"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-ds",
+        "version": "0.1.6"
+      }
+    ]
+  },
+  {
+    "id": "59a6acf5-d65f-4884-a9b8-ae7d2c9f6728",
+    "name": "io.github.samuelgursky/davinci-resolve-mcp",
+    "description": "MCP server integration for DaVinci Resolve",
+    "repository": {
+      "url": "https://github.com/samuelgursky/davinci-resolve-mcp",
+      "source": "github",
+      "id": "950355259"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "samuelgursky/davinci-resolve-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "200d7310-6d18-4b22-98b3-68ae63ea985a",
+    "name": "io.github.privetin/dataset-viewer",
+    "description": "MCP server for Hugging Face dataset viewer",
+    "repository": {
+      "url": "https://github.com/privetin/dataset-viewer",
+      "source": "github",
+      "id": "911084198"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "dataset-viewer",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "dataset-viewer",
+            "default": "dataset-viewer",
+            "type": "positional",
+            "value_hint": "dataset-viewer"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "ec2849c6-e8ed-46b1-8e57-646fd2e8be93",
+    "name": "io.github.snagasuri/deebo-prototype",
+    "description": "Autonomous debugging agent MCP server",
+    "repository": {
+      "url": "https://github.com/snagasuri/deebo-prototype",
+      "source": "github",
+      "id": "954456943"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "deebo-prototype",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "--experimental-specifier-resolution=node",
+            "is_required": true,
+            "format": "string",
+            "value": "--experimental-specifier-resolution=node",
+            "default": "--experimental-specifier-resolution=node",
+            "type": "named",
+            "name": "--experimental-specifier-resolution=node",
+            "value_hint": "node"
+          },
+          {
+            "description": "--experimental-modules",
+            "is_required": true,
+            "format": "string",
+            "value": "--experimental-modules",
+            "default": "--experimental-modules",
+            "type": "named",
+            "name": "--experimental-modules"
+          },
+          {
+            "description": "--max-old-space-size=4096",
+            "is_required": true,
+            "format": "string",
+            "value": "--max-old-space-size=4096",
+            "default": "--max-old-space-size=4096",
+            "type": "named",
+            "name": "--max-old-space-size=4096",
+            "value_hint": "4096"
+          },
+          {
+            "description": "/Users/[your-name]/.deebo/build/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "/Users/[your-name]/.deebo/build/index.js",
+            "default": "/Users/[your-name]/.deebo/build/index.js",
+            "type": "positional"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "development",
+            "name": "NODE_ENV"
+          },
+          {
+            "description": "true",
+            "name": "USE_MEMORY_BANK"
+          },
+          {
+            "description": "openrouter",
+            "name": "MOTHER_HOST"
+          },
+          {
+            "description": "anthropic/claude-3.5-sonnet",
+            "name": "MOTHER_MODEL"
+          },
+          {
+            "description": "openrouter",
+            "name": "SCENARIO_HOST"
+          },
+          {
+            "description": "deepseek/deepseek-chat",
+            "name": "SCENARIO_MODEL"
+          },
+          {
+            "description": "your-openrouter-api-key",
+            "name": "OPENROUTER_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "79f72036-83ee-4420-9767-980e27590e6f",
+    "name": "io.github.reading-plus-ai/mcp-server-deep-research",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/reading-plus-ai/mcp-server-deep-research",
+      "source": "github",
+      "id": "953282616"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-deep-research",
+        "version": "0.1.1"
+      }
+    ]
+  },
+  {
+    "id": "345bf964-02ce-4814-b37f-52c2e73ab395",
+    "name": "io.github.dmontgomery40/deepseek-mcp-server",
+    "description": "Model Context Protocol server for DeepSeek's advanced language models",
+    "repository": {
+      "url": "https://github.com/DMontgomery40/deepseek-mcp-server",
+      "source": "github",
+      "id": "920179950"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "deepseek-mcp-server",
+        "version": "0.2.1",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "DEEPSEEK_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a2015046-780d-421a-999f-c52c808236fa",
+    "name": "io.github.66julienmartin/mcp-server-deepseek_r1",
+    "description": "A Model Context Protocol (MCP) server implementation connecting Claude Desktop with DeepSeek's language models (R1/V3)",
+    "repository": {
+      "url": "https://github.com/66julienmartin/MCP-server-Deepseek_R1",
+      "source": "github",
+      "id": "927737184"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "deepseek_r1",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "DEEPSEEK_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "883a7c72-e6ca-41cb-91e9-e65436a58729",
+    "name": "io.github.ruixingshi/deepseek-thinker-mcp",
+    "description": "A MCP provider Deepseek reasoning content to MCP-enabled AI Clients, like Claude Desktop. Supports access to Deepseek's CoT from the Deepseek API service or a local Ollama server.",
+    "repository": {
+      "url": "https://github.com/ruixingshi/deepseek-thinker-mcp",
+      "source": "github",
+      "id": "931883120"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "deepseek-thinker-mcp",
+        "version": "1.0.2",
+        "environment_variables": [
+          {
+            "description": "<Your API Key>",
+            "name": "API_KEY"
+          },
+          {
+            "description": "<Your Base URL>",
+            "name": "BASE_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bac14e5d-08c4-4b69-8e40-b845632d26ed",
+    "name": "io.github.descope-sample-apps/descope-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/descope-sample-apps/descope-mcp-server-stdio",
+      "source": "github",
+      "id": "921929368"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "descope-mcp-server",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your-descope-project-id-here",
+            "name": "DESCOPE_PROJECT_ID"
+          },
+          {
+            "description": "your-descope-management-key-here",
+            "name": "DESCOPE_MANAGEMENT_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8b17658e-2a1b-4ca7-a1ae-583e7b190bce",
+    "name": "io.github.kpsunil97/devrev-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/kpsunil97/devrev-mcp-server",
+      "source": "github",
+      "id": "906414289"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "devrev-mcp",
+        "version": "0.1.1"
+      }
+    ]
+  },
+  {
+    "id": "c83f2ca0-ca97-43cf-8288-5ff4a0771e29",
+    "name": "io.github.christianhinge/dicom-mcp",
+    "description": "Model Context Protocol (MCP) for interacting with dicom servers (PACS etc.)",
+    "repository": {
+      "url": "https://github.com/ChristianHinge/dicom-mcp",
+      "source": "github",
+      "id": "946779028"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "dicom-mcp",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "Specify the directory to operate in",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/cloned/dicom-mcp",
+            "default": "--directory path/to/cloned/dicom-mcp",
+            "type": "named",
+            "name": "--directory path/to/cloned/dicom-mcp",
+            "value_hint": "path/to/cloned/dicom-mcp"
+          },
+          {
+            "description": "Script or module to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "dicom-mcp",
+            "default": "dicom-mcp",
+            "type": "positional",
+            "value_hint": "dicom-mcp"
+          },
+          {
+            "description": "Path to the configuration YAML file",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/your_config.yaml",
+            "default": "/path/to/your_config.yaml",
+            "type": "positional",
+            "value_hint": "/path/to/your_config.yaml"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5f64133c-70f4-4044-ac82-dcb2e7758c8c",
+    "name": "io.github.yanxingliu/dify-mcp-server",
+    "description": "Model Context Protocol (MCP) Server for dify workflows",
+    "repository": {
+      "url": "https://github.com/YanxingLiu/dify-mcp-server",
+      "source": "github",
+      "id": "908244326"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "dify-mcp-server",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "Directory path to operate in",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /Users/lyx/Downloads/dify-mcp-server",
+            "default": "--directory /Users/lyx/Downloads/dify-mcp-server",
+            "type": "named",
+            "name": "--directory /Users/lyx/Downloads/dify-mcp-server",
+            "value_hint": "/Users/lyx/Downloads/dify-mcp-server"
+          },
+          {
+            "description": "Server script/module",
+            "is_required": true,
+            "format": "string",
+            "value": "dify_mcp_server",
+            "default": "dify_mcp_server",
+            "type": "positional",
+            "value_hint": "dify_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://cloud.dify.ai/v1",
+            "name": "DIFY_BASE_URL"
+          },
+          {
+            "description": "app-sk1,app-sk2",
+            "name": "DIFY_APP_SKS"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "361ed7f4-8df4-4a8e-931f-edfb380e0019",
+    "name": "io.github.v-3/discordmcp",
+    "description": "Discord MCP Server for Claude Integration",
+    "repository": {
+      "url": "https://github.com/v-3/discordmcp",
+      "source": "github",
+      "id": "919856605"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "discord-mcp-server",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "ae4c8106-9947-4577-924e-c7106256dd69",
+    "name": "io.github.saseq/discord-mcp",
+    "description": "A MCP server for the Discord integration. Enable your AI assistants to seamlessly interact with Discord. Enhance your Discord experience with powerful automation capabilities.",
+    "repository": {
+      "url": "https://github.com/SaseQ/discord-mcp",
+      "source": "github",
+      "id": "948723723"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:56Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "SaseQ/discord-mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Second positional argument",
+            "is_required": true,
+            "format": "string",
+            "value": "https://gitmcp.io/SaseQ/discord-mcp",
+            "default": "https://gitmcp.io/SaseQ/discord-mcp",
+            "type": "positional",
+            "value_hint": "https://gitmcp.io/SaseQ/discord-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_DISCORD_BOT_TOKEN",
+            "name": "DISCORD_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "dedc68af-03ef-49ce-a331-e4717b96f693",
+    "name": "io.github.ashdevfr/discourse-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/AshDevFr/discourse-mcp-server",
+      "source": "github",
+      "id": "946264788"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:05:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@ashdev/discourse-mcp-server",
+        "version": "1.0.2",
+        "environment_variables": [
+          {
+            "description": "https://try.discourse.org",
+            "name": "DISCOURSE_API_URL"
+          },
+          {
+            "description": "1234",
+            "name": "DISCOURSE_API_KEY"
+          },
+          {
+            "description": "ash",
+            "name": "DISCOURSE_API_USERNAME"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d2aacd5b-0642-4832-8629-58272a922e4b",
+    "name": "io.github.ckreiling/mcp-server-docker",
+    "description": "MCP server for Docker",
+    "repository": {
+      "url": "https://github.com/ckreiling/mcp-server-docker",
+      "source": "github",
+      "id": "899787279"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-docker",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "5a9955bc-6c28-4ebd-974e-73226eb3e58f",
+    "name": "io.github.szeider/mcp-dblp",
+    "description": "A Model Context Protocol (MCP) server that provides access to the DBLP computer science bibliography database for Large Language Models.",
+    "repository": {
+      "url": "https://github.com/szeider/mcp-dblp",
+      "source": "github",
+      "id": "940314682"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-dblp",
+        "version": "1.1.0"
+      }
+    ]
+  },
+  {
+    "id": "7902d399-3080-4926-afb8-4f98c3a7d870",
+    "name": "io.github.omedia/mcp-server-drupal",
+    "description": "TS based companion MCP server for the Drupal MCP module that works with the STDIO transport.",
+    "repository": {
+      "url": "https://github.com/Omedia/mcp-server-drupal",
+      "source": "github",
+      "id": "900629184"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "Omedia/mcp-server-drupal",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "2d851046-40f2-4088-95df-d6c0f93c2f0a",
+    "name": "io.github.kukapay/dune-analytics-mcp",
+    "description": "A mcp server that bridges Dune Analytics data to AI agents.",
+    "repository": {
+      "url": "https://github.com/kukapay/dune-analytics-mcp",
+      "source": "github",
+      "id": "949262442"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "dune-analytics-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "f97607ba-eb50-4258-b46c-ce9fc6587fa9",
+    "name": "io.github.tencentedgeone/edgeone-pages-mcp",
+    "description": "An MCP service designed for deploying HTML content to EdgeOne Pages and obtaining an accessible public URL.",
+    "repository": {
+      "url": "https://github.com/TencentEdgeOne/edgeone-pages-mcp",
+      "source": "github",
+      "id": "954390434"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "edgeone-pages-mcp",
+        "version": "0.0.9"
+      }
+    ]
+  },
+  {
+    "id": "995ac56a-5ec7-4411-a86c-4ebfef9c9605",
+    "name": "io.github.edwin-finance/edwin",
+    "description": "Empowering AI agents to dominate DeFAI",
+    "repository": {
+      "url": "https://github.com/edwin-finance/edwin",
+      "source": "github",
+      "id": "918664127"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "edwin-sdk",
+        "version": "0.8.29"
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "1d89482a-a7de-4d3b-a7cb-1b7be49939ec",
+    "name": "io.github.mamertofabian/elevenlabs-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/mamertofabian/elevenlabs-mcp-server",
+      "source": "github",
+      "id": "906473152"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "elevenlabs-mcp-server",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "Flag to specify a directory for the server",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/elevenlabs-mcp-server",
+            "default": "--directory path/to/elevenlabs-mcp-server",
+            "type": "named",
+            "name": "--directory path/to/elevenlabs-mcp-server",
+            "value_hint": "path/to/elevenlabs-mcp-server"
+          },
+          {
+            "description": "Positional argument specifying the target server to run",
+            "is_required": true,
+            "format": "string",
+            "value": "elevenlabs-mcp-server",
+            "default": "elevenlabs-mcp-server",
+            "type": "positional",
+            "value_hint": "elevenlabs-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-key",
+            "name": "ELEVENLABS_API_KEY"
+          },
+          {
+            "description": "your-voice-id",
+            "name": "ELEVENLABS_VOICE_ID"
+          },
+          {
+            "description": "eleven_flash_v2",
+            "name": "ELEVENLABS_MODEL_ID"
+          },
+          {
+            "description": "0.5",
+            "name": "ELEVENLABS_STABILITY"
+          },
+          {
+            "description": "0.75",
+            "name": "ELEVENLABS_SIMILARITY_BOOST"
+          },
+          {
+            "description": "0.1",
+            "name": "ELEVENLABS_STYLE"
+          },
+          {
+            "description": "output",
+            "name": "ELEVENLABS_OUTPUT_DIR"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c0a64e6c-2ff2-4a2f-afe6-f52119a020a0",
+    "name": "io.github.shy2593666979/mcp-server-email",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Shy2593666979/mcp-server-email",
+      "source": "github",
+      "id": "953349763"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-email",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "35e1e1a0-30c9-4857-a9e0-5c64f7e29fa9",
+    "name": "io.github.whataboutyou-ai/eunomia-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/whataboutyou-ai/eunomia-mcp-server",
+      "source": "github",
+      "id": "915645627"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "eunomia-mcp-server",
+        "version": "0.0.2"
+      }
+    ]
+  },
+  {
+    "id": "e944c7a9-9eb0-495a-8bee-d8da751240e7",
+    "name": "io.github.mcpdotdirect/evm-mcp-server",
+    "description": "MCP server that provides LLM with tools for interacting with EVM networks",
+    "repository": {
+      "url": "https://github.com/mcpdotdirect/evm-mcp-server",
+      "source": "github",
+      "id": "945212492"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@mcpdotdirect/evm-mcp-server",
+        "version": "1.1.3"
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "http://localhost:3001/sse"
+      }
+    ]
+  },
+  {
+    "id": "c6f8403f-30d0-45d2-b7c3-95a6cb61c4b4",
+    "name": "io.github.mamertofabian/mcp-everything-search",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/mamertofabian/mcp-everything-search",
+      "source": "github",
+      "id": "903415597"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-everything-search",
+        "version": "0.2.1",
+        "package_arguments": [
+          {
+            "description": "Sets the directory to operate from.",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/mcp-everything-search/src/mcp_server_everything_search",
+            "default": "--directory /path/to/mcp-everything-search/src/mcp_server_everything_search",
+            "type": "named",
+            "name": "--directory /path/to/mcp-everything-search/src/mcp_server_everything_search",
+            "value_hint": "/path/to/mcp-everything-search/src/mcp_server_everything_search"
+          },
+          {
+            "description": "Server name to execute (positional argument)",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-everything-search",
+            "default": "mcp-server-everything-search",
+            "type": "positional",
+            "value_hint": "mcp-server-everything-search"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "path/to/Everything-SDK/dll/Everything64.dll",
+            "name": "EVERYTHING_SDK_PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2a5c04e4-0526-492b-aa98-49896e033b74",
+    "name": "io.github.haris-musa/excel-mcp-server",
+    "description": "A Model Context Protocol server for Excel file manipulation",
+    "repository": {
+      "url": "https://github.com/haris-musa/excel-mcp-server",
+      "source": "github",
+      "id": "931365873"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:33Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "excel-mcp-server",
+        "version": "0.1.1",
+        "environment_variables": [
+          {
+            "description": "/path/to/excel/files",
+            "name": "EXCEL_FILES_PATH"
+          }
+        ]
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "http://localhost:8000/sse"
+      }
+    ]
+  },
+  {
+    "id": "f1da402e-a006-4364-a100-5131eb05b579",
+    "name": "io.github.rishijatia/fantasy-pl-mcp",
+    "description": "Fantasy Premier League MCP Server",
+    "repository": {
+      "url": "https://github.com/rishijatia/fantasy-pl-mcp",
+      "source": "github",
+      "id": "948676369"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fpl-mcp",
+        "version": "0.1.4"
+      }
+    ]
+  },
+  {
+    "id": "3d7c6822-88bd-4569-a099-1e58b9b365b0",
+    "name": "io.github.fastnai/mcp-fastn",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/fastnai/mcp-fastn",
+      "source": "github",
+      "id": "950266465"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fastn",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "fastn-server.py",
+            "default": "fastn-server.py",
+            "type": "positional",
+            "value_hint": "fastn-server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2382172a-b26a-40fc-adee-f82132b56edc",
+    "name": "io.github.stefanoamorelli/fred-mcp-server",
+    "description": "Open-source MCP Server for the Federal Reserve Economic Data",
+    "repository": {
+      "url": "https://github.com/stefanoamorelli/fred-mcp-server",
+      "source": "github",
+      "id": "981791515"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fred-mcp-server",
+        "version": "0.2.3",
+        "environment_variables": [
+          {
+            "description": "<YOUR_API_KEY>",
+            "name": "FRED_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1f0ecfb3-f362-459d-b217-f146079c3c3b",
+    "name": "io.github.clafollett/fdic-bank-find-mcp-server",
+    "description": "MCP Server to wrap the FDIC Bank Find API",
+    "repository": {
+      "url": "https://github.com/clafollett/fdic-bank-find-mcp-server",
+      "source": "github",
+      "id": "971755349"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "clafollett/fdic-bank-find-mcp-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "c2f4ab61-b279-4cb9-932d-5f60bcd1534a",
+    "name": "io.github.zcaceres/fetch-mcp",
+    "description": "A flexible HTTP fetching Model Context Protocol server.",
+    "repository": {
+      "url": "https://github.com/zcaceres/fetch-mcp",
+      "source": "github",
+      "id": "905004409"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fetch",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "e61c643c-ec01-483c-a586-20f87ab6280e",
+    "name": "io.github.glips/figma-context-mcp",
+    "description": "MCP server to provide Figma layout information to AI coding agents like Cursor",
+    "repository": {
+      "url": "https://github.com/GLips/Figma-Context-MCP",
+      "source": "github",
+      "id": "931892749"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "figma-developer-mcp",
+        "version": "0.2.2",
+        "package_arguments": [
+          {
+            "description": "Figma API Key flag",
+            "is_required": true,
+            "format": "string",
+            "value": "--figma-api-key=YOUR-KEY",
+            "default": "--figma-api-key=YOUR-KEY",
+            "type": "named",
+            "name": "--figma-api-key=YOUR-KEY",
+            "value_hint": "YOUR-KEY"
+          },
+          {
+            "description": "stdio mode",
+            "is_required": true,
+            "format": "string",
+            "value": "--stdio",
+            "default": "--stdio",
+            "type": "named",
+            "name": "--stdio"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d7a1d303-082e-477d-8ab5-9d65dc0117d9",
+    "name": "io.github.gannonh/firebase-mcp",
+    "description": "🔥 Model Context Protocol (MCP) server for Firebase.",
+    "repository": {
+      "url": "https://github.com/gannonh/firebase-mcp",
+      "source": "github",
+      "id": "945181573"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gannonh/firebase-mcp",
+        "version": "1.4.9"
+      }
+    ]
+  },
+  {
+    "id": "3947e186-beb0-4372-8f74-045047dacebd",
+    "name": "io.github.vrknetha/mcp-server-firecrawl",
+    "description": "Official Firecrawl MCP Server - Adds powerful web scraping to Cursor, Claude and any other LLM clients.",
+    "repository": {
+      "url": "https://github.com/mendableai/firecrawl-mcp-server",
+      "source": "github",
+      "id": "899407931"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "firecrawl-mcp",
+        "version": "1.9.0"
+      }
+    ]
+  },
+  {
+    "id": "50b7ab52-c3d0-40bc-b342-38fa93da54ff",
+    "name": "io.github.sunsetcoder/flightradar24-mcp-server",
+    "description": "Model Context Protocol server for Flight Tracking",
+    "repository": {
+      "url": "https://github.com/sunsetcoder/flightradar24-mcp-server",
+      "source": "github",
+      "id": "903070998"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "flightradar24-mcp-server",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "FR24_API_KEY"
+          },
+          {
+            "description": "https://fr24api.flightradar24.com",
+            "name": "FR24_API_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "573c235f-93d7-45a3-9f23-b1166a660c97",
+    "name": "io.github.kukapay/freqtrade-mcp",
+    "description": "An MCP server that integrates with the Freqtrade cryptocurrency trading bot.",
+    "repository": {
+      "url": "https://github.com/kukapay/freqtrade-mcp",
+      "source": "github",
+      "id": "954056822"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "freqtrade-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "e4927319-b643-498e-935f-51bad4e30381",
+    "name": "io.github.mfydev/ghost-mcp",
+    "description": "A Model Context Protocol (MCP) server for interacting with Ghost CMS through LLM interfaces like Claude. Allow you to control your Ghost blog by simply asking Claude etc.",
+    "repository": {
+      "url": "https://github.com/MFYDev/ghost-mcp",
+      "source": "github",
+      "id": "930747221"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:06:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@fanyangmeng/ghost-mcp",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "https://yourblog.com",
+            "name": "GHOST_API_URL"
+          },
+          {
+            "description": "your_admin_api_key",
+            "name": "GHOST_ADMIN_API_KEY"
+          },
+          {
+            "description": "v5.0",
+            "name": "GHOST_API_VERSION"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6026be39-cc97-4ace-b557-a97aeddbbd60",
+    "name": "io.github.geropl/git-mcp-go",
+    "description": "Git MCP based on mcp-go",
+    "repository": {
+      "url": "https://github.com/geropl/git-mcp-go",
+      "source": "github",
+      "id": "940039420"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "geropl/git-mcp-go",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "fa6d267b-a797-42b7-9510-5abc3c518f3e",
+    "name": "io.github.ko1ynnky/github-actions-mcp-server",
+    "description": "GitHub Actions Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/ko1ynnky/github-actions-mcp-server",
+      "source": "github",
+      "id": "951937740"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "github-actions-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "<path-to-mcp-server>/dist/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "<path-to-mcp-server>/dist/index.js",
+            "default": "<path-to-mcp-server>/dist/index.js",
+            "type": "positional",
+            "value_hint": "<path-to-mcp-server>/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "GITHUB_PERSONAL_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cc190d52-686a-4286-812d-c4542161203d",
+    "name": "io.github.ddukbg/github-enterprise-mcp",
+    "description": "github-enterprise-mcp",
+    "repository": {
+      "url": "https://github.com/containerelic/github-enterprise-mcp",
+      "source": "github",
+      "id": "953844812"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@ddukbg/github-enterprise-mcp",
+        "version": "1.3.0",
+        "environment_variables": [
+          {
+            "description": "https://github.your-company.com/api/v3",
+            "name": "GITHUB_ENTERPRISE_URL"
+          },
+          {
+            "description": "your_github_token",
+            "name": "GITHUB_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "39d0e161-edcd-4ad5-bdc6-9c3d29908ed4",
+    "name": "io.github.longyi1207/glean-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/longyi1207/glean-mcp-server",
+      "source": "github",
+      "id": "913663339"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@modelcontextprotocol/glean",
+        "version": "0.6.2"
+      }
+    ]
+  },
+  {
+    "id": "36ad8cdb-408e-4110-827b-8d6a0a0f94bb",
+    "name": "io.github.gongrzhe/gmail-mcp-server",
+    "description": "A Model Context Protocol (MCP) server for Gmail integration in Claude Desktop with auto authentication support. This server enables AI assistants to manage Gmail through natural language interactions.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Gmail-MCP-Server",
+      "source": "github",
+      "id": "908415894"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gongrzhe/server-gmail-autoauth-mcp",
+        "version": "1.1.9"
+      }
+    ]
+  },
+  {
+    "id": "83932f7e-8c4d-475b-b03b-f30bc31793d3",
+    "name": "io.github.baryhuang/mcp-headless-gmail",
+    "description": "A MCP (Model Context Protocol) server that provides get, send Gmails without local credential or token setup.",
+    "repository": {
+      "url": "https://github.com/baryhuang/mcp-headless-gmail",
+      "source": "github",
+      "id": "951719324"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-headless-gmail",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Recipient email address",
+            "is_required": true,
+            "format": "string",
+            "value": "recipient@example.com",
+            "default": "recipient@example.com",
+            "type": "named",
+            "name": "recipient@example.com",
+            "value_hint": "recipient@example.com"
+          },
+          {
+            "description": "Email subject",
+            "is_required": true,
+            "format": "string",
+            "value": "Hello from MCP Gmail",
+            "default": "Hello from MCP Gmail",
+            "type": "named",
+            "name": "Hello from MCP Gmail",
+            "value_hint": "Hello from MCP Gmail"
+          },
+          {
+            "description": "Plain text email body",
+            "is_required": true,
+            "format": "string",
+            "value": "This is a test email sent via MCP Gmail server",
+            "default": "This is a test email sent via MCP Gmail server",
+            "type": "named",
+            "name": "This is a test email sent via MCP Gmail server",
+            "value_hint": "This is a test email sent via MCP Gmail server"
+          },
+          {
+            "description": "HTML email body",
+            "format": "string",
+            "value": "<p>This is a <strong>test email</strong> sent via MCP Gmail server</p>",
+            "default": "<p>This is a <strong>test email</strong> sent via MCP Gmail server</p>",
+            "type": "named",
+            "name": "<p>This is a <strong>test email</strong> sent via MCP Gmail server</p>",
+            "value_hint": "<p>This is a <strong>test email</strong> sent via MCP Gmail server</p>"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_access_token",
+            "name": "google_access_token"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "21242e10-3373-40a3-9119-e4d075b7c27e",
+    "name": "io.github.hichana/goalstory-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/hichana/goalstory-mcp",
+      "source": "github",
+      "id": "911416763"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "goalstory-mcp",
+        "version": "0.4.3"
+      }
+    ]
+  },
+  {
+    "id": "6e61849a-2312-4c76-a9d0-0a4b84a7795e",
+    "name": "io.github.goat-sdk/goat",
+    "description": "The leading agentic finance toolkit for AI agents",
+    "repository": {
+      "url": "https://github.com/goat-sdk/goat",
+      "source": "github",
+      "id": "894659403"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "goat-repo",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "8663db3e-ad80-4805-8032-11a3f303b5fc",
+    "name": "io.github.coding-solo/godot-mcp",
+    "description": "MCP server for interfacing with Godot game engine. Provides tools for launching the editor, running projects, and capturing debug output.",
+    "repository": {
+      "url": "https://github.com/Coding-Solo/godot-mcp",
+      "source": "github",
+      "id": "939648665"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "godot-mcp",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "true",
+            "name": "DEBUG"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "93c84b33-4392-41b2-85be-764e5f39da74",
+    "name": "io.github.mark3labs/mcp-filesystem-server",
+    "description": "Go server implementing Model Context Protocol (MCP) for filesystem operations.",
+    "repository": {
+      "url": "https://github.com/mark3labs/mcp-filesystem-server",
+      "source": "github",
+      "id": "895547074"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mark3labs/mcp-filesystem-server",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Run container image",
+            "is_required": true,
+            "format": "string",
+            "value": "ghcr.io/mark3labs/mcp-filesystem-server:latest",
+            "default": "ghcr.io/mark3labs/mcp-filesystem-server:latest",
+            "type": "positional",
+            "value_hint": "ghcr.io/mark3labs/mcp-filesystem-server:latest"
+          },
+          {
+            "description": "Allowed directory path",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/allowed/directory",
+            "default": "/path/to/allowed/directory",
+            "type": "positional",
+            "value_hint": "/path/to/allowed/directory"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "91c0fc60-7dc9-4095-a05a-9f816738df67",
+    "name": "io.github.vectorinstitute/mcp-goodnews",
+    "description": "A simple MCP application that delivers curated positive and uplifting news stories.",
+    "repository": {
+      "url": "https://github.com/VectorInstitute/mcp-goodnews",
+      "source": "github",
+      "id": "950810099"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-goodnews",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Path to the source directory",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory <absolute-path-to-cloned-repo>/mcp-goodnews/src/mcp_goodnews",
+            "default": "--directory <absolute-path-to-cloned-repo>/mcp-goodnews/src/mcp_goodnews",
+            "type": "named",
+            "name": "--directory <absolute-path-to-cloned-repo>/mcp-goodnews/src/mcp_goodnews",
+            "value_hint": "<absolute-path-to-cloned-repo>/mcp-goodnews/src/mcp_goodnews"
+          },
+          {
+            "description": "Python script to start the server",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<newsapi-api-key>",
+            "name": "NEWS_API_KEY"
+          },
+          {
+            "description": "<cohere-api-key>",
+            "name": "COHERE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "165ef95f-bfb3-4b08-b523-d17748fdfe31",
+    "name": "io.github.v-3/google-calendar",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/v-3/google-calendar",
+      "source": "github",
+      "id": "906921955"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "googlecalendar",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "6543c44a-7ad6-4f9e-bf7e-9f8f969934bf",
+    "name": "io.github.nspady/google-calendar-mcp",
+    "description": "MCP integration for Google Calendar to manage events.",
+    "repository": {
+      "url": "https://github.com/nspady/google-calendar-mcp",
+      "source": "github",
+      "id": "903584784"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:33Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "google-calendar-mcp",
+        "version": "1.1.0"
+      }
+    ]
+  },
+  {
+    "id": "d5076249-cb9d-4c5e-ae2e-544779ec1a04",
+    "name": "io.github.adenot/mcp-google-search",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/adenot/mcp-google-search",
+      "source": "github",
+      "id": "925498825"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@adenot/mcp-google-search",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "69ae0fdb-713d-4f8e-bf8e-d214e79fa295",
+    "name": "io.github.xing5/mcp-google-sheets",
+    "description": "This MCP server integrates with your Google Drive and Google Sheets, to enable creating and modifying spreadsheets.",
+    "repository": {
+      "url": "https://github.com/xing5/mcp-google-sheets",
+      "source": "github",
+      "id": "952831973"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-google-sheets",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Positional argument for script to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-google-sheets",
+            "default": "mcp-google-sheets",
+            "type": "positional",
+            "value_hint": "mcp-google-sheets"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "/full/path/to/cloned/mcp-google-sheets/service-account-key.json",
+            "name": "SERVICE_ACCOUNT_PATH"
+          },
+          {
+            "description": "your_shared_folder_id_here",
+            "name": "DRIVE_FOLDER_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b1051584-3b09-49af-a97f-a92b47861ed1",
+    "name": "io.github.rohans2/mcp-google-sheets",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/rohans2/mcp-google-sheets",
+      "source": "github",
+      "id": "975908174"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "backend",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Budget Q2",
+            "is_required": true,
+            "format": "string",
+            "value": "Budget Q2",
+            "default": "Budget Q2",
+            "type": "positional",
+            "value_hint": "Budget Q2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5486801a-8243-44ae-8d59-2e9a02c13a8e",
+    "name": "io.github.zcaceres/gtasks-mcp",
+    "description": "A Google Tasks Model Context Protocol Server for Claude",
+    "repository": {
+      "url": "https://github.com/zcaceres/gtasks-mcp",
+      "source": "github",
+      "id": "904953715"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@modelcontextprotocol/server-gtasks",
+        "version": "0.0.1"
+      }
+    ]
+  },
+  {
+    "id": "07ccf835-680a-42b4-bf0b-db28367519ee",
+    "name": "io.github.ubie-oss/mcp-vertexai-search",
+    "description": "A MCP server for Vertex AI Search",
+    "repository": {
+      "url": "https://github.com/ubie-oss/mcp-vertexai-search",
+      "source": "github",
+      "id": "934580342"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-vertexai-search",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "7461c9c2-108f-46c1-8f35-6206ec509267",
+    "name": "io.github.hannesj/mcp-graphql-schema",
+    "description": "GraphQL Schema Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/hannesj/mcp-graphql-schema",
+      "source": "github",
+      "id": "947826694"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-graphql-schema",
+        "version": "0.0.1",
+        "package_arguments": [
+          {
+            "description": "/ABSOLUTE/PATH/TO/schema.graphqls",
+            "is_required": true,
+            "format": "string",
+            "value": "/ABSOLUTE/PATH/TO/schema.graphqls",
+            "default": "/ABSOLUTE/PATH/TO/schema.graphqls",
+            "type": "positional",
+            "value_hint": "/ABSOLUTE/PATH/TO/schema.graphqls"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0f4331b9-9229-49c4-b41c-5c254b610daa",
+    "name": "io.github.horizondatawave/hdw-mcp-server",
+    "description": "A Model Context Protocol (MCP) server that provides comprehensive access to LinkedIn data and functionalities using the HorizonDataWave API, enabling not only data retrieval but also robust management of user accounts.",
+    "repository": {
+      "url": "https://github.com/horizondatawave/hdw-mcp-server",
+      "source": "github",
+      "id": "947522686"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@horizondatawave/mcp",
+        "version": "0.1.3",
+        "environment_variables": [
+          {
+            "description": "YOUR_HD_W_ACCESS_TOKEN",
+            "name": "HDW_ACCESS_TOKEN"
+          },
+          {
+            "description": "YOUR_HD_W_ACCOUNT_ID",
+            "name": "HDW_ACCOUNT_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "97174daf-db12-40ac-bab2-1c4255ce1741",
+    "name": "io.github.heurist-network/heurist-mesh-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/heurist-network/heurist-mesh-mcp-server",
+      "source": "github",
+      "id": "948277357"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mesh-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "27c761f6-dc25-4c35-9912-2dc2bbdeaadd",
+    "name": "io.github.heurist-network/heurist-agent-framework",
+    "description": "A flexible multi-interface AI agent framework for building agents with reasoning, tool use, memory, deep research, blockchain interaction, MCP, and agents-as-a-service.",
+    "repository": {
+      "url": "https://github.com/heurist-network/heurist-agent-framework",
+      "source": "github",
+      "id": "897068154"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "heurist-agent-framework",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fffcda50-ddc1-4357-a9bf-b7022f86c582",
+    "name": "io.github.syucream/holaspirit-mcp-server",
+    "description": "A MCP server that accesses to Holaspirit",
+    "repository": {
+      "url": "https://github.com/syucream/holaspirit-mcp-server",
+      "source": "github",
+      "id": "915876793"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "holaspirit-mcp-server",
+        "version": "0.2.0",
+        "environment_variables": [
+          {
+            "description": "<your token>",
+            "name": "HOLASPIRIT_API_TOKEN"
+          },
+          {
+            "description": "<your org id>",
+            "name": "HOLASPIRIT_ORGANIZATION_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b87405fe-1aae-4a7a-a4d7-cd0b5f267ad8",
+    "name": "io.github.tevonsb/homeassistant-mcp",
+    "description": "A MCP server for Home Assistant",
+    "repository": {
+      "url": "https://github.com/tevonsb/homeassistant-mcp",
+      "source": "github",
+      "id": "902220777"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:07:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "homeassistant-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "67c71178-8632-4d67-abad-c28f6e58c87f",
+    "name": "io.github.voska/hass-mcp",
+    "description": "Home Assistant MCP Server",
+    "repository": {
+      "url": "https://github.com/voska/hass-mcp",
+      "source": "github",
+      "id": "949564493"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "hass-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "-e HA_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e HA_URL",
+            "default": "-e HA_URL",
+            "type": "named",
+            "name": "-e HA_URL",
+            "value_hint": "HA_URL"
+          },
+          {
+            "description": "-e HA_TOKEN",
+            "is_required": true,
+            "format": "string",
+            "value": "-e HA_TOKEN",
+            "default": "-e HA_TOKEN",
+            "type": "named",
+            "name": "-e HA_TOKEN",
+            "value_hint": "HA_TOKEN"
+          },
+          {
+            "description": "voska/hass-mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "voska/hass-mcp",
+            "default": "voska/hass-mcp",
+            "type": "positional",
+            "value_hint": "voska/hass-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://homeassistant.local:8123",
+            "name": "HA_URL"
+          },
+          {
+            "description": "YOUR_LONG_LIVED_TOKEN",
+            "name": "HA_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "aef75131-e237-4b91-a2b8-c0f416d3618f",
+    "name": "io.github.buryhuang/mcp-hubspot",
+    "description": "A Model Context Protocol (MCP) server that enables AI assistants to interact with HubSpot CRM data, providing built-in vector storage and caching mechanisms help overcome HubSpot API limitations while improving response times.",
+    "repository": {
+      "url": "https://github.com/peakmojo/mcp-hubspot",
+      "source": "github",
+      "id": "908899631"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-server-hubspot",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "Attach stdin even if not attached",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "Remove container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Set HUBSPOT_ACCESS_TOKEN environment variable in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e HUBSPOT_ACCESS_TOKEN=your_token",
+            "default": "-e HUBSPOT_ACCESS_TOKEN=your_token",
+            "type": "named",
+            "name": "-e HUBSPOT_ACCESS_TOKEN=your_token",
+            "value_hint": "HUBSPOT_ACCESS_TOKEN=your_token"
+          },
+          {
+            "description": "Optional persistent storage for state files",
+            "format": "string",
+            "value": "-v /path/to/storage:/storage",
+            "default": "-v /path/to/storage:/storage",
+            "type": "named",
+            "name": "-v /path/to/storage:/storage",
+            "value_hint": "/path/to/storage:/storage"
+          },
+          {
+            "description": "Docker image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "buryhuang/mcp-hubspot:latest",
+            "default": "buryhuang/mcp-hubspot:latest",
+            "type": "positional",
+            "value_hint": "buryhuang/mcp-hubspot:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "532d7690-7a65-470f-81da-2ba3042bee05",
+    "name": "io.github.evalstate/mcp-hfspace",
+    "description": "MCP Server to Use HuggingFace spaces, easy configuration and Claude Desktop mode. ",
+    "repository": {
+      "url": "https://github.com/evalstate/mcp-hfspace",
+      "source": "github",
+      "id": "898049335"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@llmindset/mcp-hfspace",
+        "version": "0.5.4",
+        "package_arguments": [
+          {
+            "description": "--work-dir=~/mcp-files/ or x:/temp/mcp-files/",
+            "is_required": true,
+            "format": "string",
+            "value": "--work-dir=~/mcp-files/ or x:/temp/mcp-files/",
+            "default": "--work-dir=~/mcp-files/ or x:/temp/mcp-files/",
+            "type": "named",
+            "name": "--work-dir=~/mcp-files/ or x:/temp/mcp-files/",
+            "value_hint": "~/mcp-files/ or x:/temp/mcp-files/"
+          },
+          {
+            "description": "--HF_TOKEN=HF_{optional token}",
+            "is_required": true,
+            "format": "string",
+            "value": "--HF_TOKEN=HF_{optional token}",
+            "default": "--HF_TOKEN=HF_{optional token}",
+            "type": "named",
+            "name": "--HF_TOKEN=HF_{optional token}",
+            "value_hint": "HF_{optional token}"
+          },
+          {
+            "description": "Qwen/Qwen2-72B-Instruct",
+            "is_required": true,
+            "format": "string",
+            "value": "Qwen/Qwen2-72B-Instruct",
+            "default": "Qwen/Qwen2-72B-Instruct",
+            "type": "positional",
+            "value_hint": "Qwen/Qwen2-72B-Instruct"
+          },
+          {
+            "description": "black-forest-labs/FLUX.1-schnell",
+            "is_required": true,
+            "format": "string",
+            "value": "black-forest-labs/FLUX.1-schnell",
+            "default": "black-forest-labs/FLUX.1-schnell",
+            "type": "positional",
+            "value_hint": "black-forest-labs/FLUX.1-schnell"
+          },
+          {
+            "description": "space/example/specific-endpint",
+            "is_required": true,
+            "format": "string",
+            "value": "space/example/specific-endpint",
+            "default": "space/example/specific-endpint",
+            "type": "positional",
+            "value_hint": "space/example/specific-endpint"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0d57edf7-3fbb-42b4-aa9e-b255e7d6f8fa",
+    "name": "io.github.mektigboy/server-hyperliquid",
+    "description": "MCP Hyperliquid (https://app.hyperliquid.xyz) server",
+    "repository": {
+      "url": "https://github.com/mektigboy/server-hyperliquid",
+      "source": "github",
+      "id": "943734921"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@mektigboy/server-hyperliquid",
+        "version": "0.0.1"
+      }
+    ]
+  },
+  {
+    "id": "b51467a7-698f-4a33-9598-db5aaf4e07b3",
+    "name": "io.github.stefanoamorelli/hyprmcp",
+    "description": "Community MCP server for hyprctl",
+    "repository": {
+      "url": "https://github.com/stefanoamorelli/hyprmcp",
+      "source": "github",
+      "id": "973785828"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "stefanoamorelli/hyprmcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "--with mcp[cli]",
+            "is_required": true,
+            "format": "string",
+            "value": "--with mcp[cli]",
+            "default": "--with mcp[cli]",
+            "type": "named",
+            "name": "--with mcp[cli]",
+            "value_hint": "mcp[cli]"
+          },
+          {
+            "description": "--with subprocess",
+            "is_required": true,
+            "format": "string",
+            "value": "--with subprocess",
+            "default": "--with subprocess",
+            "type": "named",
+            "name": "--with subprocess",
+            "value_hint": "subprocess"
+          },
+          {
+            "description": "mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          },
+          {
+            "description": "<global path of the repo>/hyprmcp/hyprmcp/server.py",
+            "is_required": true,
+            "format": "string",
+            "value": "<global path of the repo>/hyprmcp/hyprmcp/server.py",
+            "default": "<global path of the repo>/hyprmcp/hyprmcp/server.py",
+            "type": "positional",
+            "value_hint": "<global path of the repo>/hyprmcp/hyprmcp/server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<global path of the repo>/hyprmcp",
+            "name": "PYTHONPATH"
+          },
+          {
+            "description": "<your-hyprland-instance-signature>",
+            "name": "HYPRLAND_INSTANCE_SIGNATURE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6a9b532e-61df-4d4d-a898-25d66aa60315",
+    "name": "io.github.iflytek/ifly-workflow-mcp-server",
+    "description": "This a simple implementation of an MCP server using iFlytek. It enables calling iFlytek workflows through MCP tools.",
+    "repository": {
+      "url": "https://github.com/iflytek/ifly-workflow-mcp-server",
+      "source": "github",
+      "id": "953998052"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ifly-workflow-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "--from git+https://github.com/iflytek/ifly-workflow-mcp-server",
+            "is_required": true,
+            "format": "string",
+            "value": "--from git+https://github.com/iflytek/ifly-workflow-mcp-server",
+            "default": "--from git+https://github.com/iflytek/ifly-workflow-mcp-server",
+            "type": "named",
+            "name": "--from git+https://github.com/iflytek/ifly-workflow-mcp-server",
+            "value_hint": "git+https://github.com/iflytek/ifly-workflow-mcp-server"
+          },
+          {
+            "description": "ifly_workflow_mcp_server",
+            "is_required": true,
+            "format": "string",
+            "value": "ifly_workflow_mcp_server",
+            "default": "ifly_workflow_mcp_server",
+            "type": "positional",
+            "value_hint": "ifly_workflow_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "/Users/hygao1024/Projects/config.yaml",
+            "name": "CONFIG_PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5bf6d045-dc83-4b51-858f-eb9c3403087f",
+    "name": "io.github.gongrzhe/image-generation-mcp-server",
+    "description": "This MCP server provides image generation capabilities using the Replicate Flux model.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Image-Generation-MCP-Server",
+      "source": "github",
+      "id": "937552153"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gongrzhe/image-gen-server",
+        "version": "1.0.1",
+        "environment_variables": [
+          {
+            "description": "your-replicate-api-token",
+            "name": "REPLICATE_API_TOKEN"
+          },
+          {
+            "description": "alternative-model-name",
+            "name": "MODEL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d78df157-559d-4e87-af1f-0dcbfe703a23",
+    "name": "io.github.idoru/influxdb-mcp-server",
+    "description": "An MCP Server for querying InfluxDB",
+    "repository": {
+      "url": "https://github.com/idoru/influxdb-mcp-server",
+      "source": "github",
+      "id": "946415795"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "influxdb-mcp-server",
+        "version": "0.1.1",
+        "environment_variables": [
+          {
+            "description": "your_token",
+            "name": "INFLUXDB_TOKEN"
+          },
+          {
+            "description": "http://localhost:8086",
+            "name": "INFLUXDB_URL"
+          },
+          {
+            "description": "your_org",
+            "name": "INFLUXDB_ORG"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "601ee7e9-e0db-470e-80e5-f1509cddf6d7",
+    "name": "io.github.sergehuber/inoyu-mcp-unomi-server",
+    "description": "An implementation of Anthropic's Model Context Protocol for the Apache Unomi CDP",
+    "repository": {
+      "url": "https://github.com/sergehuber/inoyu-mcp-unomi-server",
+      "source": "github",
+      "id": "896936323"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:26Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@inoyu/mcp-unomi-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "1967f4e6-f229-4d5f-a648-9bdc67d39da8",
+    "name": "io.github.raoulbia-ai/mcp-server-for-intercom",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/raoulbia-ai/mcp-server-for-intercom",
+      "source": "github",
+      "id": "945565923"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-for-intercom",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your_intercom_api_token",
+            "name": "INTERCOM_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b9fa6e10-c6f4-424d-b289-469d49decaaf",
+    "name": "io.github.inditextech/mcp-server-simulator-ios-idb",
+    "description": "A Model Context Protocol (MCP) server that enables LLMs to interact with iOS simulators through natural language commands.",
+    "repository": {
+      "url": "https://github.com/InditexTech/mcp-server-simulator-ios-idb",
+      "source": "github",
+      "id": "950568971"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-simulator-ios-idb",
+        "version": "1.0.1"
+      }
+    ]
+  },
+  {
+    "id": "dcac9b0e-b18c-4570-947c-7a6d351b02df",
+    "name": "io.github.ferrislucas/iterm-mcp",
+    "description": "A Model Context Protocol server that executes commands in the current iTerm session - useful for REPL and CLI assistance",
+    "repository": {
+      "url": "https://github.com/ferrislucas/iterm-mcp",
+      "source": "github",
+      "id": "914173426"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "iterm-mcp",
+        "version": "1.2.5"
+      }
+    ]
+  },
+  {
+    "id": "add3f73d-394b-4b99-b255-8d9d89db84c2",
+    "name": "io.github.rishabkoul/iterm-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/rishabkoul/iTerm-MCP-Server",
+      "source": "github",
+      "id": "953500133"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "iterm_mcp_server",
+        "version": "1.0.4"
+      }
+    ]
+  },
+  {
+    "id": "24044cb1-3333-400d-966b-3394d9f39261",
+    "name": "io.github.quarkiverse/quarkus-mcp-servers",
+    "description": "Model Context Protocol Servers in Quarkus",
+    "repository": {
+      "url": "https://github.com/quarkiverse/quarkus-mcp-servers",
+      "source": "github",
+      "id": "920668324"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "quarkiverse/quarkus-mcp-servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "d0f30dc9-bc11-43f8-9b61-034e2bec78d5",
+    "name": "io.github.qainsights/jmeter-mcp-server",
+    "description": "✨ JMeter Meets AI Workflows: Introducing the JMeter MCP Server! 🤯 ",
+    "repository": {
+      "url": "https://github.com/QAInsights/jmeter-mcp-server",
+      "source": "github",
+      "id": "956608147"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "jmeter-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "jmeter_server.py",
+            "default": "jmeter_server.py",
+            "type": "positional",
+            "value_hint": "jmeter_server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7e73a81a-e914-4cf7-aff2-482d0047e8dd",
+    "name": "io.github.gongrzhe/json-mcp-server",
+    "description": "JSON handling and processing mcp server",
+    "repository": {
+      "url": "https://github.com/GongRzhe/JSON-MCP-Server",
+      "source": "github",
+      "id": "907849216"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gongrzhe/server-json-mcp",
+        "version": "1.0.3"
+      }
+    ]
+  },
+  {
+    "id": "243a8c0e-4bb7-4932-9d7c-8e8229306295",
+    "name": "io.github.kukapay/jupiter-mcp",
+    "description": "An MCP server for executing token swaps on the Solana blockchain using Jupiter's new Ultra API.",
+    "repository": {
+      "url": "https://github.com/kukapay/jupiter-mcp",
+      "source": "github",
+      "id": "952976727"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "jupiter-mcp",
+        "version": "1.0.1",
+        "package_arguments": [
+          {
+            "description": "Jupiter MCP server entry file",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/jupiter-mcp/server/index.js",
+            "default": "path/to/jupiter-mcp/server/index.js",
+            "type": "positional",
+            "value_hint": "path/to/jupiter-mcp/server/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "solana rpc url you can access",
+            "name": "SOLANA_RPC_URL"
+          },
+          {
+            "description": "your private key",
+            "name": "PRIVATE_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "87c3876b-995b-4838-901b-062cdfb884c7",
+    "name": "io.github.razvanmacovei/k8s-multicluster-mcp",
+    "description": "An MCP (Model Context Protocol) server application for Kubernetes operations, providing a standardized API to interact with multiple Kubernetes clusters simultaneously using multiple kubeconfig files.",
+    "repository": {
+      "url": "https://github.com/razvanmacovei/k8s-multicluster-mcp",
+      "source": "github",
+      "id": "979253683"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "razvanmacovei/k8s-multicluster-mcp",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "/path/to/your/kubeconfigs",
+            "name": "KUBECONFIG_DIR"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e80eb5ed-497b-4bcf-8cc3-f7f2c5eed889",
+    "name": "io.github.lamaalrajih/kicad-mcp",
+    "description": "Model Context Protocol server for KiCad on Mac, Windows, and Linux",
+    "repository": {
+      "url": "https://github.com/lamaalrajih/kicad-mcp",
+      "source": "github",
+      "id": "951687178"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "lamaalrajih/kicad-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "ac8e4d2b-da97-4a40-934b-1c516b4250fe",
+    "name": "io.github.christophenglisch/keycloak-model-context-protocol",
+    "description": "MCP server implementation for Keycloak user management. Enables AI-powered administration of Keycloak users and realms through the Model Context Protocol (MCP). Seamlessly integrates with Claude Desktop and other MCP clients for automated user operations.",
+    "repository": {
+      "url": "https://github.com/ChristophEnglisch/keycloak-model-context-protocol",
+      "source": "github",
+      "id": "912825504"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "keycloak-model-context-protocol",
+        "version": "0.0.2",
+        "package_arguments": [
+          {
+            "description": "Second positional argument to the command",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/dist/index.js",
+            "default": "path/to/dist/index.js",
+            "type": "positional",
+            "value_hint": "path/to/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://localhost:8080",
+            "name": "KEYCLOAK_URL"
+          },
+          {
+            "description": "admin",
+            "name": "KEYCLOAK_ADMIN"
+          },
+          {
+            "description": "admin",
+            "name": "KEYCLOAK_ADMIN_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "984ee65a-dec0-4a75-b21b-2efbcd9600bd",
+    "name": "io.github.kiwamizamurai/mcp-kibela-server",
+    "description": "MCP server implementation for Kibela API integration",
+    "repository": {
+      "url": "https://github.com/kiwamizamurai/mcp-kibela-server",
+      "source": "github",
+      "id": "925867194"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@kiwamizamurai/mcp-kibela-server",
+        "version": "1.1.0",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "-e KIBELA_TEAM",
+            "is_required": true,
+            "format": "string",
+            "value": "-e KIBELA_TEAM",
+            "default": "-e KIBELA_TEAM",
+            "type": "named",
+            "name": "-e KIBELA_TEAM",
+            "value_hint": "KIBELA_TEAM"
+          },
+          {
+            "description": "-e KIBELA_TOKEN",
+            "is_required": true,
+            "format": "string",
+            "value": "-e KIBELA_TOKEN",
+            "default": "-e KIBELA_TOKEN",
+            "type": "named",
+            "name": "-e KIBELA_TOKEN",
+            "value_hint": "KIBELA_TOKEN"
+          },
+          {
+            "description": "mcp-kibela-server",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-kibela-server",
+            "default": "mcp-kibela-server",
+            "type": "positional"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_TEAM_NAME",
+            "name": "KIBELA_TEAM"
+          },
+          {
+            "description": "YOUR_TOKEN",
+            "name": "KIBELA_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "554f9f4e-2cd3-4a48-90e4-3c0351603f26",
+    "name": "io.github.macrat/mcp-server-kintone",
+    "description": "MCP server for kintone",
+    "repository": {
+      "url": "https://github.com/macrat/mcp-server-kintone",
+      "source": "github",
+      "id": "905159302"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "macrat/mcp-server-kintone",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "https://<domain>.cybozu.com",
+            "name": "KINTONE_BASE_URL"
+          },
+          {
+            "description": "<your username>",
+            "name": "KINTONE_USERNAME"
+          },
+          {
+            "description": "<your password>",
+            "name": "KINTONE_PASSWORD"
+          },
+          {
+            "description": "<your api token>, <another api token>, ...",
+            "name": "KINTONE_API_TOKEN"
+          },
+          {
+            "description": "1, 2, 3, ...",
+            "name": "KINTONE_ALLOW_APPS"
+          },
+          {
+            "description": "4, 5, ...",
+            "name": "KINTONE_DENY_APPS"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "86a12728-3ab9-4a69-a447-bcb67957a5f7",
+    "name": "io.github.kong/mcp-konnect",
+    "description": "A Model Context Protocol (MCP) server for interacting with Kong Konnect APIs, allowing AI assistants to query and analyze Kong Gateway configurations, traffic, and analytics.",
+    "repository": {
+      "url": "https://github.com/Kong/mcp-konnect",
+      "source": "github",
+      "id": "944084760"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:08:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "kong-konnect-mcp",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "kpat_api_key_here",
+            "name": "KONNECT_ACCESS_TOKEN"
+          },
+          {
+            "description": "us",
+            "name": "KONNECT_REGION"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6a4d324e-7d12-495c-b72c-fe5803363af1",
+    "name": "io.github.flux159/mcp-server-kubernetes",
+    "description": "MCP Server for kubernetes management commands",
+    "repository": {
+      "url": "https://github.com/Flux159/mcp-server-kubernetes",
+      "source": "github",
+      "id": "900130551"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-kubernetes",
+        "version": "1.6.2"
+      }
+    ]
+  },
+  {
+    "id": "4a097d31-ea39-43aa-9af5-6f19a7676901",
+    "name": "io.github.manusa/kubernetes-mcp-server",
+    "description": "Model Context Protocol (MCP) server for Kubernetes and OpenShift",
+    "repository": {
+      "url": "https://github.com/manusa/kubernetes-mcp-server",
+      "source": "github",
+      "id": "930678258"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "manusa/kubernetes-mcp-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "3c265bda-03e4-4e46-bceb-437a1b02f431",
+    "name": "io.github.gongrzhe/langflow-doc-qa-server",
+    "description": "A Model Context Protocol server for document Q&A powered by Langflow . It demonstrates core MCP concepts by providing a simple interface to query documents through a Langflow backend.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Langflow-DOC-QA-SERVER",
+      "source": "github",
+      "id": "937522079"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "doc-qa-server",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "http://127.0.0.1:7860/api/v1/run/480ec7b3-29d2-4caa-b03b-e74118f35fac",
+            "name": "API_ENDPOINT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "39843dbb-856d-46d9-92c4-74b5041c4444",
+    "name": "io.github.kone-net/mcp_server_lark",
+    "description": "A Model Context Protocol server for Lark(Feishu) sheet, message, doc and etc.",
+    "repository": {
+      "url": "https://github.com/kone-net/mcp_server_lark",
+      "source": "github",
+      "id": "955286262"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-lark",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "17c2c7f2-20f2-424f-8466-b164ed19ddef",
+    "name": "io.github.syucream/lightdash-mcp-server",
+    "description": "A MCP(Model Context Protocol) server that accesses to Lightdash",
+    "repository": {
+      "url": "https://github.com/syucream/lightdash-mcp-server",
+      "source": "github",
+      "id": "910751536"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "lightdash-mcp-server",
+        "version": "0.0.11",
+        "environment_variables": [
+          {
+            "description": "<your PAT>",
+            "name": "LIGHTDASH_API_KEY"
+          },
+          {
+            "description": "https://<your base url>",
+            "name": "LIGHTDASH_API_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "32f876df-1f34-40d7-aed8-0431b32d5091",
+    "name": "io.github.tritlo/lsp-mcp",
+    "description": "An MCP server that lets you interact with LSP servers",
+    "repository": {
+      "url": "https://github.com/Tritlo/lsp-mcp",
+      "source": "github",
+      "id": "952869992"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "lsp-mcp-server",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "debug",
+            "is_required": true,
+            "format": "string",
+            "value": "debug",
+            "default": "debug",
+            "type": "named",
+            "name": "debug",
+            "value_hint": "debug"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a4a1013a-5789-4020-9a16-eda6c453aba7",
+    "name": "io.github.tacticlaunch/mcp-linear",
+    "description": "MCP server that enables AI assistants to interact with Linear project management system through natural language, allowing users to retrieve, create, and update issues, projects, and teams.",
+    "repository": {
+      "url": "https://github.com/tacticlaunch/mcp-linear",
+      "source": "github",
+      "id": "953530564"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@tacticlaunch/mcp-linear",
+        "version": "1.0.9",
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "LINEAR_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a0e6ce8a-15eb-4776-b9de-a4bb3c7e4730",
+    "name": "io.github.jerhadf/linear-mcp-server",
+    "description": "A server that integrates Linear's project management system with the Model Context Protocol (MCP) to allow LLMs to interact with Linear.",
+    "repository": {
+      "url": "https://github.com/jerhadf/linear-mcp-server",
+      "source": "github",
+      "id": "898106797"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "linear-mcp-server",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your_linear_api_key_here",
+            "name": "LINEAR_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0c8e4aae-53ed-4acf-87d9-19d44ac4afd1",
+    "name": "io.github.geropl/linear-mcp-go",
+    "description": "linear MCP server based on mcp-go",
+    "repository": {
+      "url": "https://github.com/geropl/linear-mcp-go",
+      "source": "github",
+      "id": "940084523"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "geropl/linear-mcp-go",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "3791bb07-364f-431c-acf4-331007c52571",
+    "name": "io.github.amornpan/py-mcp-line",
+    "description": "python mcp LINE",
+    "repository": {
+      "url": "https://github.com/amornpan/py-mcp-line",
+      "source": "github",
+      "id": "940071130"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:21Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "amornpan/py-mcp-line",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "your_channel_secret",
+            "name": "LINE_CHANNEL_SECRET"
+          },
+          {
+            "description": "your_access_token",
+            "name": "LINE_ACCESS_TOKEN"
+          },
+          {
+            "description": "8000",
+            "name": "SERVER_PORT"
+          },
+          {
+            "description": "data/messages.json",
+            "name": "MESSAGES_FILE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6cfb4c39-82bb-4b43-94a5-1f50ebd10c71",
+    "name": "io.github.run-llama/mcp-server-llamacloud",
+    "description": "A MCP server connecting to managed indexes on LlamaCloud",
+    "repository": {
+      "url": "https://github.com/run-llama/mcp-server-llamacloud",
+      "source": "github",
+      "id": "898328533"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@llamaindex/mcp-server-llamacloud",
+        "version": "0.1.2",
+        "package_arguments": [
+          {
+            "description": "Index to be used (first occurrence)",
+            "is_required": true,
+            "format": "string",
+            "value": "--index 10k-SEC-Tesla",
+            "default": "--index 10k-SEC-Tesla",
+            "type": "named",
+            "name": "--index 10k-SEC-Tesla",
+            "value_hint": "10k-SEC-Tesla"
+          },
+          {
+            "description": "Description for index (first occurrence)",
+            "is_required": true,
+            "format": "string",
+            "value": "--description 10k SEC documents from 2023 for Tesla",
+            "default": "--description 10k SEC documents from 2023 for Tesla",
+            "type": "named",
+            "name": "--description 10k SEC documents from 2023 for Tesla",
+            "value_hint": "10k SEC documents from 2023 for Tesla"
+          },
+          {
+            "description": "Index to be used (second occurrence)",
+            "is_required": true,
+            "format": "string",
+            "value": "--index 10k-SEC-Apple",
+            "default": "--index 10k-SEC-Apple",
+            "type": "named",
+            "name": "--index 10k-SEC-Apple",
+            "value_hint": "10k-SEC-Apple"
+          },
+          {
+            "description": "Description for index (second occurrence)",
+            "is_required": true,
+            "format": "string",
+            "value": "--description 10k SEC documents from 2023 for Apple",
+            "default": "--description 10k SEC documents from 2023 for Apple",
+            "type": "named",
+            "name": "--description 10k SEC documents from 2023 for Apple",
+            "value_hint": "10k SEC documents from 2023 for Apple"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_PROJECT_NAME>",
+            "name": "LLAMA_CLOUD_PROJECT_NAME"
+          },
+          {
+            "description": "<YOUR_API_KEY>",
+            "name": "LLAMA_CLOUD_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1fa71606-a2ca-47f1-b249-91031917ca41",
+    "name": "io.github.stass/lldb-mcp",
+    "description": "LLDB MCP server",
+    "repository": {
+      "url": "https://github.com/stass/lldb-mcp",
+      "source": "github",
+      "id": "955087112"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "stass/lldb-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "b9f04c6e-0d22-4f17-af83-ccde8b03e4e8",
+    "name": "io.github.cyberchitta/llm-context.py",
+    "description": "Share code with LLMs via Model Context Protocol or clipboard. Rule-based customization enables easy switching between different tasks (like code review and documentation). Includes smart code outlining.",
+    "repository": {
+      "url": "https://github.com/cyberchitta/llm-context.py",
+      "source": "github",
+      "id": "789457378"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "llm-context",
+        "version": "0.3.2",
+        "package_arguments": [
+          {
+            "description": "Named argument --from with value llm-context",
+            "is_required": true,
+            "format": "string",
+            "value": "--from llm-context",
+            "default": "--from llm-context",
+            "type": "named",
+            "name": "--from llm-context",
+            "value_hint": "llm-context"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5446ebef-4e06-494b-a50f-3b02ff493274",
+    "name": "io.github.vivekkumarneu/mcp-lucene-server",
+    "description": "MCP Lucene Server",
+    "repository": {
+      "url": "https://github.com/VivekKumarNeu/MCP-Lucene-Server",
+      "source": "github",
+      "id": "969059271"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "VivekKumarNeu/MCP-Lucene-Server",
+        "version": "",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "doc2",
+            "default": "doc2",
+            "type": "positional",
+            "value_hint": "doc2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e7e51609-0d23-4d96-8063-d136bd993c93",
+    "name": "io.github.carterlasalle/mac_messages_mcp",
+    "description": "An MCP server that securely interfaces with your iMessage database via the Model Context Protocol (MCP), allowing LLMs to query and analyze iMessage conversations. It includes robust phone number validation, attachment processing, contact management, group chat handling, and full support for sending and receiving messages.",
+    "repository": {
+      "url": "https://github.com/carterlasalle/mac_messages_mcp",
+      "source": "github",
+      "id": "947677712"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mac-messages-mcp",
+        "version": "0.6.6"
+      }
+    ]
+  },
+  {
+    "id": "b8bb0138-d147-4982-85b0-dedbd2e004a5",
+    "name": "io.github.mytechnotalent/malwarebazaar_mcp",
+    "description": "An AI-driven MCP server that autonomously interfaces with Malware Bazaar, delivering real-time threat intel and sample metadata for authorized cybersecurity research workflows.",
+    "repository": {
+      "url": "https://github.com/mytechnotalent/MalwareBazaar_MCP",
+      "source": "github",
+      "id": "965127478"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mytechnotalent/MalwareBazaar_MCP",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "8197c60c-08c6-4d90-9d63-e64bf48ab6e4",
+    "name": "io.github.abel9851/mcp-server-mariadb",
+    "description": "An mcp server that provides read-only access to MariaDB.",
+    "repository": {
+      "url": "https://github.com/abel9851/mcp-server-mariadb",
+      "source": "github",
+      "id": "934896960"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-mariadb",
+        "version": "0.1.2",
+        "package_arguments": [
+          {
+            "description": "--directory /YOUR/SOURCE/PATH/mcp-server-mariadb/src/mcp_server_mariadb",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /YOUR/SOURCE/PATH/mcp-server-mariadb/src/mcp_server_mariadb",
+            "default": "--directory /YOUR/SOURCE/PATH/mcp-server-mariadb/src/mcp_server_mariadb",
+            "type": "named",
+            "name": "--directory /YOUR/SOURCE/PATH/mcp-server-mariadb/src/mcp_server_mariadb",
+            "value_hint": "/YOUR/SOURCE/PATH/mcp-server-mariadb/src/mcp_server_mariadb"
+          },
+          {
+            "description": "server.py",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "127.0.0.1",
+            "name": "MARIADB_HOST"
+          },
+          {
+            "description": "USER",
+            "name": "MARIADB_USER"
+          },
+          {
+            "description": "PASSWORD",
+            "name": "MARIADB_PASSWORD"
+          },
+          {
+            "description": "DATABASE",
+            "name": "MARIADB_DATABASE"
+          },
+          {
+            "description": "3306",
+            "name": "MARIADB_PORT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a7cfde04-fae7-4b2c-bcef-c752525a057e",
+    "name": "io.github.maton-ai/agent-toolkit",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/maton-ai/agent-toolkit",
+      "source": "github",
+      "id": "950334178"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "maton-ai/agent-toolkit",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "e4578522-e426-44f4-818c-68784f2a3038",
+    "name": "io.github.liuyoshio/mcp-compass",
+    "description": "MCP Discovery & Recommendation Service - Find the right MCP server for your needs",
+    "repository": {
+      "url": "https://github.com/liuyoshio/mcp-compass",
+      "source": "github",
+      "id": "908868990"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@liuyoshio/mcp-compass",
+        "version": "1.0.7"
+      }
+    ]
+  },
+  {
+    "id": "84bda3c9-65ce-45f2-898f-6e370718b43d",
+    "name": "io.github.tesla0225/mcp-create",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/tesla0225/mcp-create",
+      "source": "github",
+      "id": "945265954"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-create",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "9f5885d3-fe18-483d-b7b2-f507b2f37ccb",
+    "name": "io.github.anaisbetts/mcp-installer",
+    "description": "An MCP server that installs other MCP servers for you",
+    "repository": {
+      "url": "https://github.com/anaisbetts/mcp-installer",
+      "source": "github",
+      "id": "894640711"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@anaisbetts/mcp-installer",
+        "version": "0.5.0"
+      }
+    ]
+  },
+  {
+    "id": "a59a162f-d811-4344-bf53-606a74bb50c6",
+    "name": "io.github.strowk/mcp-k8s-go",
+    "description": "MCP server connecting to Kubernetes",
+    "repository": {
+      "url": "https://github.com/strowk/mcp-k8s-go",
+      "source": "github",
+      "id": "896738164"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "strowk/mcp-k8s-go",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Mounts ~/.kube/config into container",
+            "is_required": true,
+            "format": "string",
+            "value": "-v ~/.kube/config:/home/nonroot/.kube/config",
+            "default": "-v ~/.kube/config:/home/nonroot/.kube/config",
+            "type": "named",
+            "name": "-v ~/.kube/config:/home/nonroot/.kube/config",
+            "value_hint": "~/.kube/config:/home/nonroot/.kube/config"
+          },
+          {
+            "description": "Removes container after exit",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Docker image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mcpk8s/server:latest",
+            "default": "mcpk8s/server:latest",
+            "type": "positional",
+            "value_hint": "mcpk8s/server:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "93be69a3-6dbf-4e3c-aa47-a4d5a15f0588",
+    "name": "io.github.nkapila6/mcp-local-rag",
+    "description": "\"primitive\" RAG-like web search model context protocol (MCP) server that runs locally. ✨ no APIs ✨",
+    "repository": {
+      "url": "https://github.com/nkapila6/mcp-local-rag",
+      "source": "github",
+      "id": "947802631"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-local-rag",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "A named argument for directory.",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory <path where this folder is located>/mcp-local-rag/",
+            "default": "--directory <path where this folder is located>/mcp-local-rag/",
+            "type": "named",
+            "name": "--directory <path where this folder is located>/mcp-local-rag/",
+            "value_hint": "<path where this folder is located>/mcp-local-rag/"
+          },
+          {
+            "description": "A positional argument for the Python script.",
+            "is_required": true,
+            "format": "string",
+            "value": "src/mcp_local_rag/main.py",
+            "default": "src/mcp_local_rag/main.py",
+            "type": "positional",
+            "value_hint": "src/mcp_local_rag/main.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5b01e888-7245-46a6-8747-d6f9ca374c43",
+    "name": "io.github.sparfenyuk/mcp-proxy",
+    "description": "A bridge between Streamable HTTP and stdio MCP transports",
+    "repository": {
+      "url": "https://github.com/sparfenyuk/mcp-proxy",
+      "source": "github",
+      "id": "908734690"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:56Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-proxy",
+        "version": "0.6.0"
+      }
+    ]
+  },
+  {
+    "id": "9ad8f293-3ea1-4f0d-8c9f-a24945851bb6",
+    "name": "io.github.tbxark/mcp-proxy",
+    "description": "An MCP proxy server that aggregates and serves multiple MCP resource servers through a single HTTP server.",
+    "repository": {
+      "url": "https://github.com/TBXark/mcp-proxy",
+      "source": "github",
+      "id": "955698123"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:09:58Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "TBXark/mcp-proxy",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "GITHUB_PERSONAL_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "https://mcp.amap.com/sse?key=<YOUR_TOKEN>"
+      }
+    ]
+  },
+  {
+    "id": "3ec2249d-2ed3-45d2-8b52-185abfa918ac",
+    "name": "io.github.lciesielski/mcp-salesforce-example",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/lciesielski/mcp-salesforce-example",
+      "source": "github",
+      "id": "957204688"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-salesforce",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "4f189cdd-04a5-47f6-b87b-7d38cc82e625",
+    "name": "io.github.mem0ai/mem0-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/mem0ai/mem0-mcp",
+      "source": "github",
+      "id": "934683195"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mem0-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "819f0338-1101-475c-9915-65a8727a8dc5",
+    "name": "io.github.unibaseio/membase-mcp",
+    "description": "A lightweight, decentralized memory server for AI agents to store and retrieve conversations via the Unibase memory layer.",
+    "repository": {
+      "url": "https://github.com/unibaseio/membase-mcp",
+      "source": "github",
+      "id": "957747274"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "membase-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Specifies the directory to use",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/membase-mcp",
+            "default": "--directory path/to/membase-mcp",
+            "type": "named",
+            "name": "--directory path/to/membase-mcp",
+            "value_hint": "path/to/membase-mcp"
+          },
+          {
+            "description": "Path to the membase MCP server script",
+            "is_required": true,
+            "format": "string",
+            "value": "src/membase_mcp/server.py",
+            "default": "src/membase_mcp/server.py",
+            "type": "positional",
+            "value_hint": "src/membase_mcp/server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your account, 0x...",
+            "name": "MEMBASE_ACCOUNT"
+          },
+          {
+            "description": "your conversation id, should be unique",
+            "name": "MEMBASE_CONVERSATION_ID"
+          },
+          {
+            "description": "your sub account, any string",
+            "name": "MEMBASE_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b3dbb84c-3e48-4cbc-a581-bb9ebe133cb4",
+    "name": "io.github.ariadng/metatrader-mcp-server",
+    "description": "Model Context Protocol (MCP) to enable AI LLMs to trade using MetaTrader platform",
+    "repository": {
+      "url": "https://github.com/ariadng/metatrader-mcp-server",
+      "source": "github",
+      "id": "963828488"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "metatrader-mcp-server",
+        "version": "0.2.8",
+        "package_arguments": [
+          {
+            "description": "<YOUR_MT5_LOGIN>",
+            "is_required": true,
+            "format": "string",
+            "value": "--login <YOUR_MT5_LOGIN>",
+            "default": "--login <YOUR_MT5_LOGIN>",
+            "type": "named",
+            "name": "--login <YOUR_MT5_LOGIN>",
+            "value_hint": "<YOUR_MT5_LOGIN>"
+          },
+          {
+            "description": "<YOUR_MT5_PASSWORD>",
+            "is_required": true,
+            "format": "string",
+            "value": "--password <YOUR_MT5_PASSWORD>",
+            "default": "--password <YOUR_MT5_PASSWORD>",
+            "type": "named",
+            "name": "--password <YOUR_MT5_PASSWORD>",
+            "value_hint": "<YOUR_MT5_PASSWORD>"
+          },
+          {
+            "description": "<YOUR_MT5_SERVER>",
+            "is_required": true,
+            "format": "string",
+            "value": "--server <YOUR_MT5_SERVER>",
+            "default": "--server <YOUR_MT5_SERVER>",
+            "type": "named",
+            "name": "--server <YOUR_MT5_SERVER>",
+            "value_hint": "<YOUR_MT5_SERVER>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "091ef217-8e6d-4e06-8cb9-bc5ffe5467b1",
+    "name": "io.github.metricool/mcp-metricool",
+    "description": "This is a Multi-Agent Collaboration Protocol (MCP) server for interacting with the Metricool API. It allows AI agents to access and analyze social media metrics and campaign data from your Metricool account.",
+    "repository": {
+      "url": "https://github.com/metricool/mcp-metricool",
+      "source": "github",
+      "id": "967888435"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-metricool",
+        "version": "1.1.0",
+        "environment_variables": [
+          {
+            "description": "<METRICOOL_USER_TOKEN>",
+            "name": "METRICOOL_USER_TOKEN"
+          },
+          {
+            "description": "<METRICOOL_USER_ID>",
+            "name": "METRICOOL_USER_ID"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "53290776-f4aa-488d-a10f-135a17645b02",
+    "name": "io.github.jexinsam/mssql_mcp_server",
+    "description": "A Model Context Protocol (MCP) server facilitating secure interactions with MSSQL databases.",
+    "repository": {
+      "url": "https://github.com/JexinSam/mssql_mcp_server",
+      "source": "github",
+      "id": "924542723"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:15Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mssql_mcp_server",
+        "version": "0.1.2",
+        "package_arguments": [
+          {
+            "description": "Directory path for the MCP server",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/mssql_mcp_server",
+            "default": "--directory path/to/mssql_mcp_server",
+            "type": "named",
+            "name": "--directory path/to/mssql_mcp_server",
+            "value_hint": "path/to/mssql_mcp_server"
+          },
+          {
+            "description": "MCP server module name to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mssql_mcp_server",
+            "default": "mssql_mcp_server",
+            "type": "positional",
+            "value_hint": "mssql_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "mssql_driver",
+            "name": "MSSQL_DRIVER"
+          },
+          {
+            "description": "localhost",
+            "name": "MSSQL_HOST"
+          },
+          {
+            "description": "your_username",
+            "name": "MSSQL_USER"
+          },
+          {
+            "description": "your_password",
+            "name": "MSSQL_PASSWORD"
+          },
+          {
+            "description": "your_database",
+            "name": "MSSQL_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0c9a70a7-7523-42b7-a951-b4c4b8077710",
+    "name": "io.github.amornpan/py-mcp-mssql",
+    "description": "py-mcp-mssql",
+    "repository": {
+      "url": "https://github.com/amornpan/py-mcp-mssql",
+      "source": "github",
+      "id": "922607489"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "amornpan/py-mcp-mssql",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "script to run",
+            "is_required": true,
+            "format": "string",
+            "value": "server.py",
+            "default": "server.py",
+            "type": "positional",
+            "value_hint": "server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_server",
+            "name": "MSSQL_SERVER"
+          },
+          {
+            "description": "your_database",
+            "name": "MSSQL_DATABASE"
+          },
+          {
+            "description": "your_username",
+            "name": "MSSQL_USER"
+          },
+          {
+            "description": "your_password",
+            "name": "MSSQL_PASSWORD"
+          },
+          {
+            "description": "{ODBC Driver 17 for SQL Server}",
+            "name": "MSSQL_DRIVER"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "aaf985be-8d3d-41db-b69f-437cd09d85c6",
+    "name": "io.github.daobataotie/mssql-mcp",
+    "description": "mssql mcp server",
+    "repository": {
+      "url": "https://github.com/daobataotie/mssql-mcp",
+      "source": "github",
+      "id": "947666059"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "daobataotie/mssql-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "4365781f-28ff-4865-aa7d-909678f6dbb4",
+    "name": "io.github.zcaceres/mcp-markdownify-server",
+    "description": "A Model Context Protocol server for converting almost anything to Markdown",
+    "repository": {
+      "url": "https://github.com/zcaceres/markdownify-mcp",
+      "source": "github",
+      "id": "905450127"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:21Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ocr",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "71120aef-743c-47ee-bb7d-3b215c7f22a7",
+    "name": "io.github.inditextech/mcp-teams-server",
+    "description": "An MCP (Model Context Protocol) server implementation for Microsoft Teams integration, providing capabilities to read messages, create messages, reply to messages, mention members.",
+    "repository": {
+      "url": "https://github.com/InditexTech/mcp-teams-server",
+      "source": "github",
+      "id": "950628723"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:23Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-teams-server",
+        "version": "1.0.4",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9cc3a712-dd68-494f-a2a3-63bfc54ce837",
+    "name": "io.github.openmf/mcp-mifosx",
+    "description": "Model Context Protocol - MCP for Mifos X",
+    "repository": {
+      "url": "https://github.com/openMF/mcp-mifosx",
+      "source": "github",
+      "id": "955487988"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "openMF/mcp-mifosx",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "5ebda83c-f2b3-4b14-ba72-13d940fa940a",
+    "name": "io.github.jeff-nasseri/mikrotik-mcp",
+    "description": "MCP server for Mikrotik",
+    "repository": {
+      "url": "https://github.com/jeff-nasseri/mikrotik-mcp",
+      "source": "github",
+      "id": "982172059"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-mikrotik",
+        "version": "0.1.6",
+        "package_arguments": [
+          {
+            "description": "Host to connect to",
+            "is_required": true,
+            "format": "string",
+            "value": "--host <HOST>",
+            "default": "--host <HOST>",
+            "type": "named",
+            "name": "--host <HOST>",
+            "value_hint": "<HOST>"
+          },
+          {
+            "description": "Username for authentication",
+            "is_required": true,
+            "format": "string",
+            "value": "--username <USERNAME>",
+            "default": "--username <USERNAME>",
+            "type": "named",
+            "name": "--username <USERNAME>",
+            "value_hint": "<USERNAME>"
+          },
+          {
+            "description": "Password for authentication",
+            "is_required": true,
+            "format": "string",
+            "value": "--password <PASSWORD>",
+            "default": "--password <PASSWORD>",
+            "type": "named",
+            "name": "--password <PASSWORD>",
+            "value_hint": "<PASSWORD>"
+          },
+          {
+            "description": "Port to connect to",
+            "is_required": true,
+            "format": "string",
+            "value": "--port 22",
+            "default": "--port 22",
+            "type": "named",
+            "name": "--port 22",
+            "value_hint": "22"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7f9416dd-34cf-4f0d-bcfb-c87cbee3abf6",
+    "name": "io.github.yuchenssr/mindmap-mcp-server",
+    "description": "mindmap, mcp server, artifact",
+    "repository": {
+      "url": "https://github.com/YuChenSSR/mindmap-mcp-server",
+      "source": "github",
+      "id": "951261036"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mindmap-mcp-server",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "-v /path/to/output/folder:/output",
+            "is_required": true,
+            "format": "string",
+            "value": "-v /path/to/output/folder:/output",
+            "default": "-v /path/to/output/folder:/output",
+            "type": "named",
+            "name": "-v /path/to/output/folder:/output",
+            "value_hint": "/path/to/output/folder:/output"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a0774c2f-cd94-44d6-b441-d606f20c2087",
+    "name": "io.github.dmayboroda/minima",
+    "description": "On-premises conversational RAG with configurable containers",
+    "repository": {
+      "url": "https://github.com/dmayboroda/minima",
+      "source": "github",
+      "id": "882486617"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:33Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "dmayboroda/minima",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "6fefc93f-3f03-47b0-9f42-21d5a5841490",
+    "name": "io.github.mobile-next/mobile-mcp",
+    "description": "Model Context Protocol Server for Mobile Automation and Scraping (iOS, Android, Emulators, Simulators and Physical Devices)",
+    "repository": {
+      "url": "https://github.com/mobile-next/mobile-mcp",
+      "source": "github",
+      "id": "956657893"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@mobilenext/mobile-mcp",
+        "version": "0.0.17"
+      }
+    ]
+  },
+  {
+    "id": "b61a2d2e-db6c-47b4-9437-7edc8525d063",
+    "name": "io.github.kiliczsh/mcp-mongo-server",
+    "description": "A Model Context Protocol Server for MongoDB",
+    "repository": {
+      "url": "https://github.com/kiliczsh/mcp-mongo-server",
+      "source": "github",
+      "id": "898654014"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-mongo-server",
+        "version": "1.3.0",
+        "package_arguments": [
+          {
+            "description": "MongoDB connection string",
+            "is_required": true,
+            "format": "string",
+            "value": "mongodb://muhammed:kilic@localhost:27017/database",
+            "default": "mongodb://muhammed:kilic@localhost:27017/database",
+            "type": "positional",
+            "value_hint": "mongodb://muhammed:kilic@localhost:27017/database"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b4970e5b-1259-4ff9-a40a-c570f27d0930",
+    "name": "io.github.furey/mongodb-lens",
+    "description": "🍃🔎 MongoDB Lens: Full Featured MCP Server for MongoDB Databases",
+    "repository": {
+      "url": "https://github.com/furey/mongodb-lens",
+      "source": "github",
+      "id": "945309383"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mongodb-lens",
+        "version": "9.1.4"
+      }
+    ]
+  },
+  {
+    "id": "ac665c5c-e1de-4686-9012-5ac101186a31",
+    "name": "io.github.sakce/mcp-server-monday",
+    "description": "MCP Server to interact with Monday.com boards and items",
+    "repository": {
+      "url": "https://github.com/sakce/mcp-server-monday",
+      "source": "github",
+      "id": "936547010"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-monday",
+        "version": "0.2.9"
+      }
+    ]
+  },
+  {
+    "id": "3f0811e0-35b7-4e9b-a610-d8aa0b71400d",
+    "name": "io.github.morningstar/morningstar-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Morningstar/morningstar-mcp-server",
+      "source": "github",
+      "id": "956037631"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "Morningstar/morningstar-mcp-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "55ba52cd-8e0a-4bcb-9a96-1658f2d713e0",
+    "name": "io.github.yanmxa/multicluster-mcp-server",
+    "description": "The gateway for GenAI systems to interact with multiple Kubernetes clusters through the MCP",
+    "repository": {
+      "url": "https://github.com/yanmxa/multicluster-mcp-server",
+      "source": "github",
+      "id": "940456029"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "multicluster-mcp-server",
+        "version": "0.1.3"
+      }
+    ]
+  },
+  {
+    "id": "abcce212-b3e1-4741-a8b3-86c95c276fb1",
+    "name": "io.github.yuchenssr/multi-ai-advisor-mcp",
+    "description": "council of models for decision",
+    "repository": {
+      "url": "https://github.com/YuChenSSR/multi-ai-advisor-mcp",
+      "source": "github",
+      "id": "954021177"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "multi-model-advisor",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "22fbb4c3-d5fd-4191-af7a-c78686cc6123",
+    "name": "io.github.benborla/mcp-server-mysql",
+    "description": "A Model Context Protocol server that provides read-only access to MySQL databases. This server enables LLMs to inspect database schemas and execute read-only queries.",
+    "repository": {
+      "url": "https://github.com/benborla/mcp-server-mysql",
+      "source": "github",
+      "id": "900806525"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@benborla29/mcp-server-mysql",
+        "version": "2.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to the MCP server MySQL entry point.",
+            "is_required": true,
+            "format": "string",
+            "value": "/full/path/to/mcp-server-mysql/dist/index.js",
+            "default": "/full/path/to/mcp-server-mysql/dist/index.js",
+            "type": "positional",
+            "value_hint": "/full/path/to/mcp-server-mysql/dist/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "127.0.0.1",
+            "name": "MYSQL_HOST"
+          },
+          {
+            "description": "3306",
+            "name": "MYSQL_PORT"
+          },
+          {
+            "description": "root",
+            "name": "MYSQL_USER"
+          },
+          {
+            "description": "your_password",
+            "name": "MYSQL_PASS"
+          },
+          {
+            "description": "your_database",
+            "name": "MYSQL_DB"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "56577627-939e-4f31-8c96-654586538eb5",
+    "name": "io.github.designcomputer/mysql_mcp_server",
+    "description": "A Model Context Protocol (MCP) server that enables secure interaction with MySQL databases",
+    "repository": {
+      "url": "https://github.com/designcomputer/mysql_mcp_server",
+      "source": "github",
+      "id": "898128804"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mysql_mcp_server",
+        "version": "0.2.2",
+        "package_arguments": [
+          {
+            "description": "Specify the origin of the package",
+            "is_required": true,
+            "format": "string",
+            "value": "--from mysql-mcp-server",
+            "default": "--from mysql-mcp-server",
+            "type": "named",
+            "name": "--from mysql-mcp-server",
+            "value_hint": "mysql-mcp-server"
+          },
+          {
+            "description": "Name of the MCP server executable",
+            "is_required": true,
+            "format": "string",
+            "value": "mysql_mcp_server",
+            "default": "mysql_mcp_server",
+            "type": "positional",
+            "value_hint": "mysql_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "localhost",
+            "name": "MYSQL_HOST"
+          },
+          {
+            "description": "3306",
+            "name": "MYSQL_PORT"
+          },
+          {
+            "description": "your_username",
+            "name": "MYSQL_USER"
+          },
+          {
+            "description": "your_password",
+            "name": "MYSQL_PASSWORD"
+          },
+          {
+            "description": "your_database",
+            "name": "MYSQL_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "309e2634-8163-47c9-951e-1cfec85e701b",
+    "name": "io.github.leonardsellem/n8n-mcp-server",
+    "description": "MCP server that provides tools and resources for interacting with n8n API",
+    "repository": {
+      "url": "https://github.com/leonardsellem/n8n-mcp-server",
+      "source": "github",
+      "id": "947387660"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:10:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "n8n-mcp-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Positional argument providing absolute path to the built index.js file",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/your/cloned/n8n-mcp-server/build/index.js",
+            "default": "/path/to/your/cloned/n8n-mcp-server/build/index.js",
+            "type": "positional",
+            "value_hint": "/path/to/your/cloned/n8n-mcp-server/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://your-n8n-instance:5678/api/v1",
+            "name": "N8N_API_URL"
+          },
+          {
+            "description": "YOUR_N8N_API_KEY",
+            "name": "N8N_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6a44b030-46c7-4390-adf2-2a75652dee27",
+    "name": "io.github.programcomputer/nasa-mcp-server",
+    "description": "A Model Context Protocol (MCP) server for NASA APIs, providing a standardized interface for AI models to interact with NASA's vast array of data sources.",
+    "repository": {
+      "url": "https://github.com/ProgramComputer/NASA-MCP-server",
+      "source": "github",
+      "id": "943596518"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@programcomputer/nasa-mcp-server",
+        "version": "1.0.12",
+        "package_arguments": [
+          {
+            "description": "Comma-separated list",
+            "is_required": true,
+            "format": "string",
+            "value": "T2M,PRECTOTCORR,WS10M",
+            "default": "T2M,PRECTOTCORR,WS10M",
+            "type": "named",
+            "name": "T2M,PRECTOTCORR,WS10M",
+            "value_hint": "T2M,PRECTOTCORR,WS10M"
+          },
+          {
+            "description": "Community identifier",
+            "is_required": true,
+            "format": "string",
+            "value": "re",
+            "default": "re",
+            "type": "named",
+            "name": "re",
+            "value_hint": "re"
+          },
+          {
+            "description": "Latitude",
+            "is_required": true,
+            "format": "string",
+            "value": "40.7128",
+            "default": "40.7128",
+            "type": "named",
+            "name": "40.7128",
+            "value_hint": "40.7128"
+          },
+          {
+            "description": "Longitude",
+            "is_required": true,
+            "format": "string",
+            "value": "-74.0060",
+            "default": "-74.0060",
+            "type": "named",
+            "name": "-74.0060",
+            "value_hint": "-74.0060"
+          },
+          {
+            "description": "Start date (YYYYMMDD)",
+            "is_required": true,
+            "format": "string",
+            "value": "20220101",
+            "default": "20220101",
+            "type": "named",
+            "name": "20220101",
+            "value_hint": "20220101"
+          },
+          {
+            "description": "End date (YYYYMMDD)",
+            "is_required": true,
+            "format": "string",
+            "value": "20220107",
+            "default": "20220107",
+            "type": "named",
+            "name": "20220107",
+            "value_hint": "20220107"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9326c18e-b2fb-4012-a170-cdd5753f0b1e",
+    "name": "io.github.stefanoamorelli/nasdaq-data-link-mcp",
+    "description": "A Nasdaq Data Link MCP (Model Context Protocol) Server",
+    "repository": {
+      "url": "https://github.com/stefanoamorelli/nasdaq-data-link-mcp",
+      "source": "github",
+      "id": "957599131"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "nasdaq-data-link-mcp-os",
+        "version": "0.1.3",
+        "package_arguments": [
+          {
+            "description": "investment_company_type argument",
+            "is_required": true,
+            "format": "string",
+            "value": "investment_company_type N-1A",
+            "default": "investment_company_type N-1A",
+            "type": "named",
+            "name": "investment_company_type N-1A",
+            "value_hint": "N-1A"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "010904ec-6e39-4bdc-878a-75a6e79d0500",
+    "name": "io.github.kyrietangsheng/mcp-server-nationalparks",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/KyrieTangSheng/mcp-server-nationalparks",
+      "source": "github",
+      "id": "951713109"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:05Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-server-nationalparks",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "YOUR_NPS_API_KEY",
+            "name": "NPS_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f10c234b-cf64-4dc2-9e38-5f57e53aeecb",
+    "name": "io.github.pfldy2850/py-mcp-naver",
+    "description": "python MCP NAVER",
+    "repository": {
+      "url": "https://github.com/pfldy2850/py-mcp-naver",
+      "source": "github",
+      "id": "951863489"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-naver",
+        "version": "0.1.5"
+      }
+    ]
+  },
+  {
+    "id": "9c7c309a-fb3c-4099-b461-0ca725c9083b",
+    "name": "io.github.taidgh-robinson/nba-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Taidgh-Robinson/nba-mcp-server",
+      "source": "github",
+      "id": "971505657"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-nba",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "afcff9a2-a4ed-457f-80fb-8bdd1948771a",
+    "name": "io.github.r-huijts/ns-mcp-server",
+    "description": "A Model Context Protocol (MCP) server that provides access to NS (Dutch Railways) travel information through Claude AI. This server enables Claude to fetch real-time train travel information and disruptions using the official Dutch NS API.",
+    "repository": {
+      "url": "https://github.com/r-huijts/ns-mcp-server",
+      "source": "github",
+      "id": "898429869"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ns-mcp-server",
+        "version": "0.1.6",
+        "package_arguments": [
+          {
+            "description": "/path/to/ns-server/build/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/ns-server/build/index.js",
+            "default": "/path/to/ns-server/build/index.js",
+            "type": "positional",
+            "value_hint": "/path/to/ns-server/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "NS_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b4c38c39-7381-49fa-b7b4-75e2604ed93d",
+    "name": "io.github.da-okazaki/mcp-neo4j-server",
+    "description": "mcp-neo4j-server",
+    "repository": {
+      "url": "https://github.com/da-okazaki/mcp-neo4j-server",
+      "source": "github",
+      "id": "912380178"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@alanse/mcp-neo4j-server",
+        "version": "0.1.1",
+        "environment_variables": [
+          {
+            "description": "bolt://localhost:7687",
+            "name": "NEO4J_URI"
+          },
+          {
+            "description": "neo4j",
+            "name": "NEO4J_USERNAME"
+          },
+          {
+            "description": "your-password",
+            "name": "NEO4J_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d9d7e246-d3f4-4214-aa79-fe1981c73c2e",
+    "name": "io.github.bigcodegen/mcp-neovim-server",
+    "description": "Control Neovim using Model Context Protocol (MCP) and the official neovim/node-client JavaScript library",
+    "repository": {
+      "url": "https://github.com/bigcodegen/mcp-neovim-server",
+      "source": "github",
+      "id": "907120691"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-neovim-server",
+        "version": "0.4.2",
+        "environment_variables": [
+          {
+            "description": "true",
+            "name": "ALLOW_SHELL_COMMANDS"
+          },
+          {
+            "description": "/tmp/nvim",
+            "name": "NVIM_SOCKET_PATH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "6ebc1c16-ea8d-44eb-958c-74f3f0531058",
+    "name": "io.github.kocierik/mcp-nomad",
+    "description": " A nomad MCP Server (modelcontextprotocol) ",
+    "repository": {
+      "url": "https://github.com/kocierik/mcp-nomad",
+      "source": "github",
+      "id": "969499680"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "kocierik/mcp-nomad",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "-e NOMAD_ADDR=http://172.17.0.1:4646",
+            "is_required": true,
+            "format": "string",
+            "value": "-e NOMAD_ADDR=http://172.17.0.1:4646",
+            "default": "-e NOMAD_ADDR=http://172.17.0.1:4646",
+            "type": "named",
+            "name": "-e NOMAD_ADDR=http://172.17.0.1:4646",
+            "value_hint": "NOMAD_ADDR=http://172.17.0.1:4646"
+          },
+          {
+            "description": "-e NOMAD_TOKEN=secret-token-acl-optional",
+            "is_required": true,
+            "format": "string",
+            "value": "-e NOMAD_TOKEN=secret-token-acl-optional",
+            "default": "-e NOMAD_TOKEN=secret-token-acl-optional",
+            "type": "named",
+            "name": "-e NOMAD_TOKEN=secret-token-acl-optional",
+            "value_hint": "NOMAD_TOKEN=secret-token-acl-optional"
+          },
+          {
+            "description": "kocierik/mcpnomad-server:latest",
+            "is_required": true,
+            "format": "string",
+            "value": "kocierik/mcpnomad-server:latest",
+            "default": "kocierik/mcpnomad-server:latest",
+            "type": "positional",
+            "value_hint": "kocierik/mcpnomad-server:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e9a5215c-6485-462f-b086-6e97f0466b30",
+    "name": "io.github.suekou/mcp-notion-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/suekou/mcp-notion-server",
+      "source": "github",
+      "id": "896417211"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@suekou/mcp-notion-server",
+        "version": "1.2.4",
+        "package_arguments": [
+          {
+            "description": "your-built-file-path",
+            "is_required": true,
+            "format": "string",
+            "value": "your-built-file-path",
+            "default": "your-built-file-path",
+            "type": "positional",
+            "value_hint": "your-built-file-path"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-integration-token",
+            "name": "NOTION_API_TOKEN"
+          },
+          {
+            "description": "true",
+            "name": "NOTION_MARKDOWN_CONVERSION"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1455eb68-3cf0-4cc3-a8ee-fd729a00acd3",
+    "name": "io.github.v-3/notion-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/v-3/notion-server",
+      "source": "github",
+      "id": "904087475"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "notionmcp",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your_notion_api_key_here",
+            "name": "NOTION_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "dd3f5299-5869-43ec-89a8-77e25e6a157e",
+    "name": "io.github.teddyzxcv/ntfy-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/teddyzxcv/ntfy-mcp",
+      "source": "github",
+      "id": "950853704"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ntfy-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to the main entry point for ntfy-mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/ntfy-mcp/build/index.js",
+            "default": "/path/to/ntfy-mcp/build/index.js",
+            "type": "positional",
+            "value_hint": "/path/to/ntfy-mcp/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<your topic name>",
+            "name": "NTFY_TOPIC"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ba368d1c-d64d-4ecd-9bde-72304d69c4d1",
+    "name": "io.github.gitmotion/ntfy-me-mcp",
+    "description": "An ntfy MCP server for sending/fetching ntfy notifications to any/self-hosted ntfy.sh server from AI Agents 📤 (supports secure token auth & more - use with npx or docker!)",
+    "repository": {
+      "url": "https://github.com/gitmotion/ntfy-me-mcp",
+      "source": "github",
+      "id": "964136538"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ntfy-me-mcp",
+        "version": "1.3.3",
+        "environment_variables": [
+          {
+            "description": "your-topic-name",
+            "name": "NTFY_TOPIC"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9fdf29e9-6059-4a99-a5ae-4c0eda7627eb",
+    "name": "io.github.oatpp/oatpp-mcp",
+    "description": "Anthropic’s Model Context Protocol implementation for Oat++",
+    "repository": {
+      "url": "https://github.com/oatpp/oatpp-mcp",
+      "source": "github",
+      "id": "900529643"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "oatpp/oatpp-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "ab58cca1-94ad-42d8-be13-980556ac552b",
+    "name": "io.github.calclavia/mcp-obsidian",
+    "description": "A connector for Claude Desktop to read and search an Obsidian vault.",
+    "repository": {
+      "url": "https://github.com/smithery-ai/mcp-obsidian",
+      "source": "github",
+      "id": "895882011"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:33Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-obsidian",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to Obsidian vault",
+            "is_required": true,
+            "format": "string",
+            "value": "${input:vaultPath}",
+            "default": "${input:vaultPath}",
+            "type": "positional",
+            "value_hint": "${input:vaultPath}"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "752ef535-2865-4d95-bcc5-647a7be83f74",
+    "name": "io.github.stevenstavrakis/obsidian-mcp",
+    "description": "A simple MCP server for Obsidian",
+    "repository": {
+      "url": "https://github.com/StevenStavrakis/obsidian-mcp",
+      "source": "github",
+      "id": "906827503"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:35Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "obsidian-mcp",
+        "version": "1.0.6",
+        "package_arguments": [
+          {
+            "description": "/path/to/your/vault",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/your/vault",
+            "default": "/path/to/your/vault",
+            "type": "positional",
+            "value_hint": "/path/to/your/vault"
+          },
+          {
+            "description": "/path/to/your/vault2",
+            "is_required": true,
+            "format": "string",
+            "value": "/path/to/your/vault2",
+            "default": "/path/to/your/vault2",
+            "type": "positional",
+            "value_hint": "/path/to/your/vault2"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b71bb3e0-0871-4ca6-9336-3c731607d3ad",
+    "name": "io.github.yuanooo/oceanbase_mcp_server",
+    "description": "A Model Context Protocol (MCP) server that enables secure interaction with OceanBase databases. This server allows AI assistants to list tables, read data, and execute SQL queries through a controlled interface, making database exploration and analysis safer and more structured.",
+    "repository": {
+      "url": "https://github.com/yuanoOo/oceanbase_mcp_server",
+      "source": "github",
+      "id": "943079798"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "oceanbase_mcp_server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "oceanbase_mcp_server",
+            "default": "oceanbase_mcp_server",
+            "type": "positional",
+            "value_hint": "oceanbase_mcp_server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "localhost",
+            "name": "OB_HOST"
+          },
+          {
+            "description": "2881",
+            "name": "OB_PORT"
+          },
+          {
+            "description": "your_username",
+            "name": "OB_USER"
+          },
+          {
+            "description": "your_password",
+            "name": "OB_PASSWORD"
+          },
+          {
+            "description": "your_database",
+            "name": "OB_DATABASE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d3194c4f-b73a-40b2-9170-0e6e8ee713c0",
+    "name": "io.github.gongrzhe/office-powerpoint-mcp-server",
+    "description": "A MCP (Model Context Protocol) server for PowerPoint manipulation using python-pptx. This server provides tools for creating, editing, and manipulating PowerPoint presentations through the MCP protocol.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Office-PowerPoint-MCP-Server",
+      "source": "github",
+      "id": "954558050"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "office-powerpoint-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Named argument --from with value office-powerpoint-mcp-server",
+            "is_required": true,
+            "format": "string",
+            "value": "--from office-powerpoint-mcp-server",
+            "default": "--from office-powerpoint-mcp-server",
+            "type": "named",
+            "name": "--from office-powerpoint-mcp-server",
+            "value_hint": "office-powerpoint-mcp-server"
+          },
+          {
+            "description": "Positional argument ppt_mcp_server",
+            "is_required": true,
+            "format": "string",
+            "value": "ppt_mcp_server",
+            "default": "ppt_mcp_server",
+            "type": "positional",
+            "value_hint": "ppt_mcp_server"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4d3dba83-9775-4b5a-9de7-f18f7263460c",
+    "name": "io.github.gongrzhe/office-word-mcp-server",
+    "description": "A Model Context Protocol (MCP) server for creating, reading, and manipulating Microsoft Word documents. This server enables AI assistants to work with Word documents through a standardized interface, providing rich document editing capabilities.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Office-Word-MCP-Server",
+      "source": "github",
+      "id": "954434732"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "office-word-mcp-server",
+        "version": "1.1.3",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "word_mcp_server",
+            "default": "word_mcp_server",
+            "type": "positional",
+            "value_hint": "word_mcp_server"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "618671cb-8783-47c7-a81c-164f5f9e2cc1",
+    "name": "io.github.kapilduraphe/okta-mcp-server",
+    "description": "Okta MCP Server",
+    "repository": {
+      "url": "https://github.com/kapilduraphe/okta-mcp-server",
+      "source": "github",
+      "id": "932923739"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "okta-mcp-server",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "https://your-domain.okta.com",
+            "name": "OKTA_ORG_URL"
+          },
+          {
+            "description": "your-api-token",
+            "name": "OKTA_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a2e44c59-4a60-47a6-8588-22b90cebe345",
+    "name": "io.github.rajvirtual/mcp-servers",
+    "description": "A Model Context Protocol (MCP) server that provides AI assistants with access to Microsoft OneNote. This server enables AI models to read from and write to OneNote notebooks, sections, and pages.",
+    "repository": {
+      "url": "https://github.com/rajvirtual/MCP-Servers",
+      "source": "github",
+      "id": "947565134"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "rajvirtual/MCP-Servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "531956a8-df6a-4edd-bb72-36c284c1d7c8",
+    "name": "io.github.conechoai/openai-websearch-mcp",
+    "description": "openai websearch tool as mcp server",
+    "repository": {
+      "url": "https://github.com/ConechoAI/openai-websearch-mcp",
+      "source": "github",
+      "id": "947082641"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "openai-websearch-mcp",
+        "version": "0.4.0",
+        "package_arguments": [
+          {
+            "description": "Run Python module openai_websearch_mcp",
+            "is_required": true,
+            "format": "string",
+            "value": "-m openai_websearch_mcp",
+            "default": "-m openai_websearch_mcp",
+            "type": "named",
+            "name": "-m openai_websearch_mcp",
+            "value_hint": "openai_websearch_mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-key-here",
+            "name": "OPENAI_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "47685d63-d574-4311-b823-c0ddc29d8514",
+    "name": "io.github.snaggle-ai/openapi-mcp-server",
+    "description": "Allow AI to wade through complex OpenAPIs using Simple Language",
+    "repository": {
+      "url": "https://github.com/janwilmake/openapi-mcp-server",
+      "source": "github",
+      "id": "900049352"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "openapi-mcp-server",
+        "version": "2.0.3"
+      }
+    ]
+  },
+  {
+    "id": "c52271b3-e48e-4896-b5a2-2ff93189b339",
+    "name": "io.github.baryhuang/mcp-server-any-openapi",
+    "description": "A MCP server that enables Claude to discover and call any API endpoint through semantic search. Intelligently chunks OpenAPI specifications to handle large API documentation, with built-in request execution capabilities. Perfect for integrating private APIs with Claude Desktop.",
+    "repository": {
+      "url": "https://github.com/baryhuang/mcp-server-any-openapi",
+      "source": "github",
+      "id": "929659341"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:11:58Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-server-any-openapi",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Run in interactive mode",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "Automatically remove the container when it exits",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Set environment variable OPENAPI_JSON_DOCS_URL",
+            "is_required": true,
+            "format": "string",
+            "value": "-e OPENAPI_JSON_DOCS_URL=https://api.example.com/openapi.json",
+            "default": "-e OPENAPI_JSON_DOCS_URL=https://api.example.com/openapi.json",
+            "type": "named",
+            "name": "-e OPENAPI_JSON_DOCS_URL=https://api.example.com/openapi.json",
+            "value_hint": "OPENAPI_JSON_DOCS_URL=https://api.example.com/openapi.json"
+          },
+          {
+            "description": "Set environment variable MCP_API_PREFIX",
+            "is_required": true,
+            "format": "string",
+            "value": "-e MCP_API_PREFIX=finance",
+            "default": "-e MCP_API_PREFIX=finance",
+            "type": "named",
+            "name": "-e MCP_API_PREFIX=finance",
+            "value_hint": "MCP_API_PREFIX=finance"
+          },
+          {
+            "description": "Set environment variable GLOBAL_TOOL_PROMPT",
+            "is_required": true,
+            "format": "string",
+            "value": "-e GLOBAL_TOOL_PROMPT='Access to insights apis for ACME Financial Services abc.com .",
+            "default": "-e GLOBAL_TOOL_PROMPT='Access to insights apis for ACME Financial Services abc.com .",
+            "type": "named",
+            "name": "-e GLOBAL_TOOL_PROMPT='Access to insights apis for ACME Financial Services abc.com .",
+            "value_hint": "GLOBAL_TOOL_PROMPT='Access to insights apis for ACME Financial Services abc.com ."
+          },
+          {
+            "description": "Docker image name and tag",
+            "is_required": true,
+            "format": "string",
+            "value": "buryhuang/mcp-server-any-openapi:latest",
+            "default": "buryhuang/mcp-server-any-openapi:latest",
+            "type": "positional",
+            "value_hint": "buryhuang/mcp-server-any-openapi:latest"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7d68a487-bc40-4783-a2eb-1c9107fc26a4",
+    "name": "io.github.hannesj/mcp-openapi-schema",
+    "description": "OpenAPI Schema Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/hannesj/mcp-openapi-schema",
+      "source": "github",
+      "id": "947937745"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-openapi-schema",
+        "version": "0.0.1",
+        "package_arguments": [
+          {
+            "description": "The OpenAPI specification file to be used",
+            "is_required": true,
+            "format": "string",
+            "value": "/ABSOLUTE/PATH/TO/openapi.yaml",
+            "default": "/ABSOLUTE/PATH/TO/openapi.yaml",
+            "type": "positional",
+            "value_hint": "/ABSOLUTE/PATH/TO/openapi.yaml"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c01d9a66-7a37-4f66-870d-38829c0047ea",
+    "name": "io.github.spathodea-network/opencti-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Spathodea-Network/opencti-mcp",
+      "source": "github",
+      "id": "909539706"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "opencti-server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Positional argument for package execution",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/opencti-server/build/index.js",
+            "default": "path/to/opencti-server/build/index.js",
+            "type": "positional",
+            "value_hint": "path/to/opencti-server/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "${OPENCTI_URL}",
+            "name": "OPENCTI_URL"
+          },
+          {
+            "description": "${OPENCTI_TOKEN}",
+            "name": "OPENCTI_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a81b1d9e-c1a5-4848-a3f5-350ea2872ae3",
+    "name": "io.github.asusevski/opendota-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/asusevski/opendota-mcp-server",
+      "source": "github",
+      "id": "941719334"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "opendota-mcp-server",
+        "version": "0.1.1",
+        "package_arguments": [
+          {
+            "description": "bash",
+            "is_required": true,
+            "format": "string",
+            "value": "bash",
+            "default": "bash",
+            "type": "positional",
+            "value_hint": "bash"
+          },
+          {
+            "description": "-c",
+            "is_required": true,
+            "format": "string",
+            "value": "-c",
+            "default": "-c",
+            "type": "named",
+            "name": "-c",
+            "value_hint": "-c"
+          },
+          {
+            "description": "cd ~/opendota-mcp-server && source .venv/bin/activate && python src/opendota_server/server.py",
+            "is_required": true,
+            "format": "string",
+            "value": "cd ~/opendota-mcp-server && source .venv/bin/activate && python src/opendota_server/server.py",
+            "default": "cd ~/opendota-mcp-server && source .venv/bin/activate && python src/opendota_server/server.py",
+            "type": "positional",
+            "value_hint": "cd ~/opendota-mcp-server && source .venv/bin/activate && python src/opendota_server/server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9c804dd3-4283-4a5b-a34e-6f1c7065b671",
+    "name": "io.github.shanejonas/openrpc-mpc-server",
+    "description": "A Model Context Protocol (MCP) server that provides JSON-RPC functionality through OpenRPC.",
+    "repository": {
+      "url": "https://github.com/shanejonas/openrpc-mpc-server",
+      "source": "github",
+      "id": "897678596"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "openrpc-mcp-server",
+        "version": "0.1.2"
+      }
+    ]
+  },
+  {
+    "id": "54a7e4fa-a7d1-476f-bd25-2f417766c3b5",
+    "name": "io.github.mschneider82/mcp-openweather",
+    "description": "mcp server for openweather free api",
+    "repository": {
+      "url": "https://github.com/mschneider82/mcp-openweather",
+      "source": "github",
+      "id": "982749772"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:11Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mschneider82/mcp-openweather",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "The city for which weather is requested",
+            "is_required": true,
+            "format": "string",
+            "value": "Berlin",
+            "default": "Berlin",
+            "type": "positional",
+            "value_hint": "Berlin"
+          },
+          {
+            "description": "Units to display temperature (c|f|k)",
+            "format": "string",
+            "value": "units c",
+            "default": "units c",
+            "type": "named",
+            "name": "units c",
+            "value_hint": "c"
+          },
+          {
+            "description": "Language code for the response (en|de|fr|...)",
+            "format": "string",
+            "value": "lang en",
+            "default": "lang en",
+            "type": "named",
+            "name": "lang en",
+            "value_hint": "en"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0d8b287c-6023-4809-a5ba-963c5612efa2",
+    "name": "io.github.open-strategy-partners/osp_marketing_tools",
+    "description": "A Model Context Protocol (MCP) server that empowers LLMs to use some of Open Srategy Partners' core writing and product marketing techniques.",
+    "repository": {
+      "url": "https://github.com/open-strategy-partners/osp_marketing_tools",
+      "source": "github",
+      "id": "917730483"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "osp-marketing-tools",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Specifies the source repository",
+            "is_required": true,
+            "format": "string",
+            "value": "--from git+https://github.com/open-strategy-partners/osp_marketing_tools@main",
+            "default": "--from git+https://github.com/open-strategy-partners/osp_marketing_tools@main",
+            "type": "named",
+            "name": "--from git+https://github.com/open-strategy-partners/osp_marketing_tools@main",
+            "value_hint": "git+https://github.com/open-strategy-partners/osp_marketing_tools@main"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "d6801d4f-2f27-4e67-8b70-10754b48ff0d",
+    "name": "io.github.vortiago/mcp-outline",
+    "description": "A Model Context Protocol (MCP) server enabling AI assistants to interact with Outline documentation services.",
+    "repository": {
+      "url": "https://github.com/Vortiago/mcp-outline",
+      "source": "github",
+      "id": "953087223"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-outline",
+        "version": "0.2.2"
+      }
+    ]
+  },
+  {
+    "id": "925a5d1d-ab12-44bd-9297-a20bdde6ec68",
+    "name": "io.github.kukapay/pancakeswap-poolspy-mcp",
+    "description": "An MCP server that tracks newly created liquidity pools on Pancake Swap",
+    "repository": {
+      "url": "https://github.com/kukapay/pancakeswap-poolspy-mcp",
+      "source": "github",
+      "id": "949792903"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "pancakeswap-poolspy-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Specify directory to run from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/pancakeswap-poolspy-mcp",
+            "default": "--directory path/to/pancakeswap-poolspy-mcp",
+            "type": "named",
+            "name": "--directory path/to/pancakeswap-poolspy-mcp",
+            "value_hint": "path/to/pancakeswap-poolspy-mcp"
+          },
+          {
+            "description": "Python script to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "main.py",
+            "default": "main.py",
+            "type": "positional",
+            "value_hint": "main.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your api key from The Graph",
+            "name": "THEGRAPH_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a0f6fd01-5eb2-4aca-b4a6-c67eb6e0c5da",
+    "name": "io.github.vivekvells/mcp-pandoc",
+    "description": "MCP server for document format conversion using pandoc.",
+    "repository": {
+      "url": "https://github.com/vivekVells/mcp-pandoc",
+      "source": "github",
+      "id": "900427746"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:21Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-pandoc",
+        "version": "0.3.3"
+      }
+    ]
+  },
+  {
+    "id": "038a3024-c319-4a07-bd7f-9cf699cfebf1",
+    "name": "io.github.sv/mcp-paradex-py",
+    "description": "Connect AI agents to the Paradex trading platform. Retrieve market data, manage accounts, and execute trades seamlessly. Enhance your trading experience with automated tools and real-time insights.",
+    "repository": {
+      "url": "https://github.com/sv/mcp-paradex-py",
+      "source": "github",
+      "id": "944258239"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-paradex",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "--from mcpdoc",
+            "is_required": true,
+            "format": "string",
+            "value": "--from mcpdoc",
+            "default": "--from mcpdoc",
+            "type": "named",
+            "name": "--from mcpdoc",
+            "value_hint": "mcpdoc"
+          },
+          {
+            "description": "mcpdoc",
+            "is_required": true,
+            "format": "string",
+            "value": "mcpdoc",
+            "default": "mcpdoc",
+            "type": "positional",
+            "value_hint": "mcpdoc"
+          },
+          {
+            "description": "--urls Paradex:https://docs.paradex.trade/llms.txt",
+            "is_required": true,
+            "format": "string",
+            "value": "--urls Paradex:https://docs.paradex.trade/llms.txt",
+            "default": "--urls Paradex:https://docs.paradex.trade/llms.txt",
+            "type": "named",
+            "name": "--urls Paradex:https://docs.paradex.trade/llms.txt",
+            "value_hint": "Paradex:https://docs.paradex.trade/llms.txt"
+          },
+          {
+            "description": "--transport stdio",
+            "is_required": true,
+            "format": "string",
+            "value": "--transport stdio",
+            "default": "--transport stdio",
+            "type": "named",
+            "name": "--transport stdio",
+            "value_hint": "stdio"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "b2c02765-621b-403e-8859-53afb9866451",
+    "name": "io.github.hao-cyber/phone-mcp",
+    "description": "A phone control plugin for MCP that allows you to control your Android phone through ADB commands to connect any human",
+    "repository": {
+      "url": "https://github.com/hao-cyber/phone-mcp",
+      "source": "github",
+      "id": "963381978"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "hao-cyber/phone-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "dd586d17-4a7e-4658-92df-8cf6b58bff4d",
+    "name": "io.github.hungryrobot1/mcp-pif",
+    "description": "A MCP implementation of the personal intelligence framework (PIF)",
+    "repository": {
+      "url": "https://github.com/hungryrobot1/MCP-PIF",
+      "source": "github",
+      "id": "923899029"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-pif",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "23b81af0-3e03-47b8-a310-c9b07bebd547",
+    "name": "io.github.sirmews/mcp-pinecone",
+    "description": "Model Context Protocol server to allow for reading and writing from Pinecone. Rudimentary RAG",
+    "repository": {
+      "url": "https://github.com/sirmews/mcp-pinecone",
+      "source": "github",
+      "id": "900184645"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-pinecone",
+        "version": "0.1.8",
+        "package_arguments": [
+          {
+            "description": "Index name for the Pinecone database.",
+            "is_required": true,
+            "format": "string",
+            "value": "--index-name {your-index-name}",
+            "default": "--index-name {your-index-name}",
+            "type": "named",
+            "name": "--index-name {your-index-name}",
+            "value_hint": "{your-index-name}"
+          },
+          {
+            "description": "API key for authenticating with Pinecone.",
+            "is_required": true,
+            "format": "string",
+            "value": "--api-key {your-secret-api-key}",
+            "default": "--api-key {your-secret-api-key}",
+            "type": "named",
+            "name": "--api-key {your-secret-api-key}",
+            "value_hint": "{your-secret-api-key}"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cfe44c73-8b61-48c9-9d7f-b28e98d23b5b",
+    "name": "io.github.felores/placid-mcp-server",
+    "description": "Generate image and video creatives using Placid.app templates in MCP compatible hosts",
+    "repository": {
+      "url": "https://github.com/felores/placid-mcp-server",
+      "source": "github",
+      "id": "915853970"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@felores/placid-mcp-server",
+        "version": "1.7.0"
+      }
+    ]
+  },
+  {
+    "id": "dd8073c5-c7c4-42c1-a0d7-cad8089de750",
+    "name": "io.github.kelvin6365/plane-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/kelvin6365/plane-mcp-server",
+      "source": "github",
+      "id": "953147035"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "plane-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "328e3069-005e-4179-add1-c13b18db4102",
+    "name": "io.github.executeautomation/mcp-playwright",
+    "description": "Playwright Model Context Protocol Server - Tool to automate Browsers and APIs in Claude Desktop, Cline, Cursor IDE and More 🔌",
+    "repository": {
+      "url": "https://github.com/executeautomation/mcp-playwright",
+      "source": "github",
+      "id": "898077246"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@executeautomation/playwright-mcp-server",
+        "version": "1.0.5"
+      }
+    ]
+  },
+  {
+    "id": "503a5c73-c147-4b2c-90d3-292378268706",
+    "name": "io.github.shannonlal/mcp-postman",
+    "description": "MCP Server for running Postman Collections with Newman",
+    "repository": {
+      "url": "https://github.com/shannonlal/mcp-postman",
+      "source": "github",
+      "id": "910565083"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-postman",
+        "version": "1.0.2"
+      }
+    ]
+  },
+  {
+    "id": "94872987-6992-4fec-ab4b-9ef5311b3108",
+    "name": "io.github.allen-munsch/mcp-prefect",
+    "description": "https://pypi.org/project/mcp-prefect/0.1.0/",
+    "repository": {
+      "url": "https://github.com/allen-munsch/mcp-prefect",
+      "source": "github",
+      "id": "956317848"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-prefect",
+        "version": "0.1.1"
+      }
+    ]
+  },
+  {
+    "id": "00613acb-73e2-4f93-8b96-296df17316c8",
+    "name": "io.github.kenjihikmatullah/productboard-mcp",
+    "description": "Integrate the Productboard API into agentic workflows via MCP",
+    "repository": {
+      "url": "https://github.com/kenjihikmatullah/productboard-mcp",
+      "source": "github",
+      "id": "939104710"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "productboard-mcp",
+        "version": "1.0.1",
+        "environment_variables": [
+          {
+            "description": "<YOUR_TOKEN>",
+            "name": "PRODUCTBOARD_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cf42caa8-50d1-489d-aa3c-3e8432efe9e2",
+    "name": "io.github.pab1it0/prometheus-mcp-server",
+    "description": "A Model Context Protocol (MCP) server that enables AI assistants to query and analyze Prometheus metrics through standardized interfaces.",
+    "repository": {
+      "url": "https://github.com/pab1it0/prometheus-mcp-server",
+      "source": "github",
+      "id": "951416232"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "prometheus_mcp_server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Automatically remove the container when it exits.",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Keep STDIN open even if not attached.",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "Set environment variable PROMETHEUS_URL inside the container.",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PROMETHEUS_URL",
+            "default": "-e PROMETHEUS_URL",
+            "type": "named",
+            "name": "-e PROMETHEUS_URL",
+            "value_hint": "PROMETHEUS_URL"
+          },
+          {
+            "description": "Set environment variable PROMETHEUS_USERNAME inside the container.",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PROMETHEUS_USERNAME",
+            "default": "-e PROMETHEUS_USERNAME",
+            "type": "named",
+            "name": "-e PROMETHEUS_USERNAME",
+            "value_hint": "PROMETHEUS_USERNAME"
+          },
+          {
+            "description": "Set environment variable PROMETHEUS_PASSWORD inside the container.",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PROMETHEUS_PASSWORD",
+            "default": "-e PROMETHEUS_PASSWORD",
+            "type": "named",
+            "name": "-e PROMETHEUS_PASSWORD",
+            "value_hint": "PROMETHEUS_PASSWORD"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "http://your-prometheus-server:9090",
+            "name": "PROMETHEUS_URL"
+          },
+          {
+            "description": "your_username",
+            "name": "PROMETHEUS_USERNAME"
+          },
+          {
+            "description": "your_password",
+            "name": "PROMETHEUS_PASSWORD"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "68966508-9094-4eb5-9588-ff7456d6c1ce",
+    "name": "io.github.sssjiang/pubchem_mcp_server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/sssjiang/pubchem_mcp_server",
+      "source": "github",
+      "id": "955038120"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "pubchem_mcp_server",
+        "version": "0.1.5"
+      }
+    ]
+  },
+  {
+    "id": "4f9043b6-e17a-494e-89d4-52c3f39999ac",
+    "name": "io.github.dogukanakkaya/pulumi-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/dogukanakkaya/pulumi-mcp-server",
+      "source": "github",
+      "id": "951615631"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "pulumi-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "-i",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "--rm",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "--name pulumi-mcp-server",
+            "is_required": true,
+            "format": "string",
+            "value": "--name pulumi-mcp-server",
+            "default": "--name pulumi-mcp-server",
+            "type": "named",
+            "name": "--name pulumi-mcp-server",
+            "value_hint": "pulumi-mcp-server"
+          },
+          {
+            "description": "-e PULUMI_ACCESS_TOKEN",
+            "is_required": true,
+            "format": "string",
+            "value": "-e PULUMI_ACCESS_TOKEN",
+            "default": "-e PULUMI_ACCESS_TOKEN",
+            "type": "named",
+            "name": "-e PULUMI_ACCESS_TOKEN",
+            "value_hint": "PULUMI_ACCESS_TOKEN"
+          },
+          {
+            "description": "dogukanakkaya/pulumi-mcp-server",
+            "is_required": true,
+            "format": "string",
+            "value": "dogukanakkaya/pulumi-mcp-server",
+            "default": "dogukanakkaya/pulumi-mcp-server",
+            "type": "positional",
+            "value_hint": "dogukanakkaya/pulumi-mcp-server"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "${YOUR_TOKEN}",
+            "name": "PULUMI_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7997496a-c366-4949-9ca7-6741bcfdf2a0",
+    "name": "io.github.djannot/puppeteer-vision-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/djannot/puppeteer-vision-mcp",
+      "source": "github",
+      "id": "982891249"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "puppeteer-vision-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "61ffe82e-5288-4af8-a45f-9a0907c941de",
+    "name": "io.github.ashiknesin/pushover-mcp",
+    "description": "A MCP implementation for sending notifications via Pushover",
+    "repository": {
+      "url": "https://github.com/AshikNesin/pushover-mcp",
+      "source": "github",
+      "id": "943326406"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:12:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "pushover-mcp",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "start",
+            "is_required": true,
+            "format": "string",
+            "value": "start",
+            "default": "start",
+            "type": "positional",
+            "value_hint": "start"
+          },
+          {
+            "description": "--token YOUR_TOKEN",
+            "is_required": true,
+            "format": "string",
+            "value": "--token YOUR_TOKEN",
+            "default": "--token YOUR_TOKEN",
+            "type": "named",
+            "name": "--token YOUR_TOKEN",
+            "value_hint": "YOUR_TOKEN"
+          },
+          {
+            "description": "--user YOUR_USER",
+            "is_required": true,
+            "format": "string",
+            "value": "--user YOUR_USER",
+            "default": "--user YOUR_USER",
+            "type": "named",
+            "name": "--user YOUR_USER",
+            "value_hint": "YOUR_USER"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "2e9aa092-56fc-4adb-93ba-e9c9d9919440",
+    "name": "io.github.jjsantos01/qgis_mcp",
+    "description": "Model Context Protocol (MCP) that allows LLMs to use QGIS Desktop",
+    "repository": {
+      "url": "https://github.com/jjsantos01/qgis_mcp",
+      "source": "github",
+      "id": "947538862"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:03Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "qgis-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Specifies the directory to run the command from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /ABSOLUTE/PATH/TO/PARENT/REPO/FOLDER/qgis_mcp/src/qgis_mcp",
+            "default": "--directory /ABSOLUTE/PATH/TO/PARENT/REPO/FOLDER/qgis_mcp/src/qgis_mcp",
+            "type": "named",
+            "name": "--directory /ABSOLUTE/PATH/TO/PARENT/REPO/FOLDER/qgis_mcp/src/qgis_mcp",
+            "value_hint": "/ABSOLUTE/PATH/TO/PARENT/REPO/FOLDER/qgis_mcp/src/qgis_mcp"
+          },
+          {
+            "description": "The Python script to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "qgis_mcp_server.py",
+            "default": "qgis_mcp_server.py",
+            "type": "positional",
+            "value_hint": "qgis_mcp_server.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "904d15ba-e312-4dec-88b6-f52c1077bc96",
+    "name": "io.github.gongrzhe/quickchart-mcp-server",
+    "description": "A Model Context Protocol server for generating charts using QuickChart.io  . It allows you to create various types of charts through MCP tools.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/Quickchart-MCP-Server",
+      "source": "github",
+      "id": "937569492"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@gongrzhe/quickchart-mcp-server",
+        "version": "1.0.6"
+      }
+    ]
+  },
+  {
+    "id": "92c66a82-172a-45e6-92a4-ee6a053e95e6",
+    "name": "io.github.66julienmartin/mcp-server-qwen_max",
+    "description": "MCP server for Qwen Max model",
+    "repository": {
+      "url": "https://github.com/66julienmartin/MCP-server-Qwen_Max",
+      "source": "github",
+      "id": "927217229"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:07Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "qwen_max",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your-api-key-here",
+            "name": "DASHSCOPE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "edf43b88-36a4-4f07-9d46-cab08bd418aa",
+    "name": "io.github.kenliao94/mcp-server-rabbitmq",
+    "description": "MCP server for interacting with RabbitMQ",
+    "repository": {
+      "url": "https://github.com/kenliao94/mcp-server-rabbitmq",
+      "source": "github",
+      "id": "910977229"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "mcp-server-rabbitmq",
+        "version": "2.0.0",
+        "package_arguments": [
+          {
+            "description": "Specify directory to run the package from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/repo/mcp-server-rabbitmq",
+            "default": "--directory /path/to/repo/mcp-server-rabbitmq",
+            "type": "named",
+            "name": "--directory /path/to/repo/mcp-server-rabbitmq",
+            "value_hint": "/path/to/repo/mcp-server-rabbitmq"
+          },
+          {
+            "description": "Package or script name to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-rabbitmq",
+            "default": "mcp-server-rabbitmq",
+            "type": "positional",
+            "value_hint": "mcp-server-rabbitmq"
+          },
+          {
+            "description": "RabbitMQ host name",
+            "is_required": true,
+            "format": "string",
+            "value": "--rabbitmq-host <hostname ex. test.rabbit.com, localhost>",
+            "default": "--rabbitmq-host <hostname ex. test.rabbit.com, localhost>",
+            "type": "named",
+            "name": "--rabbitmq-host <hostname ex. test.rabbit.com, localhost>",
+            "value_hint": "<hostname ex. test.rabbit.com, localhost>"
+          },
+          {
+            "description": "RabbitMQ port number",
+            "is_required": true,
+            "format": "string",
+            "value": "--port <port number ex. 5672>",
+            "default": "--port <port number ex. 5672>",
+            "type": "named",
+            "name": "--port <port number ex. 5672>",
+            "value_hint": "<port number ex. 5672>"
+          },
+          {
+            "description": "RabbitMQ username",
+            "is_required": true,
+            "format": "string",
+            "value": "--username <rabbitmq username>",
+            "default": "--username <rabbitmq username>",
+            "type": "named",
+            "name": "--username <rabbitmq username>",
+            "value_hint": "<rabbitmq username>"
+          },
+          {
+            "description": "RabbitMQ password",
+            "is_required": true,
+            "format": "string",
+            "value": "--password <rabbitmq password>",
+            "default": "--password <rabbitmq password>",
+            "type": "named",
+            "name": "--password <rabbitmq password>",
+            "value_hint": "<rabbitmq password>"
+          },
+          {
+            "description": "Whether to use TLS (amqps protocol)",
+            "is_required": true,
+            "format": "string",
+            "value": "--use-tls <true if uses amqps, false otherwise>",
+            "default": "--use-tls <true if uses amqps, false otherwise>",
+            "type": "named",
+            "name": "--use-tls <true if uses amqps, false otherwise>",
+            "value_hint": "<true if uses amqps, false otherwise>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "abcd869f-0159-408c-8965-9dbcc8c2d001",
+    "name": "io.github.apify/mcp-server-rag-web-browser",
+    "description": "A MCP Server for the RAG Web Browser Actor",
+    "repository": {
+      "url": "https://github.com/apify/mcp-server-rag-web-browser",
+      "source": "github",
+      "id": "899577906"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@apify/mcp-server-rag-web-browser",
+        "version": "0.1.3"
+      }
+    ]
+  },
+  {
+    "id": "ddfb0c36-c116-4333-a62e-c9447d699b6e",
+    "name": "io.github.hiromitsusasaki/raindrop-io-mcp-server",
+    "description": "An integration that allows LLMs to interact with Raindrop.io bookmarks using the Model Context Protocol (MCP).",
+    "repository": {
+      "url": "https://github.com/hiromitsusasaki/raindrop-io-mcp-server",
+      "source": "github",
+      "id": "914932138"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "raindrop-io-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "PATH_TO_BUILD/index.js",
+            "is_required": true,
+            "format": "string",
+            "value": "PATH_TO_BUILD/index.js",
+            "default": "PATH_TO_BUILD/index.js",
+            "type": "positional",
+            "value_hint": "PATH_TO_BUILD/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_access_token_here",
+            "name": "RAINDROP_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c214300b-5fcc-48fb-ad3a-bb2d14b0403d",
+    "name": "io.github.dschuler36/reaper-mcp-server",
+    "description": "An MCP Server for interacting with Reaper projects.",
+    "repository": {
+      "url": "https://github.com/dschuler36/reaper-mcp-server",
+      "source": "github",
+      "id": "917958763"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:19Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "reaper-mcp-server",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "01129bff-3d65-4e3d-8e82-6f2f269f818c",
+    "name": "io.github.gongrzhe/redis-mcp-server",
+    "description": "A Redis MCP server (pushed to https://github.com/modelcontextprotocol/servers/tree/main/src/redis) implementation for interacting with Redis databases. This server enables LLMs to interact with Redis key-value stores through a set of standardized tools.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/REDIS-MCP-Server",
+      "source": "github",
+      "id": "907849235"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:21Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@gongrzhe/server-redis-mcp",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Docker image to run",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp/redis",
+            "default": "mcp/redis",
+            "type": "positional",
+            "value_hint": "mcp/redis"
+          },
+          {
+            "description": "Redis server connection string",
+            "is_required": true,
+            "format": "string",
+            "value": "redis://host.docker.internal:6379",
+            "default": "redis://host.docker.internal:6379",
+            "type": "positional",
+            "value_hint": "host.docker.internal:6379"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8f234bf9-d65f-4406-bed6-f8217adee4c9",
+    "name": "io.github.prajwalnayak7/mcp-server-redis",
+    "description": "MCP server to interact with Redis Server, AWS Memory DB, etc for caching or other use-cases where in-memory and key-value based storage is appropriate",
+    "repository": {
+      "url": "https://github.com/prajwalnayak7/mcp-server-redis",
+      "source": "github",
+      "id": "925879641"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:24Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-redis",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "b5ee338d-655b-4067-9e17-f1bfc442a1eb",
+    "name": "io.github.skydeckai/mcp-server-rememberizer",
+    "description": "An MCP Server to enable global access to Rememberizer",
+    "repository": {
+      "url": "https://github.com/skydeckai/mcp-server-rememberizer",
+      "source": "github",
+      "id": "901090359"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:26Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-rememberizer",
+        "version": "0.1.5",
+        "environment_variables": [
+          {
+            "description": "your_rememberizer_api_token",
+            "name": "REMEMBERIZER_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ab0a0d85-7031-4eb0-bd01-5db69fb8c667",
+    "name": "io.github.deepfates/mcp-replicate",
+    "description": "Model Context Protocol server for Replicate's API",
+    "repository": {
+      "url": "https://github.com/deepfates/mcp-replicate",
+      "source": "github",
+      "id": "913589706"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:28Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-replicate",
+        "version": "0.1.1",
+        "environment_variables": [
+          {
+            "description": "your_token_here",
+            "name": "REPLICATE_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0c43f128-7589-4ce6-9382-5399ba24bebd",
+    "name": "io.github.xxxbrian/mcp-rquest",
+    "description": "A MCP server providing realistic browser-like HTTP request capabilities with accurate TLS/JA3/JA4 fingerprints for bypassing anti-bot measures. It also supports converting PDF and HTML documents to Markdown for easier processing by LLMs.",
+    "repository": {
+      "url": "https://github.com/xxxbrian/mcp-rquest",
+      "source": "github",
+      "id": "950863558"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-rquest",
+        "version": "0.1.13"
+      }
+    ]
+  },
+  {
+    "id": "6a64a548-c36c-400f-b43c-4d977aa1e482",
+    "name": "io.github.r-huijts/rijksmuseum-mcp",
+    "description": "Rijksmuseum MCP integration for artwork exploration and analysis",
+    "repository": {
+      "url": "https://github.com/r-huijts/rijksmuseum-mcp",
+      "source": "github",
+      "id": "907496920"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-rijksmuseum",
+        "version": "1.0.4",
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "RIJKSMUSEUM_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "87e2c1e7-4fdb-436f-b52c-af683f63fb1b",
+    "name": "io.github.jifrozen0110/mcp-riot",
+    "description": "League of Legends MCP Server",
+    "repository": {
+      "url": "https://github.com/jifrozen0110/mcp-riot",
+      "source": "github",
+      "id": "967790464"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "riot",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "938ee893-25dd-424a-88b4-7ebce53bcb22",
+    "name": "io.github.salesforce-mcp/salesforce-mcp",
+    "description": "Salesforce MCP",
+    "repository": {
+      "url": "https://github.com/salesforce-mcp/salesforce-mcp",
+      "source": "github",
+      "id": "973629838"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:37Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "salesforce-mcp/salesforce-mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Argument for source identifier",
+            "is_required": true,
+            "format": "string",
+            "value": "--from salesforce-mcp",
+            "default": "--from salesforce-mcp",
+            "type": "named",
+            "name": "--from salesforce-mcp",
+            "value_hint": "salesforce-mcp"
+          },
+          {
+            "description": "Target package or operation",
+            "is_required": true,
+            "format": "string",
+            "value": "salesforce",
+            "default": "salesforce",
+            "type": "positional",
+            "value_hint": "salesforce"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_SALESFORCE_USERNAME",
+            "name": "USERNAME"
+          },
+          {
+            "description": "YOUR_SALESFORCE_PASSWORD",
+            "name": "PASSWORD"
+          },
+          {
+            "description": "YOUR_SALESFORCE_SECURITY_TOKEN",
+            "name": "SECURITY_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "583f254e-410c-4dd4-a96c-8f362475436e",
+    "name": "io.github.rust-mcp-stack/rust-mcp-filesystem",
+    "description": "Blazing-fast, asynchronous MCP server for seamless filesystem operations.",
+    "repository": {
+      "url": "https://github.com/rust-mcp-stack/rust-mcp-filesystem",
+      "source": "github",
+      "id": "968849582"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:39Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "rust-mcp-stack/rust-mcp-filesystem",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "0e45cb5a-5b45-47f3-8b5e-12bdf88d176a",
+    "name": "io.github.smn2gnt/mcp-salesforce",
+    "description": "MCP Salesforce connector",
+    "repository": {
+      "url": "https://github.com/smn2gnt/MCP-Salesforce",
+      "source": "github",
+      "id": "904538810"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-salesforce-connector",
+        "version": "0.1.3"
+      }
+    ]
+  },
+  {
+    "id": "f43b2576-74d3-4b79-b9d0-0c5816835369",
+    "name": "io.github.adityak74/mcp-scholarly",
+    "description": "A MCP server to search for accurate academic articles.",
+    "repository": {
+      "url": "https://github.com/adityak74/mcp-scholarly",
+      "source": "github",
+      "id": "910698593"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:43Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-scholarly",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "874336ad-3dfa-467f-8356-3de7d8b2b93d",
+    "name": "io.github.cyberchitta/scrapling-fetch-mcp",
+    "description": "Helps AI assistants access text content from bot-protected websites. MCP server that fetches HTML/markdown from sites with anti-automation measures using Scrapling.",
+    "repository": {
+      "url": "https://github.com/cyberchitta/scrapling-fetch-mcp",
+      "source": "github",
+      "id": "947737843"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "scrapling-fetch-mcp",
+        "version": "0.1.6"
+      }
+    ]
+  },
+  {
+    "id": "02cdb980-1dcd-4345-a8d1-d3f3f522d04b",
+    "name": "io.github.ihor-sokoliuk/mcp-searxng",
+    "description": "MCP Server for SearXNG",
+    "repository": {
+      "url": "https://github.com/ihor-sokoliuk/mcp-searxng",
+      "source": "github",
+      "id": "907172461"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-searxng",
+        "version": "0.4.6",
+        "package_arguments": [
+          {
+            "description": "Run an image",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "Remove container after run",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Set environment variable in container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e SEARXNG_URL",
+            "default": "-e SEARXNG_URL",
+            "type": "named",
+            "name": "-e SEARXNG_URL",
+            "value_hint": "SEARXNG_URL"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_SEARXNG_INSTANCE_URL",
+            "name": "SEARXNG_URL"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8d526532-7125-4b3c-b180-901914ead390",
+    "name": "io.github.stefanoamorelli/sec-edgar-mcp",
+    "description": "A Model Context Protocol (MCP) Server for SEC EDGAR",
+    "repository": {
+      "url": "https://github.com/stefanoamorelli/sec-edgar-mcp",
+      "source": "github",
+      "id": "958733763"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "sec-edgar-mcp",
+        "version": "0.1.1"
+      }
+    ]
+  },
+  {
+    "id": "3f9a95e0-3a22-4ff8-8c92-60d89d847f5c",
+    "name": "io.github.osomai/servicenow-mcp",
+    "description": "MCP Server for ServiceNow",
+    "repository": {
+      "url": "https://github.com/osomai/servicenow-mcp",
+      "source": "github",
+      "id": "941149907"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:53Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "servicenow-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Python module execution flag and module name",
+            "is_required": true,
+            "format": "string",
+            "value": "-m servicenow_mcp.cli",
+            "default": "-m servicenow_mcp.cli",
+            "type": "positional",
+            "value_hint": "servicenow_mcp.cli"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "https://your-instance.service-now.com",
+            "name": "SERVICENOW_INSTANCE_URL"
+          },
+          {
+            "description": "your-username",
+            "name": "SERVICENOW_USERNAME"
+          },
+          {
+            "description": "your-password",
+            "name": "SERVICENOW_PASSWORD"
+          },
+          {
+            "description": "basic",
+            "name": "SERVICENOW_AUTH_TYPE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fcde90d4-5b99-4262-8101-7a507bf05915",
+    "name": "io.github.geli2001/shopify-mcp",
+    "description": "MCP server for Shopify api, usable on mcp clients such as Anthropic's Claude and Cursor IDE",
+    "repository": {
+      "url": "https://github.com/GeLi2001/shopify-mcp",
+      "source": "github",
+      "id": "958329576"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:55Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "shopify-mcp",
+        "version": "1.0.5",
+        "package_arguments": [
+          {
+            "description": "--accessToken <YOUR_ACCESS_TOKEN>",
+            "is_required": true,
+            "format": "string",
+            "value": "--accessToken <YOUR_ACCESS_TOKEN>",
+            "default": "--accessToken <YOUR_ACCESS_TOKEN>",
+            "type": "named",
+            "name": "--accessToken <YOUR_ACCESS_TOKEN>",
+            "value_hint": "<YOUR_ACCESS_TOKEN>"
+          },
+          {
+            "description": "--domain <YOUR_SHOP>.myshopify.com",
+            "is_required": true,
+            "format": "string",
+            "value": "--domain <YOUR_SHOP>.myshopify.com",
+            "default": "--domain <YOUR_SHOP>.myshopify.com",
+            "type": "named",
+            "name": "--domain <YOUR_SHOP>.myshopify.com",
+            "value_hint": "<YOUR_SHOP>.myshopify.com"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fbef362d-ba4b-4708-8579-332d2a57582d",
+    "name": "io.github.dvcrn/mcp-server-siri-shortcuts",
+    "description": "MCP for calling Siri Shorcuts from LLMs",
+    "repository": {
+      "url": "https://github.com/dvcrn/mcp-server-siri-shortcuts",
+      "source": "github",
+      "id": "938652536"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:13:57Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-server-siri-shortcuts",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "1e8b16b3-9182-43a9-b4c5-07fdf8032c89",
+    "name": "io.github.korotovsky/slack-mcp-server",
+    "description": "The most powerful MCP Slack Server with Stdio and SSE transports, Proxy support and no permission requirements on Slack Workspace! ",
+    "repository": {
+      "url": "https://github.com/korotovsky/slack-mcp-server",
+      "source": "github",
+      "id": "965085580"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "korotovsky/slack-mcp-server",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "The url endpoint to connect to",
+            "is_required": true,
+            "format": "string",
+            "value": "https://x.y.z.q:3001/sse",
+            "default": "https://x.y.z.q:3001/sse",
+            "type": "positional",
+            "value_hint": "https://x.y.z.q:3001/sse"
+          },
+          {
+            "description": "Add HTTP headers to the request",
+            "is_required": true,
+            "format": "string",
+            "value": "--header Authorization: Bearer ${SLACK_MCP_SSE_API_KEY}",
+            "default": "--header Authorization: Bearer ${SLACK_MCP_SSE_API_KEY}",
+            "type": "named",
+            "name": "--header Authorization: Bearer ${SLACK_MCP_SSE_API_KEY}",
+            "value_hint": "Authorization: Bearer ${SLACK_MCP_SSE_API_KEY}"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "my-$$e-$ecret",
+            "name": "SLACK_MCP_SSE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "61942e80-99c9-4856-90c8-5a11ac76ade5",
+    "name": "io.github.isaacwasserman/mcp-snowflake-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/isaacwasserman/mcp-snowflake-server",
+      "source": "github",
+      "id": "903050511"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp_snowflake_server",
+        "version": "0.4.0",
+        "package_arguments": [
+          {
+            "description": "--python=3.12",
+            "is_required": true,
+            "format": "string",
+            "value": "--python=3.12",
+            "default": "--python=3.12",
+            "type": "named",
+            "name": "--python=3.12",
+            "value_hint": "3.12"
+          },
+          {
+            "description": "--directory /absolute/path/to/mcp_snowflake_server",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /absolute/path/to/mcp_snowflake_server",
+            "default": "--directory /absolute/path/to/mcp_snowflake_server",
+            "type": "named",
+            "name": "--directory /absolute/path/to/mcp_snowflake_server",
+            "value_hint": "/absolute/path/to/mcp_snowflake_server"
+          },
+          {
+            "description": "mcp_snowflake_server",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp_snowflake_server",
+            "default": "mcp_snowflake_server",
+            "type": "positional",
+            "value_hint": "mcp_snowflake_server"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "523175e8-6767-4387-af85-a46f256a6390",
+    "name": "io.github.szeider/mcp-solver",
+    "description": "Model Context Protocol (MCP) server for constraint optimization and solving\"",
+    "repository": {
+      "url": "https://github.com/szeider/mcp-solver",
+      "source": "github",
+      "id": "903561149"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-solver",
+        "version": "3.2.0"
+      }
+    ]
+  },
+  {
+    "id": "387ef1e6-0e4c-43ea-9416-bf3b399a3c76",
+    "name": "io.github.yeonupark/mcp-soccer-data",
+    "description": "An MCP server that provides real-time football data based on the SoccerDataAPI.",
+    "repository": {
+      "url": "https://github.com/yeonupark/mcp-soccer-data",
+      "source": "github",
+      "id": "966702385"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-soccer-data",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "f25f6cdb-0623-4a04-bac2-f1b26331b432",
+    "name": "io.github.sendaifun/solana-agent-kit",
+    "description": "connect any ai agents to solana protocols",
+    "repository": {
+      "url": "https://github.com/sendaifun/solana-agent-kit",
+      "source": "github",
+      "id": "889798967"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "solana-agent-kit",
+        "version": "2.0.3"
+      }
+    ]
+  },
+  {
+    "id": "20c38c50-831e-478a-9f52-064d3ad8a6ce",
+    "name": "io.github.varunneal/spotify-mcp",
+    "description": "MCP to connect your LLM with Spotify.",
+    "repository": {
+      "url": "https://github.com/varunneal/spotify-mcp",
+      "source": "github",
+      "id": "896675928"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:13Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "spotify-mcp",
+        "version": "0.2.0",
+        "package_arguments": [
+          {
+            "description": "Set the working directory",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /path/to/spotify_mcp",
+            "default": "--directory /path/to/spotify_mcp",
+            "type": "named",
+            "name": "--directory /path/to/spotify_mcp",
+            "value_hint": "/path/to/spotify_mcp"
+          },
+          {
+            "description": "Program to run",
+            "is_required": true,
+            "format": "string",
+            "value": "spotify-mcp",
+            "default": "spotify-mcp",
+            "type": "positional",
+            "value_hint": "spotify-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "YOUR_CLIENT_ID",
+            "name": "SPOTIFY_CLIENT_ID"
+          },
+          {
+            "description": "YOUR_CLIENT_SECRET",
+            "name": "SPOTIFY_CLIENT_SECRET"
+          },
+          {
+            "description": "http://127.0.0.1:8080/callback",
+            "name": "SPOTIFY_REDIRECT_URI"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8a0bb0a3-74c3-41c1-9b9f-2974dd1576fe",
+    "name": "io.github.boston343/starwind-ui-mcp",
+    "description": "Local MCP server implementation for Starwind UI that you can use with Cursor, Windsurf, and other AI tools",
+    "repository": {
+      "url": "https://github.com/starwind-ui/starwind-ui-mcp",
+      "source": "github",
+      "id": "948419950"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:15Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@starwind-ui/mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "09a2ecf8-1774-490e-8542-2b25a6445a58",
+    "name": "io.github.r-huijts/strava-mcp",
+    "description": "A Model Context Protocol (MCP) server that connects to Strava API, providing tools to access Strava data through LLMs",
+    "repository": {
+      "url": "https://github.com/r-huijts/strava-mcp",
+      "source": "github",
+      "id": "961429605"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "strava-mcp-server",
+        "version": "1.0.0"
+      }
+    ]
+  },
+  {
+    "id": "e532ff07-269a-47fb-98ad-6315d7081ccb",
+    "name": "io.github.atharvagupta2003/mcp-stripe",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/atharvagupta2003/mcp-stripe",
+      "source": "github",
+      "id": "928410809"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-stripe",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "charge_id argument",
+            "is_required": true,
+            "format": "string",
+            "value": "charge_id ch_abc123",
+            "default": "charge_id ch_abc123",
+            "type": "named",
+            "name": "charge_id ch_abc123",
+            "value_hint": "ch_abc123"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0b245c5f-ba2b-4e8d-b9db-26681b0fa2e3",
+    "name": "io.github.wilsonchenghy/shadertoy-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/wilsonchenghy/ShaderToy-MCP",
+      "source": "github",
+      "id": "958998300"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:23Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "wilsonchenghy/ShaderToy-MCP",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Use with optional extra dependencies",
+            "is_required": true,
+            "format": "string",
+            "value": "--with mcp[cli]",
+            "default": "--with mcp[cli]",
+            "type": "named",
+            "name": "--with mcp[cli]",
+            "value_hint": "mcp[cli]"
+          },
+          {
+            "description": "Specify mcp command",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          },
+          {
+            "description": "Path to the ShaderToy-MCP server script",
+            "is_required": true,
+            "format": "string",
+            "value": "<path_to_project>/ShaderToy-MCP/src/ShaderToy-MCP/server.py",
+            "default": "<path_to_project>/ShaderToy-MCP/src/ShaderToy-MCP/server.py",
+            "type": "positional",
+            "value_hint": "<path_to_project>/ShaderToy-MCP/src/ShaderToy-MCP/server.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_actual_api_key",
+            "name": "SHADERTOY_APP_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "9826cb7a-bc6f-41d9-b9b7-f76f781c1eca",
+    "name": "io.github.sonnylazuardi/cursor-talk-to-figma-mcp",
+    "description": "Cursor Talk To Figma MCP",
+    "repository": {
+      "url": "https://github.com/sonnylazuardi/cursor-talk-to-figma-mcp",
+      "source": "github",
+      "id": "949523404"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "cursor-talk-to-figma-mcp",
+        "version": "0.2.1"
+      }
+    ]
+  },
+  {
+    "id": "ff2b0e88-9426-4aa1-bfb1-165cc810344f",
+    "name": "io.github.laksh-star/mcp-server-tmdb",
+    "description": "MCP Server with TMDB",
+    "repository": {
+      "url": "https://github.com/Laksh-star/mcp-server-tmdb",
+      "source": "github",
+      "id": "901420381"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-tmdb",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "TMDB_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bdeb1cca-49ce-476a-87a2-f27c30b086bd",
+    "name": "io.github.ramxx/mcp-tavily",
+    "description": "An MCP server for Tavily's search API",
+    "repository": {
+      "url": "https://github.com/RamXX/mcp-tavily",
+      "source": "github",
+      "id": "896967375"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp_tavily",
+        "version": "0.1.8",
+        "package_arguments": [
+          {
+            "description": "Python module execution: -m mcp_server_tavily",
+            "is_required": true,
+            "format": "string",
+            "value": "-m mcp_server_tavily",
+            "default": "-m mcp_server_tavily",
+            "type": "named",
+            "name": "-m mcp_server_tavily",
+            "value_hint": "mcp_server_tavily"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "TAVILY_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "",
+    "name": "",
+    "description": "",
+    "repository": {
+      "url": "",
+      "source": "",
+      "id": ""
+    },
+    "version_detail": {
+      "version": "",
+      "release_date": "",
+      "is_latest": false
+    }
+  },
+  {
+    "id": "0cd13ce0-2f67-414a-afb1-4e11dd3e4cba",
+    "name": "io.github.chaindead/telegram-mcp",
+    "description": "Telegram MCP for managing dialogs, messages, drafts, read statuses, and more.",
+    "repository": {
+      "url": "https://github.com/chaindead/telegram-mcp",
+      "source": "github",
+      "id": "958652024"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:34Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "chaindead/telegram-mcp",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "<your-app-id>",
+            "name": "TG_APP_ID"
+          },
+          {
+            "description": "<your-api-hash>",
+            "name": "TG_API_HASH"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cb9e2dc2-e335-4271-8e8d-5aff43cd389b",
+    "name": "io.github.arturborycki/mcp-teradata",
+    "description": "MCP Server for Teradata database",
+    "repository": {
+      "url": "https://github.com/arturborycki/mcp-teradata",
+      "source": "github",
+      "id": "970353793"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "teradata-mcp",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "6275eefc-3f97-4a30-85ca-9678de62bdcf",
+    "name": "io.github.gongrzhe/terminal-controller-mcp",
+    "description": "A Model Context Protocol (MCP) server that enables secure terminal command execution, directory navigation, and file system operations through a standardized interface.",
+    "repository": {
+      "url": "https://github.com/GongRzhe/terminal-controller-mcp",
+      "source": "github",
+      "id": "938867662"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "terminal-controller",
+        "version": "0.1.8",
+        "package_arguments": [
+          {
+            "description": "Positional module argument to run the module terminal_controller with python",
+            "is_required": true,
+            "format": "string",
+            "value": "-m terminal_controller",
+            "default": "-m terminal_controller",
+            "type": "named",
+            "name": "-m terminal_controller",
+            "value_hint": "terminal_controller"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1aa1e801-80d9-4ea1-80c2-e7d037ce98e3",
+    "name": "io.github.geli2001/tft-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/GeLi2001/tft-mcp-server",
+      "source": "github",
+      "id": "957763921"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:41Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "mcp-server-tft",
+        "version": "0.1.3",
+        "package_arguments": [
+          {
+            "description": "<YOUR_RIOT_API_KEY>",
+            "is_required": true,
+            "format": "string",
+            "value": "--apiKey <YOUR_RIOT_API_KEY>",
+            "default": "--apiKey <YOUR_RIOT_API_KEY>",
+            "type": "named",
+            "name": "--apiKey <YOUR_RIOT_API_KEY>",
+            "value_hint": "<YOUR_RIOT_API_KEY>"
+          },
+          {
+            "description": "<YOUR_GAME_NAME>",
+            "is_required": true,
+            "format": "string",
+            "value": "--gameName <YOUR_GAME_NAME>",
+            "default": "--gameName <YOUR_GAME_NAME>",
+            "type": "named",
+            "name": "--gameName <YOUR_GAME_NAME>",
+            "value_hint": "<YOUR_GAME_NAME>"
+          },
+          {
+            "description": "<YOUR_TAG_LINE>",
+            "is_required": true,
+            "format": "string",
+            "value": "--tagLine <YOUR_TAG_LINE>",
+            "default": "--tagLine <YOUR_TAG_LINE>",
+            "type": "named",
+            "name": "--tagLine <YOUR_TAG_LINE>",
+            "value_hint": "<YOUR_TAG_LINE>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ea41dc54-96fd-41db-90ec-92a1a45e7151",
+    "name": "io.github.kukapay/thegraph-mcp",
+    "description": "An MCP server that powers AI agents with indexed blockchain data from The Graph.",
+    "repository": {
+      "url": "https://github.com/kukapay/thegraph-mcp",
+      "source": "github",
+      "id": "952738950"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "thegraph-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Specifies the directory to run the application from",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/thegraph-mcp",
+            "default": "--directory path/to/thegraph-mcp",
+            "type": "named",
+            "name": "--directory path/to/thegraph-mcp",
+            "value_hint": "path/to/thegraph-mcp"
+          },
+          {
+            "description": "Main python file to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "main.py",
+            "default": "main.py",
+            "type": "positional",
+            "value_hint": "main.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "THEGRAPH_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7f7268e0-670a-4630-83da-acc1090264c3",
+    "name": "io.github.delorenj/mcp-server-ticketmaster",
+    "description": "A Ticketmaster MCP server that provides query capabilites from the Discovery API",
+    "repository": {
+      "url": "https://github.com/delorenj/mcp-server-ticketmaster",
+      "source": "github",
+      "id": "918433694"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@delorenj/mcp-server-ticketmaster",
+        "version": "0.2.5",
+        "environment_variables": [
+          {
+            "description": "your-api-key-here",
+            "name": "TICKETMASTER_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5c1709d9-3f57-4dbd-a727-5ce383a59c32",
+    "name": "io.github.alexarevalo9/ticktick-mcp-server",
+    "description": "A Model Context Protocol (MCP) server designed to integrate with the TickTick task management platform, enabling intelligent context-aware task operations and automation.",
+    "repository": {
+      "url": "https://github.com/alexarevalo9/ticktick-mcp-server",
+      "source": "github",
+      "id": "957668156"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "@alexarevalo.ai/mcp-server-ticktick",
+        "version": "1.1.9",
+        "package_arguments": [
+          {
+            "description": "Run container in interactive mode",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i",
+            "value_hint": "-i"
+          },
+          {
+            "description": "Automatically remove the container when it exits",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm",
+            "value_hint": "--rm"
+          },
+          {
+            "description": "Set the TICKTICK_CLIENT_ID environment variable in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e TICKTICK_CLIENT_ID",
+            "default": "-e TICKTICK_CLIENT_ID",
+            "type": "named",
+            "name": "-e TICKTICK_CLIENT_ID",
+            "value_hint": "TICKTICK_CLIENT_ID"
+          },
+          {
+            "description": "Set the TICKTICK_CLIENT_SECRET environment variable in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e TICKTICK_CLIENT_SECRET",
+            "default": "-e TICKTICK_CLIENT_SECRET",
+            "type": "named",
+            "name": "-e TICKTICK_CLIENT_SECRET",
+            "value_hint": "TICKTICK_CLIENT_SECRET"
+          },
+          {
+            "description": "Set the TICKTICK_ACCESS_TOKEN environment variable in the container",
+            "is_required": true,
+            "format": "string",
+            "value": "-e TICKTICK_ACCESS_TOKEN",
+            "default": "-e TICKTICK_ACCESS_TOKEN",
+            "type": "named",
+            "name": "-e TICKTICK_ACCESS_TOKEN",
+            "value_hint": "TICKTICK_ACCESS_TOKEN"
+          },
+          {
+            "description": "Docker image name",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp/ticktick",
+            "default": "mcp/ticktick",
+            "type": "positional",
+            "value_hint": "mcp/ticktick"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "<YOUR_CLIENT_ID>",
+            "name": "TICKTICK_CLIENT_ID"
+          },
+          {
+            "description": "<YOUR_CLIENT_SECRET>",
+            "name": "TICKTICK_CLIENT_SECRET"
+          },
+          {
+            "description": "<YOUR_ACCESS_TOKEN>",
+            "name": "TICKTICK_ACCESS_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f79220af-20c6-4d21-b4f6-13f176b7f1d8",
+    "name": "io.github.abhiz123/todoist-mcp-server",
+    "description": "MCP server for Todoist integration enabling natural language task management with Claude",
+    "repository": {
+      "url": "https://github.com/abhiz123/todoist-mcp-server",
+      "source": "github",
+      "id": "898075293"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:56Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@abhiz123/todoist-mcp-server",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your_api_token_here",
+            "name": "TODOIST_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "10bb9deb-9384-4e4d-935e-9d830015a43e",
+    "name": "io.github.kukapay/token-minter-mcp",
+    "description": "An MCP server providing tools for AI agents to mint ERC-20 tokens across multiple blockchains.",
+    "repository": {
+      "url": "https://github.com/kukapay/token-minter-mcp",
+      "source": "github",
+      "id": "951336068"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:14:59Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "token-minter-mcp",
+        "version": "1.0.1",
+        "package_arguments": [
+          {
+            "description": "Path to the server entry point",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/token-minter-mcp/server/index.js",
+            "default": "path/to/token-minter-mcp/server/index.js",
+            "type": "positional",
+            "value_hint": "path/to/token-minter-mcp/server/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your infura key",
+            "name": "INFURA_KEY"
+          },
+          {
+            "description": "your private key",
+            "name": "PRIVATE_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "4bd856fc-761e-43e3-9236-7b996b6b7ec7",
+    "name": "io.github.kukapay/token-revoke-mcp",
+    "description": "An MCP server for checking and revoking ERC-20 token allowances across multiple blockchains.",
+    "repository": {
+      "url": "https://github.com/kukapay/token-revoke-mcp",
+      "source": "github",
+      "id": "956577908"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:01Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "token-revoke-mcp",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "your moralis api key",
+            "name": "MORALIS_API_KEY"
+          },
+          {
+            "description": "your wallet private key",
+            "name": "PRIVATE_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a038d159-c51e-49ef-aa02-c794e8a5cb94",
+    "name": "io.github.suhail-ak-s/mcp-typesense-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/suhail-ak-s/mcp-typesense-server",
+      "source": "github",
+      "id": "940089654"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "typesense-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "The Typesense server host",
+            "is_required": true,
+            "format": "string",
+            "value": "--host your-typesense-host",
+            "default": "--host your-typesense-host",
+            "type": "named",
+            "name": "--host your-typesense-host",
+            "value_hint": "your-typesense-host"
+          },
+          {
+            "description": "The Typesense server port",
+            "is_required": true,
+            "format": "string",
+            "value": "--port 8108",
+            "default": "--port 8108",
+            "type": "named",
+            "name": "--port 8108",
+            "value_hint": "8108"
+          },
+          {
+            "description": "The Typesense server protocol",
+            "is_required": true,
+            "format": "string",
+            "value": "--protocol http",
+            "default": "--protocol http",
+            "type": "named",
+            "name": "--protocol http",
+            "value_hint": "http"
+          },
+          {
+            "description": "The Typesense API key",
+            "is_required": true,
+            "format": "string",
+            "value": "--api-key your-api-key",
+            "default": "--api-key your-api-key",
+            "type": "named",
+            "name": "--api-key your-api-key",
+            "value_hint": "your-api-key"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "7d8aa739-c9c6-4afd-991b-cf425be475db",
+    "name": "io.github.gongrzhe/travel-planner-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/GongRzhe/TRAVEL-PLANNER-MCP-Server",
+      "source": "github",
+      "id": "907849260"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@gongrzhe/server-travelplanner-mcp",
+        "version": "0.1.2",
+        "environment_variables": [
+          {
+            "description": "your_google_maps_api_key",
+            "name": "GOOGLE_MAPS_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1ff3b09d-5c19-4254-849f-34244dc6ee88",
+    "name": "io.github.kukapay/uniswap-poolspy-mcp",
+    "description": "An MCP server that tracks newly created liquidity pools on Uniswap across nine blockchain networks.",
+    "repository": {
+      "url": "https://github.com/kukapay/uniswap-poolspy-mcp",
+      "source": "github",
+      "id": "950939450"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:09Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "uniswap-poolspy-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "run main.py",
+            "default": "run main.py",
+            "type": "positional",
+            "value_hint": "main.py"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your api key from The Graph",
+            "name": "THEGRAPH_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "1dd6d7a5-ba98-4fce-b4a4-d0541df84569",
+    "name": "io.github.kukapay/uniswap-trader-mcp",
+    "description": "An MCP server for AI agents to automate token swaps on Uniswap DEX across multiple blockchains.",
+    "repository": {
+      "url": "https://github.com/kukapay/uniswap-trader-mcp",
+      "source": "github",
+      "id": "952312114"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "uniswap-trader-mcp",
+        "version": "1.0.1",
+        "package_arguments": [
+          {
+            "description": "Path to main entry file",
+            "is_required": true,
+            "format": "string",
+            "value": "path/to/uniswap-trader-mcp/server/index.js",
+            "default": "path/to/uniswap-trader-mcp/server/index.js",
+            "type": "positional",
+            "value_hint": "path/to/uniswap-trader-mcp/server/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your infura key",
+            "name": "INFURA_KEY"
+          },
+          {
+            "description": "your private key",
+            "name": "WALLET_PRIVATE_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "51d74701-2a57-476f-a5ed-75a93be58f42",
+    "name": "io.github.ognis1205/mcp-server-unitycatalog",
+    "description": "Unity Catalog AI Model Context Protocol Server",
+    "repository": {
+      "url": "https://github.com/ognis1205/mcp-server-unitycatalog",
+      "source": "github",
+      "id": "926414362"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:16Z",
+      "is_latest": true
+    },
+    "package_canonical": "docker",
+    "packages": [
+      {
+        "registry_name": "docker",
+        "name": "mcp-server-unitycatalog",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Remove container after run",
+            "is_required": true,
+            "format": "string",
+            "value": "--rm",
+            "default": "--rm",
+            "type": "named",
+            "name": "--rm"
+          },
+          {
+            "description": "Keep STDIN open even if not attached",
+            "is_required": true,
+            "format": "string",
+            "value": "-i",
+            "default": "-i",
+            "type": "named",
+            "name": "-i"
+          },
+          {
+            "description": "Specify Unity Catalog server URL",
+            "is_required": true,
+            "format": "string",
+            "value": "--uc_server <your unity catalog url>",
+            "default": "--uc_server <your unity catalog url>",
+            "type": "named",
+            "name": "--uc_server <your unity catalog url>",
+            "value_hint": "<your unity catalog url>"
+          },
+          {
+            "description": "Specify Unity Catalog name",
+            "is_required": true,
+            "format": "string",
+            "value": "--uc_catalog <your catalog name>",
+            "default": "--uc_catalog <your catalog name>",
+            "type": "named",
+            "name": "--uc_catalog <your catalog name>",
+            "value_hint": "<your catalog name>"
+          },
+          {
+            "description": "Specify Unity Catalog schema name",
+            "is_required": true,
+            "format": "string",
+            "value": "--uc_schema <your schema name>",
+            "default": "--uc_schema <your schema name>",
+            "type": "named",
+            "name": "--uc_schema <your schema name>",
+            "value_hint": "<your schema name>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "3cccaee3-1b35-4a97-bc23-d1a8603aa366",
+    "name": "io.github.codergamester/mcp-unity",
+    "description": "MCP Server to integrate Unity Editor game engine with different AI Model clients (e.g. Claude Desktop, Windsurf, Cursor)",
+    "repository": {
+      "url": "https://github.com/CoderGamester/mcp-unity",
+      "source": "github",
+      "id": "948148972"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "com.gamelovers.mcp-unity",
+        "version": "1.0.2"
+      }
+    ]
+  },
+  {
+    "id": "162d7f33-0f96-47d7-980b-361fb0ddc381",
+    "name": "io.github.quazaai/unitymcpintegration",
+    "description": "Enable AI Agents to Control Unity",
+    "repository": {
+      "url": "https://github.com/quazaai/UnityMCPIntegration",
+      "source": "github",
+      "id": "950083186"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "com.quaza.unitymcp",
+        "version": "0.0.1",
+        "environment_variables": [
+          {
+            "description": "5010",
+            "name": "MCP_WEBSOCKET_PORT"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "aa301cee-889b-4606-b66b-fd9dc1e77817",
+    "name": "io.github.isaacwasserman/mcp-vegalite-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/isaacwasserman/mcp-vegalite-server",
+      "source": "github",
+      "id": "902526658"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-vegalite",
+        "version": "0.0.1"
+      }
+    ]
+  },
+  {
+    "id": "6b136dc5-ffcf-41b0-bf5f-e5dff5d47981",
+    "name": "io.github.burningion/video-editing-mcp",
+    "description": "MCP Interface for Video Jungle",
+    "repository": {
+      "url": "https://github.com/burningion/video-editing-mcp",
+      "source": "github",
+      "id": "898031405"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:26Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "video-editor-mcp",
+        "version": "0.1.25",
+        "package_arguments": [
+          {
+            "description": "Directory to use",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory /Users/<PATH_TO>/video-jungle-mcp",
+            "default": "--directory /Users/<PATH_TO>/video-jungle-mcp",
+            "type": "named",
+            "name": "--directory /Users/<PATH_TO>/video-jungle-mcp",
+            "value_hint": "/Users/<PATH_TO>/video-jungle-mcp"
+          },
+          {
+            "description": "Script or module name",
+            "is_required": true,
+            "format": "string",
+            "value": "video-editor-mcp",
+            "default": "video-editor-mcp",
+            "type": "positional",
+            "value_hint": "video-editor-mcp"
+          },
+          {
+            "description": "API Key input",
+            "is_required": true,
+            "format": "string",
+            "value": "<YOURAPIKEY>",
+            "default": "<YOURAPIKEY>",
+            "type": "positional",
+            "value_hint": "<YOURAPIKEY>"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "1",
+            "name": "LOAD_PHOTOS_DB"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "cbc3c68c-82c8-4a9f-86b9-78e3893df494",
+    "name": "io.github.13rac1/videocapture-mcp",
+    "description": "Model Context Protocol (MCP) server to capture images from an OpenCV-compatible webcam or video source",
+    "repository": {
+      "url": "https://github.com/13rac1/videocapture-mcp",
+      "source": "github",
+      "id": "956274853"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:30Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "videocapture-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Use extra requirements with package",
+            "is_required": true,
+            "format": "string",
+            "value": "--with mcp[cli]",
+            "default": "--with mcp[cli]",
+            "type": "named",
+            "name": "--with mcp[cli]",
+            "value_hint": "mcp[cli]"
+          },
+          {
+            "description": "Use extra requirements with package",
+            "is_required": true,
+            "format": "string",
+            "value": "--with numpy",
+            "default": "--with numpy",
+            "type": "named",
+            "name": "--with numpy",
+            "value_hint": "numpy"
+          },
+          {
+            "description": "Use extra requirements with package",
+            "is_required": true,
+            "format": "string",
+            "value": "--with opencv-python",
+            "default": "--with opencv-python",
+            "type": "named",
+            "name": "--with opencv-python",
+            "value_hint": "opencv-python"
+          },
+          {
+            "description": "MCP run command",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp",
+            "default": "mcp",
+            "type": "positional",
+            "value_hint": "mcp"
+          },
+          {
+            "description": "Path to script",
+            "is_required": true,
+            "format": "string",
+            "value": "C:\\ABSOLUTE_PATH\\videocapture-mcp\\videocapture_mcp.py",
+            "default": "C:\\ABSOLUTE_PATH\\videocapture-mcp\\videocapture_mcp.py",
+            "type": "positional",
+            "value_hint": "C:\\ABSOLUTE_PATH\\videocapture-mcp\\videocapture_mcp.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "8b5bb45d-a025-4e7b-a185-dbb5e349af32",
+    "name": "io.github.mfukushim/map-traveler-mcp",
+    "description": "Virtual traveler library for MCP",
+    "repository": {
+      "url": "https://github.com/mfukushim/map-traveler-mcp",
+      "source": "github",
+      "id": "911417007"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:32Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@mfukushim/map-traveler-mcp",
+        "version": "0.0.77",
+        "environment_variables": [
+          {
+            "description": "http://192.168.1.100:8188",
+            "name": "comfy_url"
+          },
+          {
+            "description": "C:\\Documents\\t2itest.json",
+            "name": "comfy_workflow_t2i"
+          },
+          {
+            "description": "C:\\Documents\\i2itest.json",
+            "name": "comfy_workflow_i2i"
+          },
+          {
+            "description": "ckpt_name='animagineXL40_v40.safetensors',denoise=0.65",
+            "name": "comfy_params"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5f14d558-f478-43b5-8dde-20c9997f196a",
+    "name": "io.github.dinghuazhou/sample-mcp-server-tos",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/dinghuazhou/sample-mcp-server-tos",
+      "source": "github",
+      "id": "947289080"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-server-tos",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "Git repository URL with subdirectory parameter",
+            "is_required": true,
+            "format": "string",
+            "value": "git+https://github.com/volcengine/ai-app-lab#subdirectory=mcp/server/mcp_server_tos",
+            "default": "git+https://github.com/volcengine/ai-app-lab#subdirectory=mcp/server/mcp_server_tos",
+            "type": "positional",
+            "value_hint": "git+https://github.com/volcengine/ai-app-lab#subdirectory=mcp/server/mcp_server_tos"
+          },
+          {
+            "description": "Server entry point",
+            "is_required": true,
+            "format": "string",
+            "value": "mcp-server-tos",
+            "default": "mcp-server-tos",
+            "type": "positional",
+            "value_hint": "mcp-server-tos"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your ak",
+            "name": "VOLC_ACCESSKEY"
+          },
+          {
+            "description": "your sk",
+            "name": "VOLC_SECRETKEY"
+          },
+          {
+            "description": "tos region",
+            "name": "REGION"
+          },
+          {
+            "description": "tos endpoint",
+            "name": "TOS_ENDPOINT"
+          },
+          {
+            "description": "your security token",
+            "name": "SECURITY_TOKEN"
+          },
+          {
+            "description": "your specific bucket",
+            "name": "TOS_BUCKET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "f3285cc9-1d33-472f-aa28-0b9d7723f877",
+    "name": "io.github.wanaku-ai/wanaku",
+    "description": "Wanaku MCP Router",
+    "repository": {
+      "url": "https://github.com/wanaku-ai/wanaku",
+      "source": "github",
+      "id": "925674818"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "wanaku-ai/wanaku",
+        "version": "",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c7876b07-1fe3-4006-a104-93ef9f9e1669",
+    "name": "io.github.kapilduraphe/webflow-mcp-server",
+    "description": "Webflow MCP server",
+    "repository": {
+      "url": "https://github.com/kapilduraphe/webflow-mcp-server",
+      "source": "github",
+      "id": "935070409"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "webflow-mcp-server",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "Path to the entry point script",
+            "is_required": true,
+            "format": "string",
+            "value": "/ABSOLUTE/PATH/TO/YOUR/build/index.js",
+            "default": "/ABSOLUTE/PATH/TO/YOUR/build/index.js",
+            "type": "positional",
+            "value_hint": "/ABSOLUTE/PATH/TO/YOUR/build/index.js"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your-api-token",
+            "name": "WEBFLOW_API_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e69c8abd-6964-48b1-a7cb-89c926932c47",
+    "name": "io.github.kukapay/whale-tracker-mcp",
+    "description": "A mcp server for tracking cryptocurrency whale transactions.",
+    "repository": {
+      "url": "https://github.com/kukapay/whale-tracker-mcp",
+      "source": "github",
+      "id": "948027955"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "whale-tracker-mcp",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0d2cbcc1-4b34-4b2b-af66-595d8fb5e78a",
+    "name": "io.github.lharries/whatsapp-mcp",
+    "description": "WhatsApp MCP server",
+    "repository": {
+      "url": "https://github.com/lharries/whatsapp-mcp",
+      "source": "github",
+      "id": "957053334"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:45Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "lharries/whatsapp-mcp",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "Directory to run in",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory {{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server",
+            "default": "--directory {{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server",
+            "type": "named",
+            "name": "--directory {{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server",
+            "value_hint": "{{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server"
+          },
+          {
+            "description": "Main Python file",
+            "is_required": true,
+            "format": "string",
+            "value": "main.py",
+            "default": "main.py",
+            "type": "positional",
+            "value_hint": "main.py"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "5f5a497c-673d-4988-b86b-c3bcaaf1a317",
+    "name": "io.github.bharathvaj-ganesan/whois-mcp",
+    "description": "MCP Server for whois lookups.",
+    "repository": {
+      "url": "https://github.com/bharathvaj-ganesan/whois-mcp",
+      "source": "github",
+      "id": "943452732"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:47Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@bharathvaj/whois-mcp",
+        "version": "1.0.1"
+      }
+    ]
+  },
+  {
+    "id": "02b79b89-cce8-4401-aa1f-255b01587266",
+    "name": "io.github.zzaebok/mcp-wikidata",
+    "description": "A server implementation for Wikidata API using the Model Context Protocol (MCP).",
+    "repository": {
+      "url": "https://github.com/zzaebok/mcp-wikidata",
+      "source": "github",
+      "id": "959274715"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:49Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-wikidata",
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "id": "598ea4ee-6e94-49b7-abce-c53b6b2b22f7",
+    "name": "io.github.wildfly-extras/wildfly-mcp",
+    "description": "WildFly MCP server and other tooling to integrate WildFly in AI space",
+    "repository": {
+      "url": "https://github.com/wildfly-extras/wildfly-mcp",
+      "source": "github",
+      "id": "919946635"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:51Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "wildfly-extras/wildfly-mcp",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "a8a08cbd-074f-49ba-8f98-3ef8583cc93b",
+    "name": "io.github.simonb97/win-cli-mcp-server",
+    "description": "Model Context Protocol server for secure command-line interactions on Windows systems",
+    "repository": {
+      "url": "https://github.com/SimonB97/win-cli-mcp-server",
+      "source": "github",
+      "id": "898475770"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@simonb97/server-win-cli",
+        "version": "0.2.0"
+      }
+    ]
+  },
+  {
+    "id": "4e6fc5a4-eecb-46e4-a3ce-4310cbb8c3f4",
+    "name": "io.github.anshumax/world_bank_mcp_server",
+    "description": "An implementation of the Model Context Protocol for the World Bank open data API",
+    "repository": {
+      "url": "https://github.com/anshumax/world_bank_mcp_server",
+      "source": "github",
+      "id": "911984754"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:56Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "world_bank_mcp_server",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "description": "The directory to use",
+            "is_required": true,
+            "format": "string",
+            "value": "--directory path/to/world_bank_mcp_server",
+            "default": "--directory path/to/world_bank_mcp_server",
+            "type": "named",
+            "name": "--directory path/to/world_bank_mcp_server",
+            "value_hint": "path/to/world_bank_mcp_server"
+          },
+          {
+            "description": "The server script/module to execute",
+            "is_required": true,
+            "format": "string",
+            "value": "world_bank_mcp_server",
+            "default": "world_bank_mcp_server",
+            "type": "positional",
+            "value_hint": "world_bank_mcp_server"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ccb9aa0c-bbf5-46e6-a5f0-a5b4c11d519a",
+    "name": "io.github.enescinr/twitter-mcp",
+    "description": "A Model Context Protocol server allows to interact with Twitter, enabling posting tweets and searching Twitter.",
+    "repository": {
+      "url": "https://github.com/EnesCinr/twitter-mcp",
+      "source": "github",
+      "id": "901627660"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:15:58Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@enescinar/twitter-mcp",
+        "version": "0.1.0",
+        "environment_variables": [
+          {
+            "description": "your_api_key_here",
+            "name": "API_KEY"
+          },
+          {
+            "description": "your_api_secret_key_here",
+            "name": "API_SECRET_KEY"
+          },
+          {
+            "description": "your_access_token_here",
+            "name": "ACCESS_TOKEN"
+          },
+          {
+            "description": "your_access_token_secret_here",
+            "name": "ACCESS_TOKEN_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a24e506b-b16b-412d-b806-fcf7e39b4549",
+    "name": "io.github.vidhupv/x-mcp",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/vidhupv/x-mcp",
+      "source": "github",
+      "id": "898698501"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "pypi",
+    "packages": [
+      {
+        "registry_name": "pypi",
+        "name": "x-mcp",
+        "version": "0.1.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "x-mcp",
+            "default": "x-mcp",
+            "type": "positional",
+            "value_hint": "x-mcp"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "your_api_key",
+            "name": "TWITTER_API_KEY"
+          },
+          {
+            "description": "your_api_secret",
+            "name": "TWITTER_API_SECRET"
+          },
+          {
+            "description": "your_access_token",
+            "name": "TWITTER_ACCESS_TOKEN"
+          },
+          {
+            "description": "your_access_token_secret",
+            "name": "TWITTER_ACCESS_TOKEN_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bce1c06f-6325-418a-91e2-0ff2f6cf8ffc",
+    "name": "io.github.shenghaiwang/xcodebuild",
+    "description": "MCP tool for building Xcode iOS workspace/project and feeding back error to LLMs.",
+    "repository": {
+      "url": "https://github.com/ShenghaiWang/xcodebuild",
+      "source": "github",
+      "id": "941391898"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcpxcodebuild",
+        "version": "0.10.0"
+      }
+    ]
+  },
+  {
+    "id": "aeca0d6b-ed78-4634-a29a-6d08f71de2b6",
+    "name": "io.github.john-zhang-dev/xero-mcp",
+    "description": "A Model Context Protocol server allows Clients to interact with Xero",
+    "repository": {
+      "url": "https://github.com/john-zhang-dev/xero-mcp",
+      "source": "github",
+      "id": "950380608"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "xero-mcp",
+        "version": "1.3.0",
+        "environment_variables": [
+          {
+            "description": "YOUR_CLIENT_ID",
+            "name": "XERO_CLIENT_ID"
+          },
+          {
+            "description": "YOUR_CLIENT_SECRET",
+            "name": "XERO_CLIENT_SECRET"
+          },
+          {
+            "description": "http://localhost:5000/callback",
+            "name": "XERO_REDIRECT_URI"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a33de229-5e89-468d-aa2a-570b0f6e3dfa",
+    "name": "io.github.xgenerationlab/xiyan_mcp_server",
+    "description": "A Model Context Protocol (MCP) server that enables natural language queries to databases",
+    "repository": {
+      "url": "https://github.com/XGenerationLab/xiyan_mcp_server",
+      "source": "github",
+      "id": "947753431"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:08Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "xiyan_mcp_server",
+        "version": "0.1.5"
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "",
+        "url": "http://localhost:8000/sse"
+      }
+    ]
+  },
+  {
+    "id": "cd63d589-6f0e-4d2d-8c9c-b6857f48cc62",
+    "name": "io.github.apeyroux/mcp-xmind",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/apeyroux/mcp-xmind",
+      "source": "github",
+      "id": "902421970"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:10Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@41px/mcp-xmind",
+        "version": "1.1.1",
+        "package_arguments": [
+          {
+            "description": "/Users/alex/XMind",
+            "is_required": true,
+            "format": "string",
+            "value": "/Users/alex/XMind",
+            "default": "/Users/alex/XMind",
+            "type": "positional",
+            "value_hint": "/Users/alex/XMind"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "c859bceb-143a-43dc-84e6-8ad8f707fcb0",
+    "name": "io.github.chuckbryan/ynabmcpserver",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/ChuckBryan/ynabmcpserver",
+      "source": "github",
+      "id": "982820266"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:12Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "ynabmcpserver",
+        "version": "0.0.0"
+      }
+    ]
+  },
+  {
+    "id": "0278fd92-a009-4a47-a6df-5f77db37e6ab",
+    "name": "io.github.zubeidhendricks/youtube-mcp-server",
+    "description": "MCP Server for YouTube API, enabling video management, Shorts creation, and advanced analytics",
+    "repository": {
+      "url": "https://github.com/ZubeidHendricks/youtube-mcp-server",
+      "source": "github",
+      "id": "909607678"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:14Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "zubeid-youtube-mcp-server",
+        "version": "1.0.0",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "YOUTUBE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "be45349a-793d-44d9-b2c6-6d4a30785a18",
+    "name": "io.github.prathamesh0901/zoom-mcp-server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/Prathamesh0901/zoom-mcp-server",
+      "source": "github",
+      "id": "978843359"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:17Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@prathamesh0901/zoom-mcp-server",
+        "version": "1.0.1",
+        "environment_variables": [
+          {
+            "description": "Your Zoom Account ID",
+            "name": "ZOOM_ACCOUNT_ID"
+          },
+          {
+            "description": "Your Zoom Client ID",
+            "name": "ZOOM_CLIENT_ID"
+          },
+          {
+            "description": "Your Zoom Client Secret",
+            "name": "ZOOM_CLIENT_SECRET"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "17829ab3-ae45-4fdd-95dc-4bb82a75752d",
+    "name": "io.github.isdaniel/mcp_weather_server",
+    "description": "",
+    "repository": {
+      "url": "https://github.com/isdaniel/mcp_weather_server",
+      "source": "github",
+      "id": "949740349"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:18Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp_weather_server",
+        "version": "0.2.1"
+      }
+    ]
+  },
+  {
+    "id": "c636fa7e-796e-40a3-bdfc-52d7f4b82db4",
+    "name": "io.github.zcaceres/easy-mcp",
+    "description": "Absurdly easy Model Context Protocol Servers in Typescript",
+    "repository": {
+      "url": "https://github.com/zcaceres/easy-mcp",
+      "source": "github",
+      "id": "908705399"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:20Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "easy-mcp",
+        "version": "1.0.1"
+      }
+    ]
+  },
+  {
+    "id": "9297bbe7-81bc-4a7c-97ba-fcaaf8c7a626",
+    "name": "io.github.tadata-org/fastapi_mcp",
+    "description": "Expose your FastAPI endpoints as Model Context Protocol (MCP) tools, with Auth!",
+    "repository": {
+      "url": "https://github.com/tadata-org/fastapi_mcp",
+      "source": "github",
+      "id": "944976593"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:22Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "fastapi-mcp",
+        "version": "0.3.3"
+      }
+    ]
+  },
+  {
+    "id": "c978017d-b94a-4d0c-a46e-5395cb94a67e",
+    "name": "io.github.punkpeye/fastmcp",
+    "description": "A TypeScript framework for building MCP servers.",
+    "repository": {
+      "url": "https://github.com/punkpeye/fastmcp",
+      "source": "github",
+      "id": "908799323"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:25Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "fastmcp",
+        "version": "1.0.0",
+        "package_arguments": [
+          {
+            "description": "/PATH/TO/YOUR_PROJECT/src/index.ts",
+            "is_required": true,
+            "format": "string",
+            "value": "/PATH/TO/YOUR_PROJECT/src/index.ts",
+            "default": "/PATH/TO/YOUR_PROJECT/src/index.ts",
+            "type": "positional",
+            "value_hint": "/PATH/TO/YOUR_PROJECT/src/index.ts"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "value",
+            "name": "YOUR_ENV_VAR"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "499f5fa7-c91e-4dac-bf51-9f075eaa2769",
+    "name": "io.github.strowk/foxy-contexts",
+    "description": "Foxy contexts is a library for building context servers supporting Model Context Protocol",
+    "repository": {
+      "url": "https://github.com/strowk/foxy-contexts",
+      "source": "github",
+      "id": "896729097"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:27Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "strowk/foxy-contexts",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "121af804-12e1-4ac3-add1-3f8e2da4a8fe",
+    "name": "io.github.alibaba/higress",
+    "description": "🤖 AI Gateway | AI Native API Gateway",
+    "repository": {
+      "url": "https://github.com/alibaba/higress",
+      "source": "github",
+      "id": "558188628"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:29Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "alibaba/higress",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "b846b02f-1f0e-4c62-a3e9-e62cf3ccbf1a",
+    "name": "io.github.quarkiverse/quarkus-mcp-server",
+    "description": "This extension enables developers to implement the MCP server features easily.",
+    "repository": {
+      "url": "https://github.com/quarkiverse/quarkus-mcp-server",
+      "source": "github",
+      "id": "901850977"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:31Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "quarkiverse/quarkus-mcp-server",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "816a9400-2e2b-4697-8fbb-2a22fd81de74",
+    "name": "io.github.mcpdotdirect/template-mcp-server",
+    "description": "Template to quickly set up your own MCP server ",
+    "repository": {
+      "url": "https://github.com/mcpdotdirect/template-mcp-server",
+      "source": "github",
+      "id": "946258129"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:33Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@mcpdotdirect/create-mcp-server",
+        "version": "2.0.1",
+        "package_arguments": [
+          {
+            "description": "start",
+            "is_required": true,
+            "format": "string",
+            "value": "start",
+            "default": "start",
+            "type": "positional",
+            "value_hint": "start"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "development",
+            "name": "NODE_ENV"
+          }
+        ]
+      }
+    ],
+    "remotes": [
+      {
+        "transport_type": "sse",
+        "url": "http://localhost:3001/sse"
+      }
+    ]
+  },
+  {
+    "id": "bdcb0c25-b41c-4e61-ad25-89e5ddb35dcc",
+    "name": "io.github.marimo-team/codemirror-mcp",
+    "description": "CodeMirror extension to hook up a Model Context Provider (MCP)",
+    "repository": {
+      "url": "https://github.com/marimo-team/codemirror-mcp",
+      "source": "github",
+      "id": "914149601"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:36Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "@marimo-team/codemirror-mcp",
+        "version": "0.1.2",
+        "environment_variables": [
+          {
+            "description": "${input:apiKey}",
+            "name": "API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "a9d37e55-2034-40aa-8956-4c05c52b40c7",
+    "name": "io.github.badkk/awesome-crypto-mcp-servers",
+    "description": "A collection of crypto MCP servers.",
+    "repository": {
+      "url": "https://github.com/badkk/awesome-crypto-mcp-servers",
+      "source": "github",
+      "id": "911501074"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:38Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "badkk/awesome-crypto-mcp-servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "0007544a-3948-4934-866b-b4a96fe53b55",
+    "name": "io.github.appcypher/awesome-mcp-servers",
+    "description": "Awesome MCP Servers - A curated list of Model Context Protocol servers",
+    "repository": {
+      "url": "https://github.com/appcypher/awesome-mcp-servers",
+      "source": "github",
+      "id": "895801050"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:40Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "appcypher/awesome-mcp-servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "fedddd78-b4fc-4bf9-96a2-021779348acf",
+    "name": "io.github.punkpeye/awesome-mcp-servers",
+    "description": "A collection of MCP servers.",
+    "repository": {
+      "url": "https://github.com/punkpeye/awesome-mcp-servers",
+      "source": "github",
+      "id": "896335270"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:42Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "punkpeye/awesome-mcp-servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "9926bddd-9633-4a76-a5b6-bb3be30b2ed4",
+    "name": "io.github.wong2/awesome-mcp-servers",
+    "description": "A curated list of Model Context Protocol (MCP) servers",
+    "repository": {
+      "url": "https://github.com/wong2/awesome-mcp-servers",
+      "source": "github",
+      "id": "895553015"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:44Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "wong2/awesome-mcp-servers",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "2a679bdd-d106-4510-99ea-b4802070d30f",
+    "name": "io.github.jaw9c/awesome-remote-mcp-servers",
+    "description": "A curated, opinionated list of high-quality remote Model Context Protocol (MCP) servers. ",
+    "repository": {
+      "url": "https://github.com/jaw9c/awesome-remote-mcp-servers",
+      "source": "github",
+      "id": "961291556"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:46Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "jaw9c/awesome-remote-mcp-servers",
+        "version": "",
+        "package_arguments": [
+          {
+            "description": "<REMOTE_MCP_SERVER_URL>",
+            "is_required": true,
+            "format": "string",
+            "value": "<REMOTE_MCP_SERVER_URL>",
+            "default": "<REMOTE_MCP_SERVER_URL>",
+            "type": "positional",
+            "value_hint": "<REMOTE_MCP_SERVER_URL>"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "de52e791-0131-40d1-be41-ba7b14f3c134",
+    "name": "io.github.ai-agent-hub/mcp-marketplace",
+    "description": "OpenSource MCP Marketplace and Html Plugin to Integrate with your AI Application",
+    "repository": {
+      "url": "https://github.com/AI-Agent-Hub/mcp-marketplace",
+      "source": "github",
+      "id": "978816723"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:48Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "AI-Agent-Hub/mcp-marketplace",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "d0568ded-6678-4940-b344-9644e04e6d7b",
+    "name": "io.github.mcp-router/mcp-router",
+    "description": "MCP Router enables easily manage your MCP (Model Context Protocol) servers with enhanced security",
+    "repository": {
+      "url": "https://github.com/mcp-router/mcp-router",
+      "source": "github",
+      "id": "952939763"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:50Z",
+      "is_latest": true
+    },
+    "package_canonical": "npm",
+    "packages": [
+      {
+        "registry_name": "npm",
+        "name": "my-docs-site",
+        "version": "0.0.0",
+        "package_arguments": [
+          {
+            "is_required": true,
+            "format": "string",
+            "value": "connect",
+            "default": "connect",
+            "type": "positional",
+            "value_hint": "connect"
+          }
+        ],
+        "environment_variables": [
+          {
+            "description": "Issued Token",
+            "name": "MCPR_TOKEN"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "72d60875-916c-4555-8651-a10f013c7c30",
+    "name": "io.github.mcpx-dev/mcp-badges",
+    "description": "Get your projects MCP (Model Context Protocol)  badges",
+    "repository": {
+      "url": "https://github.com/mcpx-dev/mcp-badges",
+      "source": "github",
+      "id": "911113162"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:52Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcpx-dev/mcp-badges",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "41203071-aa7d-49f7-83a9-3f3c8429d178",
+    "name": "io.github.apappascs/mcp-servers-hub",
+    "description": "Discover the most comprehensive and up-to-date collection of MCP servers in the market. This repository serves as a centralized hub, offering an extensive catalog of open-source and proprietary MCP servers, complete with features, documentation links, and contributors.",
+    "repository": {
+      "url": "https://github.com/apappascs/mcp-servers-hub",
+      "source": "github",
+      "id": "907417434"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:54Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "apappascs/mcp-servers-hub",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "29cf2977-4a42-44f0-8e62-f92ca8391412",
+    "name": "io.github.wong2/mcp-cli",
+    "description": "A CLI inspector for the Model Context Protocol",
+    "repository": {
+      "url": "https://github.com/wong2/mcp-cli",
+      "source": "github",
+      "id": "898806068"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:56Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "@wong2/mcp-cli",
+        "version": "1.10.0"
+      }
+    ]
+  },
+  {
+    "id": "04b4489b-db48-4aaa-98f6-036bcf5fd483",
+    "name": "io.github.eqtylab/mcp-guardian",
+    "description": "Manage / Proxy / Secure your MCP Servers",
+    "repository": {
+      "url": "https://github.com/eqtylab/mcp-guardian",
+      "source": "github",
+      "id": "926222936"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:16:58Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "eqtylab/mcp-guardian",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "963aac9c-4999-4ce6-93c9-43d4b2de16bb",
+    "name": "io.github.pathintegral-institute/mcpm.sh",
+    "description": "CLI MCP package manager & registry for all platforms and all clients. Search & configure MCP servers. Advanced Router & Profile features.",
+    "repository": {
+      "url": "https://github.com/pathintegral-institute/mcpm.sh",
+      "source": "github",
+      "id": "952463457"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:17:00Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcpm",
+        "version": ""
+      }
+    ]
+  },
+  {
+    "id": "3288499d-b820-45c9-8abf-60c050c5c741",
+    "name": "io.github.zueai/mcp-manager",
+    "description": "simple web ui to manage mcp (model context protocol) servers in the claude app",
+    "repository": {
+      "url": "https://github.com/zueai/mcp-manager",
+      "source": "github",
+      "id": "900260982"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:17:02Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcp-manager",
+        "version": "0.1.9"
+      }
+    ]
+  },
+  {
+    "id": "9f38c975-9a2a-484f-8173-562153f515e4",
+    "name": "io.github.jeamee/mcphub-desktop",
+    "description": "Desktop APP for Discover and Install MCP Servers",
+    "repository": {
+      "url": "https://github.com/Jeamee/MCPHub-Desktop",
+      "source": "github",
+      "id": "898806615"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:17:04Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "mcphub-desktop",
+        "version": "0.2.1"
+      }
+    ]
+  },
+  {
+    "id": "53bef572-b137-447a-bb2f-9fdd37926619",
+    "name": "io.github.chatmcp/mcp-directory",
+    "description": "directory for Awesome MCP Servers",
+    "repository": {
+      "url": "https://github.com/chatmcp/mcpso",
+      "source": "github",
+      "id": "899309258"
+    },
+    "version_detail": {
+      "version": "0.0.1-seed",
+      "release_date": "2025-05-16T19:17:06Z",
+      "is_latest": true
+    },
+    "package_canonical": "unknown",
+    "packages": [
+      {
+        "registry_name": "unknown",
+        "name": "navfast",
+        "version": "0.1.0"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
When cloning the repository and building the project using:

```bash
go build ./cmd/registry
./registry
```

the application fails to start because the default seed file path (`data/seed.json`) does not exist in the repo:

```
Failed to read seed file: failed to read file: open data/seed.json: The system cannot find the file specified.
```

To address this, this PR adds a `data/seed.json` file to ensure the app can run successfully with default settings.

### Changes:

* Added `data/seed.json` as a default seed file to align with the default configuration
* Contents are copied from the latest available seed file (e.g. `seed_2025_05_16.json`)
* Ensures the application runs out-of-the-box without requiring additional environment configuration
* Developers can still override the seed file path using the `SEED_FILE_PATH` environment variable

Let me know if you'd prefer to solve this differently (e.g., by changing the default path or improving fallback behavior).
