### PR TITLE
Remove leftover bson tags from the Go structs

### DIFF
--- a/pkg/api/v0/types.go
+++ b/pkg/api/v0/types.go
@@ -8,18 +8,18 @@ import (
 
 // RegistryExtensions represents registry-generated metadata
 type RegistryExtensions struct {
-	ID          string    `json:"id" bson:"_id"`
-	PublishedAt time.Time `json:"published_at" bson:"published_at"`
-	UpdatedAt   time.Time `json:"updated_at,omitempty" bson:"updated_at,omitempty"`
-	IsLatest    bool      `json:"is_latest" bson:"is_latest"`
-	ReleaseDate string    `json:"release_date" bson:"release_date"`
+	ID          string    `json:"id"`
+	PublishedAt time.Time `json:"published_at"`
+	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+	IsLatest    bool      `json:"is_latest"`
+	ReleaseDate string    `json:"release_date"`
 }
 
 // ServerRecord represents the unified storage and API response model
 type ServerRecord struct {
-	Server                          model.ServerJSON       `json:"server" bson:"server"`                                                    // Pure MCP server.json
-	XIOModelContextProtocolRegistry RegistryExtensions     `json:"x-io.modelcontextprotocol.registry,omitempty" bson:"registry_extensions"` // Registry-generated data
-	XPublisher                      map[string]interface{} `json:"x-publisher,omitempty" bson:"publisher_extensions"`                       // x-publisher extensions
+	Server                          model.ServerJSON       `json:"server"`                                                    // Pure MCP server.json
+	XIOModelContextProtocolRegistry RegistryExtensions     `json:"x-io.modelcontextprotocol.registry,omitempty"` // Registry-generated data
+	XPublisher                      map[string]interface{} `json:"x-publisher,omitempty"`                       // x-publisher extensions
 }
 
 // ServerListResponse represents the paginated server list response

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -11,44 +11,44 @@ const (
 
 // ServerJSON represents complete server information as defined in the MCP spec (pure, no registry metadata)
 type ServerJSON struct {
-	Schema        string        `json:"$schema,omitempty" bson:"$schema,omitempty"`
-	Name          string        `json:"name" minLength:"1" maxLength:"200" bson:"name"`
-	Description   string        `json:"description" minLength:"1" maxLength:"100" bson:"description"`
-	Status        Status        `json:"status,omitempty" minLength:"1" bson:"status,omitempty"`
-	Repository    Repository    `json:"repository,omitempty" bson:"repository"`
-	VersionDetail VersionDetail `json:"version_detail" bson:"version_detail"`
-	Packages      []Package     `json:"packages,omitempty" bson:"packages,omitempty"`
-	Remotes       []Remote      `json:"remotes,omitempty" bson:"remotes,omitempty"`
+	Schema        string        `json:"$schema,omitempty"`
+	Name          string        `json:"name" minLength:"1" maxLength:"200"`
+	Description   string        `json:"description" minLength:"1" maxLength:"100"`
+	Status        Status        `json:"status,omitempty" minLength:"1"`
+	Repository    Repository    `json:"repository,omitempty"`
+	VersionDetail VersionDetail `json:"version_detail"`
+	Packages      []Package     `json:"packages,omitempty"`
+	Remotes       []Remote      `json:"remotes,omitempty"`
 }
 
 // Package represents a package configuration
 type Package struct {
 	// RegistryType indicates how to download packages (e.g., "npm", "pypi", "docker-hub", "mcpb")
-	RegistryType string `json:"registry_type,omitempty" bson:"registry_type,omitempty"`
+	RegistryType string `json:"registry_type,omitempty"`
 	// RegistryBaseURL is the base URL of the package registry
-	RegistryBaseURL string `json:"registry_base_url,omitempty" bson:"registry_base_url,omitempty"`
+	RegistryBaseURL string `json:"registry_base_url,omitempty"`
 	// Identifier is the package identifier - either a package name (for registries) or URL (for direct downloads)
-	Identifier           string          `json:"identifier,omitempty" bson:"identifier,omitempty"`
-	Version              string          `json:"version,omitempty" bson:"version,omitempty"`
-	FileSHA256           string          `json:"file_sha256,omitempty" bson:"file_sha256,omitempty"`
-	RunTimeHint          string          `json:"runtime_hint,omitempty" bson:"runtime_hint,omitempty"`
-	RuntimeArguments     []Argument      `json:"runtime_arguments,omitempty" bson:"runtime_arguments,omitempty"`
-	PackageArguments     []Argument      `json:"package_arguments,omitempty" bson:"package_arguments,omitempty"`
-	EnvironmentVariables []KeyValueInput `json:"environment_variables,omitempty" bson:"environment_variables,omitempty"`
+	Identifier           string          `json:"identifier,omitempty"`
+	Version              string          `json:"version,omitempty"`
+	FileSHA256           string          `json:"file_sha256,omitempty"`
+	RunTimeHint          string          `json:"runtime_hint,omitempty"`
+	RuntimeArguments     []Argument      `json:"runtime_arguments,omitempty"`
+	PackageArguments     []Argument      `json:"package_arguments,omitempty"`
+	EnvironmentVariables []KeyValueInput `json:"environment_variables,omitempty"`
 }
 
 // Remote represents a remote connection endpoint
 type Remote struct {
-	TransportType string          `json:"transport_type" bson:"transport_type"`
-	URL           string          `json:"url" format:"uri" bson:"url"`
-	Headers       []KeyValueInput `json:"headers,omitempty" bson:"headers,omitempty"`
+	TransportType string          `json:"transport_type"`
+	URL           string          `json:"url" format:"uri"`
+	Headers       []KeyValueInput `json:"headers,omitempty"`
 }
 
 // Repository represents a source code repository as defined in the spec
 type Repository struct {
-	URL    string `json:"url" bson:"url"`
-	Source string `json:"source" bson:"source"`
-	ID     string `json:"id,omitempty" bson:"id,omitempty"`
+	URL    string `json:"url"`
+	Source string `json:"source"`
+	ID     string `json:"id,omitempty"`
 }
 
 // Format represents the input format type
@@ -63,25 +63,25 @@ const (
 
 // Input represents a configuration input
 type Input struct {
-	Description string   `json:"description,omitempty" bson:"description,omitempty"`
-	IsRequired  bool     `json:"is_required,omitempty" bson:"is_required,omitempty"`
-	Format      Format   `json:"format,omitempty" bson:"format,omitempty"`
-	Value       string   `json:"value,omitempty" bson:"value,omitempty"`
-	IsSecret    bool     `json:"is_secret,omitempty" bson:"is_secret,omitempty"`
-	Default     string   `json:"default,omitempty" bson:"default,omitempty"`
-	Choices     []string `json:"choices,omitempty" bson:"choices,omitempty"`
+	Description string   `json:"description,omitempty"`
+	IsRequired  bool     `json:"is_required,omitempty"`
+	Format      Format   `json:"format,omitempty"`
+	Value       string   `json:"value,omitempty"`
+	IsSecret    bool     `json:"is_secret,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Choices     []string `json:"choices,omitempty"`
 }
 
 // InputWithVariables represents an input that can contain variables
 type InputWithVariables struct {
-	Input     `json:",inline" bson:",inline"`
-	Variables map[string]Input `json:"variables,omitempty" bson:"variables,omitempty"`
+	Input     `json:",inline"`
+	Variables map[string]Input `json:"variables,omitempty"`
 }
 
 // KeyValueInput represents a named input with variables
 type KeyValueInput struct {
-	InputWithVariables `json:",inline" bson:",inline"`
-	Name               string `json:"name" bson:"name"`
+	InputWithVariables `json:",inline"`
+	Name               string `json:"name"`
 }
 
 // ArgumentType represents the type of argument
@@ -94,14 +94,14 @@ const (
 
 // Argument defines a type that can be either a PositionalArgument or a NamedArgument
 type Argument struct {
-	InputWithVariables `json:",inline" bson:",inline"`
-	Type               ArgumentType `json:"type" bson:"type"`
-	Name               string       `json:"name,omitempty" bson:"name,omitempty"`
-	IsRepeated         bool         `json:"is_repeated,omitempty" bson:"is_repeated,omitempty"`
-	ValueHint          string       `json:"value_hint,omitempty" bson:"value_hint,omitempty"`
+	InputWithVariables `json:",inline"`
+	Type               ArgumentType `json:"type"`
+	Name               string       `json:"name,omitempty"`
+	IsRepeated         bool         `json:"is_repeated,omitempty"`
+	ValueHint          string       `json:"value_hint,omitempty"`
 }
 
 // VersionDetail represents the version details of a server (pure MCP spec, no registry metadata)
 type VersionDetail struct {
-	Version string `json:"version" bson:"version"`
+	Version string `json:"version"`
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR removes the now obsolete bson tags (we moved away from MongoDB).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
