### PR TITLE
Replace Codecov with GitHub Actions artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,10 @@ jobs:
     - name: Run all tests
       run: make test-all
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+    - name: Upload coverage artifacts
+      uses: actions/upload-artifact@v4
       with:
-        file: ./coverage.out
-        flags: unittests
-        name: codecov-unit
-        fail_ci_if_error: false
+        name: coverage-report
+        path: |
+          coverage.out
+          coverage.html


### PR DESCRIPTION
## Summary

- Remove Codecov integration from CI workflow
- Upload coverage reports as GitHub Actions artifacts instead
- Eliminates external dependency and potential security/reliability issues

Closes #309