### PR TITLE
Add reverse DNS namespace validation for MCP server names

### DIFF
--- a/internal/service/registry_service.go
+++ b/internal/service/registry_service.go
@@ -76,8 +76,13 @@ func (s *registryServiceImpl) Publish(req model.PublishRequest) (*model.ServerRe
 		return nil, err
 	}
 
-	// Validate server name exists
+	// Validate server name exists and format
 	if _, err := model.ParseServerName(req.Server); err != nil {
+		return nil, err
+	}
+
+	// Validate reverse-DNS namespace matching for remote URLs
+	if err := model.ValidateRemoteNamespaceMatch(req.Server); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

- Enforce server names to use reverse-DNS namespace format (dns-namespace/name)
- Validate that remote URLs match the declared namespace
- Add comprehensive test coverage for hostname-to-namespace conversion
- Skip validation for localhost and local development URLs

This ensures consistency between server namespaces and their hosting domains, improving registry organization and preventing namespace conflicts.