### PR TITLE
Update LICENSE copyright holder to MCP Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 GitHub
+Copyright (c) 2025 MCP Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Updates the LICENSE file to change copyright holder from "GitHub" to "MCP Contributors"
- Better reflects the community-driven nature of the MCP Registry project

## Changes
- Modified LICENSE file: `Copyright (c) 2025 GitHub` → `Copyright (c) 2025 MCP Contributors`

🤖 Generated with [Claude Code](https://claude.ai/code)