### PR TITLE
chore: bump golangci-lint to v2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install golangci-lint
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.1
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
 
     - name: Run lint
       run: make lint

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ The MCP Registry service provides a centralized repository for MCP server entrie
 - Docker (optional, but recommended for development)
 
 For development:
-- golangci-lint v2.3.1 - Install with:
+- golangci-lint v2.4.0 - Install with:
   ```bash
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.3.1
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
   ```
 
 ## Running


### PR DESCRIPTION
Updates golangci-lint version references from v2.3.1 to v2.4.0.

Changes:
- README.md: Updated prerequisites documentation and installation command

Note: The CI workflow file (.github/workflows/ci.yml) also needs updating but requires additional permissions.

Fixes #287

Generated with [Claude Code](https://claude.ai/code)