### PR TITLE
Remove tracked binaries and fix build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-build/*
+build/
+bin/
+
 .db
 .env
 .mcpregistry*
-**/bin
-cmd/registry/registry
 .DS_Store
 validate-examples
 validate-schemas

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ dev-local: ## Run registry locally (requires MongoDB)
 
 # Cleanup
 clean: ## Clean build artifacts and coverage files
-	rm -f bin/registry
+	rm -rf bin
 	rm -f coverage.out coverage.html
 	cd tools/publisher && rm -f publisher
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## Show this help message
 
 # Build targets
 build: ## Build the registry application
-	go build ./cmd/registry
+	go build -o bin/registry ./cmd/registry
 
 publisher: ## Build the publisher tool
 	cd tools/publisher && ./build.sh
@@ -62,7 +62,7 @@ dev-local: ## Run registry locally (requires MongoDB)
 
 # Cleanup
 clean: ## Clean build artifacts and coverage files
-	rm -f registry
+	rm -f bin/registry
 	rm -f coverage.out coverage.html
 	cd tools/publisher && rm -f publisher
 


### PR DESCRIPTION
## Summary
- Remove registry binary from git tracking
- Update Makefile to output binaries to bin/ directory  
- Fix .gitignore to properly exclude bin/ directory and all binaries

This follows Go best practices by placing all compiled binaries in the bin/ directory.