### PR TITLE
infra: Always pull latest images

### DIFF
--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -62,8 +62,9 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 				Spec: &corev1.PodSpecArgs{
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
-							Name:  pulumi.String("mcp-registry"),
-							Image: pulumi.String("ghcr.io/modelcontextprotocol/registry:latest"),
+							Name:            pulumi.String("mcp-registry"),
+							Image:           pulumi.String("ghcr.io/modelcontextprotocol/registry:latest"),
+							ImagePullPolicy: pulumi.String("Always"),
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{
 									ContainerPort: pulumi.Int(8080),


### PR DESCRIPTION
The Always pull policy is needed for the latest tag to force Kubernetes to pull the newest image on every pod creation, even if an image with that tag already exists locally. Without this, pods might use outdated cached versions since the latest tag is mutable and can point to different images over time.
