### PR TITLE
fix: make repository optional in openapi spec

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -108,7 +108,6 @@ components:
         - id
         - name
         - description
-        - repository
         - version_detail
       properties:
         id:


### PR DESCRIPTION
This makes repository optional as per #111.
