### PR TITLE
Make value_hint optional to allow constant positional arguments

### DIFF
--- a/docs/server-json/examples.md
+++ b/docs/server-json/examples.md
@@ -42,7 +42,8 @@ Suppose your MCP server application requires a `mcp start` CLI arguments to star
   "description": "Sample NuGet MCP server for a random number and random weather",
   "repository": {
     "url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer",
-    "source": "github"
+    "source": "github",
+    "id": "def456gh-ijkl-7890-mnop-qrstuvwxyz13"
   },
   "version_detail": {
     "version": "0.4.0-beta"
@@ -223,7 +224,8 @@ The `dnx` tool ships with the .NET 10 SDK, starting with Preview 6.
   "description": "Sample NuGet MCP server for a random number and random weather",
   "repository": {
     "url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer",
-    "source": "github"
+    "source": "github",
+    "id": "def456gh-ijkl-7890-mnop-qrstuvwxyz13"
   },
   "version_detail": {
     "version": "0.3.0-beta"

--- a/docs/server-json/examples.md
+++ b/docs/server-json/examples.md
@@ -40,11 +40,6 @@ Suppose your MCP server application requires a `mcp start` CLI arguments to star
 {
   "name": "Knapcode.SampleMcpServer",
   "description": "Sample NuGet MCP server for a random number and random weather",
-  "repository": {
-    "url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer",
-    "source": "github",
-    "id": "def456gh-ijkl-7890-mnop-qrstuvwxyz13"
-  },
   "version_detail": {
     "version": "0.4.0-beta"
   },
@@ -53,7 +48,6 @@ Suppose your MCP server application requires a `mcp start` CLI arguments to star
       "registry_name": "nuget",
       "name": "Knapcode.SampleMcpServer",
       "version": "0.4.0-beta",
-      "runtime_hint": "dnx",
       "package_arguments": [
         {
           "type": "positional",
@@ -69,7 +63,7 @@ Suppose your MCP server application requires a `mcp start` CLI arguments to star
 }
 ```
 
-This will effectively instruct the MCP client to execute `dnx Knapcode.SampleMcpServer@0.4.0-beta -- mcp start`.
+This will essentially instruct the MCP client to execute `dnx Knapcode.SampleMcpServer@0.4.0-beta -- mcp start` instead of the default `dnx Knapcode.SampleMcpServer@0.4.0-beta` (when no `package_arguments` are provided).
 
 ## Filesystem Server with Multiple Packages
 

--- a/docs/server-json/examples.md
+++ b/docs/server-json/examples.md
@@ -12,8 +12,7 @@
     "id": "abc123de-f456-7890-ghij-klmnopqrstuv"
   },
   "version_detail": {
-    "version": "1.0.2",
-    "release_date": "2023-06-15T10:30:00Z"
+    "version": "1.0.2"
   },
   "packages": [
     {
@@ -33,6 +32,44 @@
 }
 ```
 
+## Constant (fixed) arguments needed to start the MCP server
+
+Suppose your MCP server application requires a `mcp start` CLI arguments to start in MCP server mode. Express these as positional arguments like this:
+
+```json
+{
+  "name": "Knapcode.SampleMcpServer",
+  "description": "Sample NuGet MCP server for a random number and random weather",
+  "repository": {
+    "url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "0.4.0-beta"
+  },
+  "packages": [
+    {
+      "registry_name": "nuget",
+      "name": "Knapcode.SampleMcpServer",
+      "version": "0.4.0-beta",
+      "runtime_hint": "dnx",
+      "package_arguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "start"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This will effectively instruct the MCP client to execute `dnx Knapcode.SampleMcpServer@0.4.0-beta -- mcp start`.
+
 ## Filesystem Server with Multiple Packages
 
 ```json
@@ -45,8 +82,7 @@
     "id": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9"
   },
   "version_detail": {
-    "version": "1.0.2",
-    "release_date": "2023-06-15T10:30:00Z"
+    "version": "1.0.2"
   },
   "packages": [
     {
@@ -128,8 +164,7 @@
     "id": "xyz789ab-cdef-0123-4567-890ghijklmno"
   },
   "version_detail": {
-    "version": "2.0.0",
-    "release_date": "2024-01-20T14:30:00Z"
+    "version": "2.0.0"
   },
   "remotes": [
     {
@@ -152,8 +187,7 @@
     "id": "def456gh-ijkl-7890-mnop-qrstuvwxyz12"
   },
   "version_detail": {
-    "version": "0.5.0",
-    "release_date": "2024-02-10T09:15:00Z"
+    "version": "0.5.0"
   },
   "packages": [
     {
@@ -192,8 +226,7 @@ The `dnx` tool ships with the .NET 10 SDK, starting with Preview 6.
     "source": "github"
   },
   "version_detail": {
-    "version": "0.3.0",
-    "release_date": "2025-07-02T18:54:28.00Z"
+    "version": "0.3.0-beta"
   },
   "packages": [
     {
@@ -226,8 +259,7 @@ The `dnx` tool ships with the .NET 10 SDK, starting with Preview 6.
     "id": "ghi789jk-lmno-1234-pqrs-tuvwxyz56789"
   },
   "version_detail": {
-    "version": "3.1.0",
-    "release_date": "2024-03-05T16:45:00Z"
+    "version": "3.1.0"
   },
   "packages": [
     {
@@ -313,8 +345,7 @@ The `dnx` tool ships with the .NET 10 SDK, starting with Preview 6.
     "id": "klm012no-pqrs-3456-tuvw-xyz789abcdef"
   },
   "version_detail": {
-    "version": "1.5.0",
-    "release_date": "2024-04-01T12:00:00Z"
+    "version": "1.5.0"
   },
   "packages": [
     {

--- a/docs/server-json/schema.json
+++ b/docs/server-json/schema.json
@@ -204,8 +204,7 @@
         {
           "type": "object",
           "required": [
-            "type",
-            "value_hint"
+            "type"
           ],
           "properties": {
             "type": {

--- a/docs/server-json/schema.json
+++ b/docs/server-json/schema.json
@@ -7,8 +7,7 @@
       "type": "object",
       "required": [
         "url",
-        "source",
-        "id"
+        "source"
       ],
       "properties": {
         "url": {

--- a/docs/server-json/schema.json
+++ b/docs/server-json/schema.json
@@ -7,7 +7,8 @@
       "type": "object",
       "required": [
         "url",
-        "source"
+        "source",
+        "id"
       ],
       "properties": {
         "url": {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This is one attempt to resolve https://github.com/modelcontextprotocol/registry/issues/169.

Instead of adding a new "constant" argument type, I expanded the existing positional one and just dropped the `value_hint` requirement. I am not sure if this has VS Code impact @sandy081, @connor4312.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I tested the current server.json samples in the repo against the new (less strict) schema. Of course they passed (aside from an unrelated bug in my previous NuGet sample 🤦).

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
