### PR TITLE
Integrate GitHub Client ID into device flow authentication and fix inline model handling during publish

### DIFF
--- a/internal/api/handlers/v0/publish.go
+++ b/internal/api/handlers/v0/publish.go
@@ -38,8 +38,13 @@ func PublishHandler(registry service.RegistryService, authService auth.Service) 
 		}
 
 		// Get server details from the request
-		serverDetail := publishReq.ServerDetail
+		var serverDetail model.ServerDetail
 
+		err = json.Unmarshal(body, &serverDetail)
+		if err != nil {
+			http.Error(w, "Invalid server detail payload: "+err.Error(), http.StatusBadRequest)
+			return
+		}
 		// Validate required fields
 		if serverDetail.Name == "" {
 			http.Error(w, "Name is required", http.StatusBadRequest)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -20,8 +20,7 @@ type Authentication struct {
 // PublishRequest represents a request to publish a server to the registry
 type PublishRequest struct {
 	ServerDetail    `json:",inline"`
-	Authentication  Authentication `json:"-"` // Now provided via Authorization header
-	AuthStatusToken string         `json:"-"` // Used internally for device flows
+	AuthStatusToken string `json:"-"` // Used internally for device flows
 }
 
 // Repository represents a source code repository as defined in the spec
@@ -121,7 +120,7 @@ type Server struct {
 
 // ServerDetail represents detailed server information as defined in the spec
 type ServerDetail struct {
-	Server           `json:",inline" bson:",inline"`
-	Packages         []Package `json:"packages,omitempty" bson:"packages,omitempty"`
-	Remotes          []Remote  `json:"remotes,omitempty" bson:"remotes,omitempty"`
+	Server   `json:",inline" bson:",inline"`
+	Packages []Package `json:"packages,omitempty" bson:"packages,omitempty"`
+	Remotes  []Remote  `json:"remotes,omitempty" bson:"remotes,omitempty"`
 }


### PR DESCRIPTION
Integrate the GitHub Client ID into the device flow authentication process, ensuring it is fetched from the server's health endpoint. Additionally, address the handling of inline models during the publish request to improve functionality.