### PR TITLE
Server definition with skills and metadata

### DIFF
--- a/internal/api/handlers/v0/publish.go
+++ b/internal/api/handlers/v0/publish.go
@@ -112,7 +112,7 @@ func PublishHandler(registry service.RegistryService, authService auth.Service) 
 		err = registry.Publish(&serverDetail)
 		if err != nil {
 			// Check for specific error types and return appropriate HTTP status codes
-			if errors.Is(err, database.ErrInvalidVersion) || errors.Is(err, database.ErrAlreadyExists) {
+			if errors.Is(err, database.ErrInvalidVersion) || errors.Is(err, database.ErrAlreadyExists) || errors.Is(err, database.ErrInvalidInput) {
 				http.Error(w, "Failed to publish server details: "+err.Error(), http.StatusBadRequest)
 				return
 			}

--- a/internal/api/handlers/v0/publish_test.go
+++ b/internal/api/handlers/v0/publish_test.go
@@ -577,8 +577,8 @@ func TestPublishIntegration(t *testing.T) {
 					VersionDetail: model.VersionDetail{
 						Version: "1.0.0",
 					},
-					Skills: []string{},
 				},
+				Skills: []string{},
 			},
 		}
 
@@ -591,7 +591,7 @@ func TestPublishIntegration(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 		handler := v0.PublishHandler(registryService, authService)
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "invalid input")
@@ -611,8 +611,8 @@ func TestPublishIntegration(t *testing.T) {
 					VersionDetail: model.VersionDetail{
 						Version: "1.0.0",
 					},
-					Skills: []string{"search", ""},
 				},
+				Skills: []string{"search", ""},
 			},
 		}
 
@@ -625,7 +625,7 @@ func TestPublishIntegration(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 		handler := v0.PublishHandler(registryService, authService)
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "invalid input")
@@ -663,7 +663,7 @@ func TestPublishIntegration(t *testing.T) {
 
 		recorder := httptest.NewRecorder()
 		handler := v0.PublishHandler(registryService, authService)
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusCreated, recorder.Code)
 		var response map[string]string
@@ -734,7 +734,7 @@ func TestPublishIntegration(t *testing.T) {
 		recorder := httptest.NewRecorder()
 
 		// Call the handler
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		// Check the response
 		assert.Equal(t, http.StatusCreated, recorder.Code)
@@ -782,7 +782,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "dummy_token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusCreated, recorder.Code)
 
@@ -815,7 +815,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "Name is required")
@@ -840,7 +840,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "Version is required")
@@ -865,7 +865,7 @@ func TestPublishIntegration(t *testing.T) {
 		// No Authorization header
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "Authorization header is required")
@@ -879,7 +879,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "Invalid")
@@ -890,7 +890,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
 		assert.Contains(t, recorder.Body.String(), "Method not allowed")
@@ -921,7 +921,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer github_token_first")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		var response map[string]string
 		err = json.Unmarshal(recorder.Body.Bytes(), &response)
@@ -955,7 +955,7 @@ func TestPublishIntegration(t *testing.T) {
 		duplicateReq.Header.Set("Authorization", "Bearer github_token_duplicate")
 
 		duplicateRecorder := httptest.NewRecorder()
-		handler(duplicateRecorder, duplicateReq)
+		handler.ServeHTTP(duplicateRecorder, duplicateReq)
 
 		// The duplicate should fail
 		assert.Equal(t, http.StatusBadRequest, duplicateRecorder.Code)
@@ -993,7 +993,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer github_token_v1")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		var response map[string]string
 		err = json.Unmarshal(recorder.Body.Bytes(), &response)
@@ -1027,7 +1027,7 @@ func TestPublishIntegration(t *testing.T) {
 		secondReq.Header.Set("Authorization", "Bearer github_token_v2")
 
 		secondRecorder := httptest.NewRecorder()
-		handler(secondRecorder, secondReq)
+		handler.ServeHTTP(secondRecorder, secondReq)
 
 		var secondResponse map[string]string
 		err = json.Unmarshal(secondRecorder.Body.Bytes(), &secondResponse)
@@ -1073,7 +1073,7 @@ func TestPublishIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer github_token_newer")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		var response map[string]string
 		err = json.Unmarshal(recorder.Body.Bytes(), &response)
@@ -1107,7 +1107,7 @@ func TestPublishIntegration(t *testing.T) {
 		olderReq.Header.Set("Authorization", "Bearer github_token_older")
 
 		olderRecorder := httptest.NewRecorder()
-		handler(olderRecorder, olderReq)
+		handler.ServeHTTP(olderRecorder, olderReq)
 
 		// This should fail - we shouldn't allow publishing older versions after newer ones
 		assert.Equal(t, http.StatusBadRequest, olderRecorder.Code, "Publishing older version should fail")
@@ -1160,7 +1160,7 @@ func TestPublishIntegrationEndToEnd(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer github_e2e_token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		var response map[string]string
 		err = json.Unmarshal(recorder.Body.Bytes(), &response)
@@ -1312,7 +1312,7 @@ func TestPublishIntegrationWithComplexPackages(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer github_complex_token")
 
 		recorder := httptest.NewRecorder()
-		handler(recorder, req)
+		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusCreated, recorder.Code)
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -116,7 +116,7 @@ type Server struct {
 	Description   string         `json:"description" bson:"description"`
 	Repository    Repository     `json:"repository" bson:"repository"`
 	VersionDetail VersionDetail  `json:"version_detail" bson:"version_detail"`
-	Skills        []string       `json:"skills,omitempty" bson:"skills,omitempty"`
+	Skills        []string       `json:"skills" bson:"skills,omitempty"`
 	Metadata      map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
 }
 
@@ -125,6 +125,6 @@ type ServerDetail struct {
 	Server   `json:",inline" bson:",inline"`
 	Packages []Package      `json:"packages,omitempty" bson:"packages,omitempty"`
 	Remotes  []Remote       `json:"remotes,omitempty" bson:"remotes,omitempty"`
-	Skills   []string       `json:"skills,omitempty" bson:"skills,omitempty"`
+	Skills   []string       `json:"skills" bson:"skills,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty" bson:"metadata,omitempty"`
 }

--- a/internal/service/fake_service.go
+++ b/internal/service/fake_service.go
@@ -119,6 +119,26 @@ func (s *fakeRegistryService) Publish(serverDetail *model.ServerDetail) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	if serverDetail == nil {
+		return database.ErrInvalidInput
+	}
+
+	// Validate skills: if provided, must not be empty and must not contain empty strings
+	skills := serverDetail.Skills
+	if skills == nil {
+		skills = serverDetail.Server.Skills
+	}
+	if skills != nil {
+		if len(skills) == 0 {
+			return database.ErrInvalidInput
+		}
+		for _, skill := range skills {
+			if skill == "" {
+				return database.ErrInvalidInput
+			}
+		}
+	}
+
 	// Use the database's Publish method to add the server detail
 	return s.db.Publish(ctx, serverDetail)
 }

--- a/internal/service/registry_service.go
+++ b/internal/service/registry_service.go
@@ -94,14 +94,19 @@ func (s *registryServiceImpl) Publish(serverDetail *model.ServerDetail) error {
 		return database.ErrInvalidInput
 	}
 
-	// Validate skills: must not be empty, must not contain empty strings
+	// Validate skills: if provided, must not be empty and must not contain empty strings
 	skills := serverDetail.Skills
-	if len(skills) == 0 {
-		return database.ErrInvalidInput
+	if skills == nil {
+		skills = serverDetail.Server.Skills
 	}
-	for _, skill := range skills {
-		if skill == "" {
+	if skills != nil {
+		if len(skills) == 0 {
 			return database.ErrInvalidInput
+		}
+		for _, skill := range skills {
+			if skill == "" {
+				return database.ErrInvalidInput
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
To enable more precise server selection and differentiation by explicitly defining server skills and metadata. Maks the registry "an MCP server of MCP servers."
Currently does the following-
->Empty skills arrays are rejected (servers must declare at least one skill)
->Skills containing empty strings are rejected (skills must be meaningful)

## How Has This Been Tested?
Unit tests in internal/api/handlers/v0/publish_test.go:
->publish_fails_with_empty_skills_array: Verifies that publishing a server with an empty skills array returns HTTP 400 with "invalid input" message.
->publish_fails_with_skills_containing_empty_string: Verifies that publishing a server with skills containing empty strings returns HTTP 400 with "invalid input" message.
->publish_succeeds_with_valid_skills_and_metadata: Verifies that publishing a server with valid skills succeeds.

## Breaking Changes
No breaking changes, existing servers without skills or metadata remain compatible.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Closes #79 
