### PR TITLE
Enhance health check endpoint with GitHub client ID

### DIFF
--- a/internal/api/handlers/v0/health.go
+++ b/internal/api/handlers/v0/health.go
@@ -4,12 +4,22 @@ package v0
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/modelcontextprotocol/registry/internal/config"
 )
 
+type HealthResponse struct {
+	Status         string `json:"status"`
+	GitHubClientId string `json:"github_client_id"`
+}
+
 // HealthHandler returns a handler for health check endpoint
-func HealthHandler() http.HandlerFunc {
+func HealthHandler(cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		json.NewEncoder(w).Encode(HealthResponse{
+			Status:         "ok",
+			GitHubClientId: cfg.GithubClientID,
+		})
 	}
 }

--- a/internal/api/router/v0.go
+++ b/internal/api/router/v0.go
@@ -13,7 +13,7 @@ import (
 // RegisterV0Routes registers all v0 API routes to the provided router
 func RegisterV0Routes(mux *http.ServeMux, cfg *config.Config, registry service.RegistryService, authService auth.Service) {
 	// Register v0 endpoints
-	mux.HandleFunc("/v0/health", v0.HealthHandler())
+	mux.HandleFunc("/v0/health", v0.HealthHandler(cfg))
 	mux.HandleFunc("/v0/servers", v0.ServersHandler(registry))
 	mux.HandleFunc("/v0/servers/{id}", v0.ServersDetailHandler(registry))
 	mux.HandleFunc("/v0/ping", v0.PingHandler(cfg))

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -33,7 +33,9 @@ paths:
                   status:
                     type: string
                     example: ok
-                    
+                  github_client_id:
+                      type: string
+                      example: "your_github_client_id"
   /v0/ping:
     get:
       tags:


### PR DESCRIPTION
Improve the health check endpoint to include the GitHub client ID in the response schema, providing additional context for clients.

This will be useful for publishers if they want query details for githubClientID for auth flows.