### PR TITLE
Add a status field indicating if a server is deprecated or active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cmd/registry/registry
 publisher
 validate-examples
 validate-schemas
+.idea/

--- a/docs/server-json/examples.md
+++ b/docs/server-json/examples.md
@@ -6,6 +6,7 @@
 {
   "name": "io.modelcontextprotocol/brave-search",
   "description": "MCP server for Brave Search API integration",
+  "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
     "source": "github",
@@ -71,6 +72,7 @@ This will essentially instruct the MCP client to execute `dnx Knapcode.SampleMcp
 {
   "name": "io.modelcontextprotocol/filesystem",
   "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+  "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
     "source": "github",
@@ -382,6 +384,39 @@ The `dnx` tool ships with the .NET 10 SDK, starting with Preview 6.
     {
       "transport_type": "streamable",
       "url": "https://hybrid-mcp.example.com/stream"
+    }
+  ]
+}
+```
+
+## Deprecated Server Example
+
+```json
+{
+  "name": "io.legacy/old-weather-server",
+  "description": "Legacy weather server - DEPRECATED: Use weather-v2 instead for new projects",
+  "status": "deprecated",
+  "repository": {
+    "url": "https://github.com/example/old-weather",
+    "source": "github",
+    "id": "legacy-abc123-def456-789012-345678-901234567890"
+  },
+  "version_detail": {
+    "version": "0.9.5"
+  },
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@legacy/old-weather-server",
+      "version": "0.9.5",
+      "environment_variables": [
+        {
+          "name": "WEATHER_API_KEY",
+          "description": "Weather API key",
+          "is_required": true,
+          "is_secret": true
+        }
+      ]
     }
   ]
 }

--- a/docs/server-json/schema.json
+++ b/docs/server-json/schema.json
@@ -60,6 +60,12 @@
           "description": "Human-readable description of the server's functionality",
           "example": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
         },
+        "status": {
+          "type": "string",
+          "enum": ["active", "deprecated"],
+          "default": "active",
+          "description": "Server lifecycle status. 'deprecated' indicates the server is no longer recommended for new usage."
+        },
         "repository": {
           "$ref": "#/$defs/Repository"
         },

--- a/docs/server-registry-api/examples.md
+++ b/docs/server-registry-api/examples.md
@@ -17,6 +17,7 @@ GET /v0/servers?limit=5000&offset=0
       "id": "a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1",
       "name": "io.modelcontextprotocol/filesystem",
       "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+      "status": "active",
       "repository": {
         "url": "https://github.com/modelcontextprotocol/servers",
         "source": "github",
@@ -49,6 +50,7 @@ GET /v0/servers/a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1?version=0.0.3
   "id": "a5e8a7f0-d4e4-4a1d-b12f-2896a23fd4f1",
   "name": "io.modelcontextprotocol/filesystem",
   "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+  "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
     "source": "github",
@@ -143,6 +145,7 @@ API Response:
   "id": "brave-search-12345",
   "name": "io.modelcontextprotocol/brave-search",
   "description": "MCP server for Brave Search API integration",
+  "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
     "source": "github",
@@ -195,6 +198,7 @@ API Response:
   "id": "filesystem-67890",
   "name": "io.modelcontextprotocol/filesystem",
   "description": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations",
+  "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
     "source": "github",
@@ -268,6 +272,7 @@ API Response:
   "id": "remote-fs-54321",
   "name": "Remote Brave Search Server",
   "description": "Cloud-hosted MCP Brave Search server",
+  "status": "active",
   "repository": {
     "url": "https://github.com/example/remote-fs",
     "source": "github",

--- a/docs/server-registry-api/openapi.yaml
+++ b/docs/server-registry-api/openapi.yaml
@@ -109,6 +109,12 @@ components:
         description:
           type: string
           example: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
+        status:
+          type: string
+          enum: [active, deprecated]
+          default: active
+          description: "Server lifecycle status. 'deprecated' indicates the server is no longer recommended for new usage."
+          example: "active"
         repository:
           $ref: '#/components/schemas/Repository'
         version_detail:

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -10,6 +10,16 @@ const (
 	AuthMethodNone AuthMethod = "none"
 )
 
+// ServerStatus represents the lifecycle status of a server
+type ServerStatus string
+
+const (
+	// ServerStatusActive represents an active server recommended for use
+	ServerStatusActive ServerStatus = "active"
+	// ServerStatusDeprecated represents a server no longer recommended for new usage
+	ServerStatusDeprecated ServerStatus = "deprecated"
+)
+
 // Authentication holds information about the authentication method and credentials
 type Authentication struct {
 	Method  AuthMethod `json:"method,omitempty"`
@@ -114,6 +124,7 @@ type Server struct {
 	ID            string        `json:"id" bson:"id"`
 	Name          string        `json:"name" bson:"name"`
 	Description   string        `json:"description" bson:"description"`
+	Status        ServerStatus  `json:"status,omitempty" bson:"status,omitempty"`
 	Repository    Repository    `json:"repository" bson:"repository"`
 	VersionDetail VersionDetail `json:"version_detail" bson:"version_detail"`
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -14,9 +14,9 @@ const (
 type ServerStatus string
 
 const (
-	// ServerStatusActive represents an active server recommended for use
+	// ServerStatusActive represents an actively maintained server (as asserted by the publisher)
 	ServerStatusActive ServerStatus = "active"
-	// ServerStatusDeprecated represents a server no longer recommended for new usage
+	// ServerStatusDeprecated represents a server that is no longer actively maintained
 	ServerStatusDeprecated ServerStatus = "deprecated"
 )
 

--- a/tools/publisher/server.json
+++ b/tools/publisher/server.json
@@ -1,6 +1,7 @@
 {
     "description": "<your description here>",
     "name": "io.github.<owner>/<server-name>",
+    "status": "active",
     "packages": [
         {
             "registry_name": "npm",

--- a/tools/validate-examples/main.go
+++ b/tools/validate-examples/main.go
@@ -22,7 +22,7 @@ const (
 	// IMPORTANT: Only change this count if you have intentionally added or removed examples
 	// from the examples.md file. This check prevents accidental formatting changes from
 	// causing examples to be skipped during validation.
-	expectedExampleCount = 8
+	expectedExampleCount = 9
 )
 
 func main() {


### PR DESCRIPTION
The following PR adds a new server `status` field to support the status of servers, like deprecated or active

Details:
* Add status field to server.json schema with 'active' and 'deprecated' values
* Update OpenAPI spec to include status field in Server responses
* Add ServerStatus enum and field to Go model structs
* Update examples to demonstrate status field usage (`active` and `deprecated`)

Since this is my first PR there's a good chance I might have missed something so I'll appreciate any feedback to make this and any PRs in the future easier for you to review 😃 

Fixes: #181

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The main goal is to have a way for server authors to notify registry consumers that a server may no longer be maintained and shouldn't be considered for using.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
