### PR TITLE
build: Optimize Dockerfile by splitting out dependency installation and go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM golang:1.24-alpine AS builder
 WORKDIR /app
+
+# Copy go mod files first and download dependencies
+# This creates a separate layer that only invalidates when dependencies change
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
 COPY . .
+
 ARG GO_BUILD_TAGS
 RUN go build ${GO_BUILD_TAGS:+-tags="$GO_BUILD_TAGS"} -o /build/registry ./cmd/registry
 


### PR DESCRIPTION
Create a separate step in the Docker image to install the dependencies. This makes local dev a bunch faster, because Docker doesn't redownload all the dependencies each time you make a small file changes.