### PR TITLE
Disable ireturn linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - gosec
     - grouper
     - importas
-    - ireturn
     - makezero
     - misspell
     - nakedret

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -92,8 +92,6 @@ func WithSkipPaths(paths ...string) MiddlewareOption {
 }
 
 // NewHumaAPI creates a new Huma API with all routes registered
-//
-//nolint:ireturn // huma.API is the expected interface type for Huma APIs
 func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.ServeMux, metrics *telemetry.Metrics) huma.API {
 	// Create Huma API configuration
 	humaConfig := huma.DefaultConfig("MCP Registry API", "1.0.0")

--- a/internal/service/fake_service.go
+++ b/internal/service/fake_service.go
@@ -15,8 +15,6 @@ type fakeRegistryService struct {
 }
 
 // NewFakeRegistryService creates a new fake registry service with pre-populated data
-//
-//nolint:ireturn // Factory function intentionally returns interface for dependency injection
 func NewFakeRegistryService() RegistryService {
 	// Sample registry entries with updated model structure using ServerDetail
 	serverDetails := []*model.ServerDetail{
@@ -81,7 +79,7 @@ func (s *fakeRegistryService) List(cursor string, limit int) ([]model.ServerResp
 	if err != nil {
 		return nil, "", err
 	}
-	
+
 	// Convert ServerRecord to ServerResponse format
 	result := make([]model.ServerResponse, len(serverRecords))
 	for i, record := range serverRecords {

--- a/internal/service/registry_service.go
+++ b/internal/service/registry_service.go
@@ -18,8 +18,6 @@ type registryServiceImpl struct {
 }
 
 // NewRegistryServiceWithDB creates a new registry service with the provided database
-//
-//nolint:ireturn // Factory function intentionally returns interface for dependency injection
 func NewRegistryServiceWithDB(db database.Database) RegistryService {
 	return &registryServiceImpl{
 		db: db,

--- a/tools/publisher/auth/dns.go
+++ b/tools/publisher/auth/dns.go
@@ -5,8 +5,6 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider creates a new DNS-based auth provider
-//
-//nolint:ireturn // Factory function intentionally returns interface for dependency injection
 func NewDNSProvider(registryURL, domain, hexSeed string) Provider {
 	return &DNSProvider{
 		CryptoProvider: &CryptoProvider{

--- a/tools/publisher/auth/github-at.go
+++ b/tools/publisher/auth/github-at.go
@@ -63,8 +63,6 @@ type ServerHealthResponse struct {
 }
 
 // NewGitHubATProvider creates a new GitHub OAuth provider
-//
-//nolint:ireturn // Factory function intentionally returns interface for dependency injection
 func NewGitHubATProvider(forceLogin bool, registryURL string) Provider {
 	return &GitHubATProvider{
 		forceLogin:  forceLogin,

--- a/tools/publisher/auth/github-oidc.go
+++ b/tools/publisher/auth/github-oidc.go
@@ -15,8 +15,6 @@ type GitHubOIDCProvider struct {
 }
 
 // NewGitHubOIDCProvider creates a new GitHub OIDC provider
-//
-//nolint:ireturn // Factory function intentionally returns interface for dependency injection
 func NewGitHubOIDCProvider(registryURL string) Provider {
 	return &GitHubOIDCProvider{
 		registryURL: registryURL,

--- a/tools/publisher/auth/http.go
+++ b/tools/publisher/auth/http.go
@@ -5,7 +5,6 @@ type HTTPProvider struct {
 }
 
 // NewHTTPProvider creates a new HTTP-based auth provider
-//nolint:ireturn // Factory function returns interface by design
 func NewHTTPProvider(registryURL, domain, hexSeed string) Provider {
 	return &HTTPProvider{
 		CryptoProvider: &CryptoProvider{

--- a/tools/publisher/auth/none.go
+++ b/tools/publisher/auth/none.go
@@ -19,7 +19,6 @@ type TokenResponse struct {
 	ExpiresAt     int64  `json:"expires_at"`
 }
 
-//nolint:ireturn // Factory function returns interface by design
 func NewNoneProvider(registryURL string) Provider {
 	return &NoneProvider{
 		registryURL: registryURL,


### PR DESCRIPTION
## Summary

- Disable the `ireturn` linter rule in golangci-lint configuration
- Remove all related `nolint:ireturn` comments from the codebase

The `ireturn` rule was flagging factory functions that intentionally return interfaces for dependency injection, which is a common and valid Go pattern. Since this pattern is used extensively throughout the codebase for good architectural reasons, it makes sense to disable this rule entirely.

References: https://stackoverflow.com/questions/72385337/golang-linter-always-complains