### PR TITLE
feat(infra): helm-chart based deployment templates and scripts

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,20 +9,23 @@ To deploy this application, you'll need the following:
 
 ## `deploy.sh` script
 
-This script can be used to "install" the application w/ the cluster in your current context.
+This script can be used to "install" the mcp-registry application w/ the cluster in your current context.
+
+The mcp registry will be available immediately after the deployment completes.
 
 > 
-> Tip: To get see the cluster run `kubectl config current-context`
+> Tip: To see the current cluster run `kubectl config current-context`
 > 
 
 An example of running the full command:
 
 ```bash
 cd ./deploy
-./deploy --namespace my-mcp-registry \
+./deploy.sh --namespace my-mcp-registry \
     --github-secret-name mcp-github-org \
-    --registry-image example.io/mcp-registry \
-    --db-image example.io/mongo
+    --registry-image example.io/registry \
+    --db-image docker.io/library/mongo \
+    --db-image-tag 7.0.22
 ```
 
 `--namespace`
@@ -56,6 +59,8 @@ There are various ways to create this secret, but I found the most convenient wa
 `--registry-image`
 This should be the host/repo image reference of the mcp-registry application built from the Dockerfile at the root of this repository, ex: example.io/registry
 
+Note: In order for K8's to deploy the registry container, it must have access to the registry image. This means the Dockerfile in this repo must be built and hosted in a registry accessible to the cluster.
+
 `--registry-image-tag`
 Image tag of the registry image to use. By default the value in .Chart.AppVersion will be used.
 
@@ -79,10 +84,11 @@ To upgrade a deployment, provide the name of the deployment w/ the `--upgrade` f
 Ex:
 ```sh
 cd ./deploy
-./deploy --namespace my-mcp-registry \
+./deploy.sh --namespace my-mcp-registry \
     --github-secret-name mcp-github-org \
-    --registry-image example.io/mcp-registry \
-    --db-image example.io/mongo \
+    --registry-image example.io/registry \
+    --db-image docker.io/library/mongo \
+    --db-image-tag 7.0.22 \
     --upgrade chart-12345
 ```
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This adds support for deploying the repository as a helm chart to any Kubernetes clusters. It also includes a `deploy.sh` script and documentation for convenience.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The current `docker-compose.yml` works well for local deployments, but it can be a bit difficult to leverage in a cloud provider. This bridges the gap and offers a deployment model that targets any Kubernetes cluster.  This makes it cloud provider agnostic while also making it easy to stand up on any cloud provider that offers managed Kubernetes, and also is road to an actual production deployment choice moving forward as Kubernetes natively handles many production procedures/tooling.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

This has been tested on Azure, including first-time setup as well as upgrading (via the deploy.sh)

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
~~- [ ] New and existing tests pass locally~~ Change does not require any source changes
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Address #91 

Since there is some mention of moving to Postgres, I wrote the database settings in a way that splits mongo specific settings into its own section.
