### PR TITLE
Remove requirement of repository.id from server.json

### DIFF
--- a/docs/server-json/examples.md
+++ b/docs/server-json/examples.md
@@ -9,8 +9,7 @@
   "status": "active",
   "repository": {
     "url": "https://github.com/modelcontextprotocol/servers",
-    "source": "github",
-    "id": "abc123de-f456-7890-ghij-klmnopqrstuv"
+    "source": "github"
   },
   "version_detail": {
     "version": "1.0.2"

--- a/docs/server-json/schema.json
+++ b/docs/server-json/schema.json
@@ -8,8 +8,7 @@
       "type": "object",
       "required": [
         "url",
-        "source",
-        "id"
+        "source"
       ],
       "properties": {
         "url": {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -31,7 +31,7 @@ type PublishRequest struct {
 type Repository struct {
 	URL    string `json:"url" bson:"url"`
 	Source string `json:"source" bson:"source"`
-	ID     string `json:"id" bson:"id"`
+	ID     string `json:"id,omitempty" bson:"id,omitempty"`
 }
 
 // ServerList represents the response for listing servers as defined in the spec


### PR DESCRIPTION
Make repository.id optional by:
- Removing 'id' from required fields in JSON schema
- Adding omitempty tags to Go model structs 
- Updating examples to show simpler format without id

This fixes publishing failures where the publisher tool doesn't 
generate repository.id but the schema requires it.

Fixes #179

🤖 Generated with [Claude Code](https://claude.ai/code)