### PR TITLE
feat: add version field to OpenAPI specification

### DIFF
--- a/docs/server-registry-api/openapi.yaml
+++ b/docs/server-registry-api/openapi.yaml
@@ -3,6 +3,7 @@ jsonSchemaDialect: "https://json-schema.org/draft/2020-12/schema"
 $id: https://modelcontextprotocol.io/schemas/draft/2025-07-09/server-registry-openapi
 info:
   title: MCP Server Registry API
+  version: "2025-07-09"
   summary: API for discovering and accessing MCP server metadata
   description: |
     Specification for a theoretical REST API that serves up metadata about MCP servers.


### PR DESCRIPTION
## Description

This PR addresses #300 by adding explicit versioning to the MCP Registry API OpenAPI specification.

## Changes

- Added `version: "2025-07-09"` field to the `info` section of the OpenAPI specification
- Maintains consistency with existing date-based versioning used across all schema files

## Rationale

As outlined in #300, the OpenAPI spec was missing an explicit version field, which could lead to:
- Compatibility issues as the API evolves
- Lack of clarity for API consumers
- Missing functionality in OpenAPI tooling that expects a version field

This follows the MCP specification's date-based versioning approach.

Closes #300