### PR TITLE
Fix struct duplication between internal/model and tools/publisher

### DIFF
--- a/tools/publisher/main.go
+++ b/tools/publisher/main.go
@@ -13,53 +13,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/modelcontextprotocol/registry/internal/model"
 	"github.com/modelcontextprotocol/registry/tools/publisher/auth"
 	"github.com/modelcontextprotocol/registry/tools/publisher/auth/github"
 )
-
-// Server structure types for JSON generation
-type Repository struct {
-	URL    string `json:"url"`
-	Source string `json:"source"`
-}
-
-type VersionDetail struct {
-	Version string `json:"version"`
-}
-
-type EnvironmentVariable struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
-type RuntimeArgument struct {
-	Description string `json:"description"`
-	IsRequired  bool   `json:"is_required"`
-	Format      string `json:"format"`
-	Value       string `json:"value"`
-	Default     string `json:"default"`
-	Type        string `json:"type"`
-	ValueHint   string `json:"value_hint"`
-}
-
-type Package struct {
-	RegistryName         string                `json:"registry_name"`
-	Name                 string                `json:"name"`
-	Version              string                `json:"version"`
-	RuntimeHint          string                `json:"runtime_hint,omitempty"`
-	RuntimeArguments     []RuntimeArgument     `json:"runtime_arguments,omitempty"`
-	PackageArguments     []RuntimeArgument     `json:"package_arguments,omitempty"`
-	EnvironmentVariables []EnvironmentVariable `json:"environment_variables,omitempty"`
-}
-
-type ServerJSON struct {
-	Name          string        `json:"name"`
-	Description   string        `json:"description"`
-	Status        string        `json:"status,omitempty"`
-	Repository    Repository    `json:"repository"`
-	VersionDetail VersionDetail `json:"version_detail"`
-	Packages      []Package     `json:"packages"`
-}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -361,27 +318,29 @@ func publishToRegistry(registryURL string, mcpData []byte, token string) error {
 }
 
 func createServerStructure(name, description, version, repoURL, repoSource, registryName,
-	packageName, packageVersion, runtimeHint, execute string, envVars []string, packageArgs []string, status string) ServerJSON {
+	packageName, packageVersion, runtimeHint, execute string, envVars []string, packageArgs []string, status string) model.ServerDetail {
 	// Parse environment variables
-	var environmentVariables []EnvironmentVariable
+	var environmentVariables []model.KeyValueInput
 	for _, envVar := range envVars {
 		parts := strings.SplitN(envVar, ":", 2)
+		envVarName := parts[0]
+		envVarDesc := fmt.Sprintf("Environment variable for %s", parts[0])
 		if len(parts) == 2 {
-			environmentVariables = append(environmentVariables, EnvironmentVariable{
-				Name:        parts[0],
-				Description: parts[1],
-			})
-		} else {
-			// If no description provided, use a default
-			environmentVariables = append(environmentVariables, EnvironmentVariable{
-				Name:        parts[0],
-				Description: fmt.Sprintf("Environment variable for %s", parts[0]),
-			})
+			envVarDesc = parts[1]
 		}
+
+		environmentVariables = append(environmentVariables, model.KeyValueInput{
+			Name: envVarName,
+			InputWithVariables: model.InputWithVariables{
+				Input: model.Input{
+					Description: envVarDesc,
+				},
+			},
+		})
 	}
 
 	// Parse package arguments
-	var packageArguments []RuntimeArgument
+	var packageArguments []model.Argument
 	for i, pkgArg := range packageArgs {
 		parts := strings.SplitN(pkgArg, ":", 2)
 		value := parts[0]
@@ -390,19 +349,23 @@ func createServerStructure(name, description, version, repoURL, repoSource, regi
 			description = parts[1]
 		}
 
-		packageArguments = append(packageArguments, RuntimeArgument{
-			Description: description,
-			IsRequired:  true, // Package arguments are typically required
-			Format:      "string",
-			Value:       value,
-			Default:     value,
-			Type:        "positional",
-			ValueHint:   value,
+		packageArguments = append(packageArguments, model.Argument{
+			InputWithVariables: model.InputWithVariables{
+				Input: model.Input{
+					Description: description,
+					IsRequired:  true, // Package arguments are typically required
+					Format:      model.FormatString,
+					Value:       value,
+					Default:     value,
+				},
+			},
+			Type:      model.ArgumentTypePositional,
+			ValueHint: value,
 		})
 	}
 
 	// Parse execute command to create runtime arguments
-	var runtimeArguments []RuntimeArgument
+	var runtimeArguments []model.Argument
 	if execute != "" {
 		// Split the execute command into parts, handling quoted strings
 		parts := smartSplit(execute)
@@ -423,43 +386,53 @@ func createServerStructure(name, description, version, repoURL, repoSource, regi
 					description = fmt.Sprintf("Value for %s", parts[i])
 				}
 
-				runtimeArguments = append(runtimeArguments, RuntimeArgument{
-					Description: description,
-					IsRequired:  false,
-					Format:      "string",
-					Value:       arg,
-					Default:     arg,
-					Type:        "positional",
-					ValueHint:   arg,
+				runtimeArguments = append(runtimeArguments, model.Argument{
+					InputWithVariables: model.InputWithVariables{
+						Input: model.Input{
+							Description: description,
+							IsRequired:  false,
+							Format:      model.FormatString,
+							Value:       arg,
+							Default:     arg,
+						},
+					},
+					Type:      model.ArgumentTypePositional,
+					ValueHint: arg,
 				})
 			}
 		}
 	}
 
 	// Create package
-	pkg := Package{
+	pkg := model.Package{
 		RegistryName:         registryName,
 		Name:                 packageName,
 		Version:              packageVersion,
-		RuntimeHint:          runtimeHint,
+		RunTimeHint:          runtimeHint,
 		RuntimeArguments:     runtimeArguments,
 		PackageArguments:     packageArguments,
 		EnvironmentVariables: environmentVariables,
 	}
 
-	// Create server structure
-	return ServerJSON{
-		Name:        name,
-		Description: description,
-		Status:      status,
-		Repository: Repository{
-			URL:    repoURL,
-			Source: repoSource,
+	// Create server structure using model types
+	// Note: We only populate the fields we need for publishing
+	return model.ServerDetail{
+		Server: model.Server{
+			Name:        name,
+			Description: description,
+			Status:      model.ServerStatus(status),
+			Repository: model.Repository{
+				URL:    repoURL,
+				Source: repoSource,
+				// Should we allow setting the ID here, or it will be generated by the registry?
+			},
+			VersionDetail: model.VersionDetail{
+				Version: version,
+				// ReleaseDate and IsLatest will be set by the registry
+			},
 		},
-		VersionDetail: VersionDetail{
-			Version: version,
-		},
-		Packages: []Package{pkg},
+		Packages: []model.Package{pkg},
+		// Remotes can be empty for basic server definitions
 	}
 }
 


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR consolidates duplicate struct definitions between the publisher tool and the internal model package to eliminate code duplication and ensure consistency:
- Removed duplicate structs from `tools/publisher/main.go` (Repository, VersionDetail, Package, etc.)
- Updated publisher to import `github.com/modelcontextprotocol/registry/internal/model`
- Modified `createServerStructure()` to return `model.ServerDetail` and populate the full model structure
- The generated JSON now includes all model fields but only sets values for relevant ones. **Others like ID, ReleaseDate and IsLatest are left empty and so automatically set to their default values when marshalling.** I assume this shouldn't be a problem given these will be set/overwritten by the registry, but it's worth to note it.

**Example output:**

```bash
➜  publisher git:(use-model-types) ./bin/mcp-publisher create --name "io.github.example/simple-server" --description "A simple MCP server" --repo-url "https://github.com/example/simple-server" --output "simple.json"
2025/08/01 01:35:27 Successfully created simple.json
2025/08/01 01:35:27 You may need to edit the file to:
2025/08/01 01:35:27   - Add or modify package arguments
2025/08/01 01:35:27   - Set environment variable requirements
2025/08/01 01:35:27   - Add remote server configurations
2025/08/01 01:35:27   - Adjust runtime arguments
➜  publisher git:(use-model-types) cat simple.json 
{
  "id": "",
  "name": "io.github.example/simple-server",
  "description": "A simple MCP server",
  "status": "active",
  "repository": {
    "url": "https://github.com/example/simple-server",
    "source": "github",
    "id": ""
  },
  "version_detail": {
    "version": "1.0.0",
    "release_date": "",
    "is_latest": false
  },
  "packages": [
    {
      "registry_name": "npm",
      "name": "io.github.example/simple-server",
      "version": "1.0.0",
      "runtime_hint": "npx"
    }
  ]
}%   
```

```bash
➜  publisher git:(use-model-types) ./bin/mcp-publisher create --name "io.github.example/complex-server" --description "A complex MCP server with configuration" --repo-url "https://github.com/example/complex-server" --version "2.1.0" --status "deprecated" --execute "node server.js --port 8080 --config /etc/config.json" --env-var "API_TOKEN:Your API authentication token" --env-var "LOG_LEVEL:Logging level (debug, info, warn, error)" --package-arg "config-file:Path to configuration 
  file" --package-arg "database-url:Database connection URL" --runtime-hint "docker" --registry "docker" --output "complex.json"
2025/08/01 01:44:51 Successfully created complex.json
2025/08/01 01:44:51 You may need to edit the file to:
2025/08/01 01:44:51   - Add or modify package arguments
2025/08/01 01:44:51   - Set environment variable requirements
2025/08/01 01:44:51   - Add remote server configurations
2025/08/01 01:44:51   - Adjust runtime arguments
➜  publisher git:(use-model-types) ✗ cat complex.json
{
  "id": "",
  "name": "io.github.example/complex-server",
  "description": "A complex MCP server with configuration",
  "status": "deprecated",
  "repository": {
    "url": "https://github.com/example/complex-server",
    "source": "github",
    "id": ""
  },
  "version_detail": {
    "version": "2.1.0",
    "release_date": "",
    "is_latest": false
  },
  "packages": [
    {
      "registry_name": "docker",
      "name": "io.github.example/complex-server",
      "version": "2.1.0",
      "runtime_hint": "docker",
      "runtime_arguments": [
        {
          "description": "Runtime argument 1",
          "format": "string",
          "value": "server.js",
          "default": "server.js",
          "type": "positional",
          "value_hint": "server.js"
        },
        {
          "description": "Command line flag: --port",
          "format": "string",
          "value": "--port",
          "default": "--port",
          "type": "positional",
          "value_hint": "--port"
        },
        {
          "description": "Value for --port",
          "format": "string",
          "value": "8080",
          "default": "8080",
          "type": "positional",
          "value_hint": "8080"
        },
        {
          "description": "Command line flag: --config",
          "format": "string",
          "value": "--config",
          "default": "--config",
          "type": "positional",
          "value_hint": "--config"
        },
        {
          "description": "Value for --config",
          "format": "string",
          "value": "/etc/config.json",
          "default": "/etc/config.json",
          "type": "positional",
          "value_hint": "/etc/config.json"
        }
      ],
      "package_arguments": [
        {
          "description": "Path to configuration \n  file",
          "is_required": true,
          "format": "string",
          "value": "config-file",
          "default": "config-file",
          "type": "positional",
          "value_hint": "config-file"
        },
        {
          "description": "Database connection URL",
          "is_required": true,
          "format": "string",
          "value": "database-url",
          "default": "database-url",
          "type": "positional",
          "value_hint": "database-url"
        }
      ],
      "environment_variables": [
        {
          "description": "Your API authentication token",
          "name": "API_TOKEN"
        },
        {
          "description": "Logging level (debug, info, warn, error)",
          "name": "LOG_LEVEL"
        }
      ]
    }
  ]
}%    
```

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Compared the output of the same command before and after the changes and the only difference is the values we skipped setting and were automatically set to their defaults.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
