### PR TITLE
Add redirect from root path to Swagger UI documentation

### DIFF
--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -16,5 +16,10 @@ func New(cfg *config.Config, registry service.RegistryService, authService auth.
 	// Register routes for all API versions
 	RegisterV0Routes(mux, cfg, registry, authService)
 
+	// Redirect root to Swagger UI
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/v0/swagger/index.html", http.StatusFound)
+	})
+
 	return mux
 }


### PR DESCRIPTION
## Summary
- Added redirect from `/` to `/v0/swagger/index.html` to help contributors quickly access API documentation
- Implemented the redirect in router.go after v0 routes registration

🤖 Generated with [Claude Code](https://claude.ai/code)