### PR TITLE
fix: use path.Join instead of filepath.Join for embedded migrations

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"path/filepath"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -96,7 +96,7 @@ func (m *Migrator) loadMigrations() ([]Migration, error) {
 		}
 
 		// Read the migration SQL
-		content, err := migrationFiles.ReadFile(filepath.Join("migrations", name))
+		content, err := migrationFiles.ReadFile(path.Join("migrations", name))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read migration file %s: %w", name, err)
 		}


### PR DESCRIPTION
Fixes Windows compatibility issue where filepath.Join uses backslashes but embed.FS always expects forward slashes for embedded paths.

Fixes #337

Also see https://github.com/golang/go/issues/44305

🤖 Generated with [Claude Code](https://claude.ai/code)