### PR TITLE
Add validation to prevent duplicate remote URLs in server publishing

### DIFF
--- a/internal/database/memory.go
+++ b/internal/database/memory.go
@@ -139,6 +139,18 @@ func (db *MemoryDB) List(
 				if string(entry.ServerJSON.Status) != value.(string) {
 					include = false
 				}
+			case "remote_url":
+				found := false
+				remoteURL := value.(string)
+				for _, remote := range entry.ServerJSON.Remotes {
+					if remote.URL == remoteURL {
+						found = true
+						break
+					}
+				}
+				if !found {
+					include = false
+				}
 			}
 		}
 

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -76,6 +76,10 @@ func (db *PostgreSQL) List(
 			whereClause += fmt.Sprintf(" AND s.status = $%d", argIndex)
 			args = append(args, v)
 			argIndex++
+		case "remote_url":
+			whereClause += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM jsonb_array_elements(s.remotes) AS remote WHERE remote->>'url' = $%d)", argIndex)
+			args = append(args, v)
+			argIndex++
 		}
 	}
 

--- a/internal/service/registry_service_test.go
+++ b/internal/service/registry_service_test.go
@@ -1,0 +1,138 @@
+//nolint:testpackage
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/registry/internal/database"
+	"github.com/modelcontextprotocol/registry/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateNoDuplicateRemoteURLs(t *testing.T) {
+	// Create test data
+	existingServers := map[string]*model.ServerDetail{
+		"existing1": {
+			Name:        "com.example/existing-server",
+			Description: "An existing server",
+			VersionDetail: model.VersionDetail{
+				Version: "1.0.0",
+			},
+			Remotes: []model.Remote{
+				{URL: "https://api.example.com/mcp"},
+				{URL: "https://webhook.example.com/sse"},
+			},
+		},
+		"existing2": {
+			Name:        "com.microsoft/another-server",
+			Description: "Another existing server",
+			VersionDetail: model.VersionDetail{
+				Version: "1.0.0",
+			},
+			Remotes: []model.Remote{
+				{URL: "https://api.microsoft.com/mcp"},
+			},
+		},
+	}
+
+	// Create memory database with existing data
+	memDB := database.NewMemoryDB(existingServers)
+	service := NewRegistryServiceWithDB(memDB)
+
+	tests := []struct {
+		name         string
+		serverDetail model.ServerDetail
+		expectError  bool
+		errorMsg     string
+	}{
+		{
+			name: "no remote URLs - should pass",
+			serverDetail: model.ServerDetail{
+				Name:        "com.example/new-server",
+				Description: "A new server with no remotes",
+				VersionDetail: model.VersionDetail{
+					Version: "1.0.0",
+				},
+				Remotes: []model.Remote{},
+			},
+			expectError: false,
+		},
+		{
+			name: "new unique remote URLs - should pass",
+			serverDetail: model.ServerDetail{
+				Name:        "com.example/new-server",
+				Description: "A new server",
+				VersionDetail: model.VersionDetail{
+					Version: "1.0.0",
+				},
+				Remotes: []model.Remote{
+					{URL: "https://new.example.com/mcp"},
+					{URL: "https://unique.example.com/sse"},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "duplicate remote URL - should fail",
+			serverDetail: model.ServerDetail{
+				Name:        "com.example/new-server",
+				Description: "A new server with duplicate URL",
+				VersionDetail: model.VersionDetail{
+					Version: "1.0.0",
+				},
+				Remotes: []model.Remote{
+					{URL: "https://api.example.com/mcp"}, // This URL already exists
+				},
+			},
+			expectError: true,
+			errorMsg:    "remote URL https://api.example.com/mcp is already used by server com.example/existing-server",
+		},
+		{
+			name: "updating same server with same URLs - should pass",
+			serverDetail: model.ServerDetail{
+				Name:        "com.example/existing-server", // Same name as existing
+				Description: "Updated existing server",
+				VersionDetail: model.VersionDetail{
+					Version: "1.1.0",
+				},
+				Remotes: []model.Remote{
+					{URL: "https://api.example.com/mcp"}, // Same URL as before
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "one new URL, one duplicate - should fail",
+			serverDetail: model.ServerDetail{
+				Name:        "com.example/new-server",
+				Description: "A new server",
+				VersionDetail: model.VersionDetail{
+					Version: "1.0.0",
+				},
+				Remotes: []model.Remote{
+					{URL: "https://unique.example.com/mcp"},
+					{URL: "https://api.microsoft.com/mcp"}, // Duplicate
+				},
+			},
+			expectError: true,
+			errorMsg:    "remote URL https://api.microsoft.com/mcp is already used by server com.microsoft/another-server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			impl := service.(*registryServiceImpl)
+			
+			err := impl.validateNoDuplicateRemoteURLs(ctx, tt.serverDetail)
+			
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add validation to prevent servers from being published with remote URLs already used by other servers
- Ensures unique remote URL assignments across the registry to prevent conflicts
- New validation runs during the publish process and returns clear error messages for conflicts