### PR TITLE
docs: fix grammar in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What is the registry?
 
-The registry will provide MCP clients with a list of MCP servers. Like an app store for MCP servers. (In future it might do more, like also hosting a list of clients.)
+The registry will provide MCP clients with a list of MCP servers, like an app store for MCP servers. (In the future it might do more, like also hosting a list of clients).
 
 There are two parts to the registry project:
 1. 🟦 **The MCP registry spec**: An [API specification](./docs/server-registry-api/) that allows anyone to implement a registry.


### PR DESCRIPTION
## Summary
Fixed grammar issues in the README description for better readability.

## Motivation and Context
The registry description had a sentence fragment and missing article that made it harder to read smoothly.

## How Has This Been Tested?
N/A - text-only changes to documentation.

## Breaking Changes
None.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Changed ". Like an app store for MCP servers." to ", like an app store for MCP servers" (joined sentence fragment) and "In future" to "In the future" (added missing article).
