### PR TITLE
Do not gitignore all folders and files named publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ build/*
 .mcpregistry*
 **/bin
 cmd/registry/registry
-publisher
 validate-examples
 validate-schemas


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The following PR removes the gitignore entry for `publisher` since this means we gitignore all folders and files named `publisher`. 

My assumption is the intent for this was to just ignore binaries named `publisher` but currently that binary is going to be located at `tools/publisher/bin/mcp-publisher` and the **/bin pattern already ignores all bin/ directories (taken from the build.sh).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
