### PR TITLE
fix: remove id property from Server schema

### DIFF
--- a/docs/server-registry-api/openapi.yaml
+++ b/docs/server-registry-api/openapi.yaml
@@ -203,10 +203,6 @@ components:
         - description
         - version_detail
       properties:
-        id:
-          type: string
-          format: uuid
-          example: "123e4567-e89b-12d3-a456-426614174000"
         name:
           type: string
           description: "Reverse DNS name of the MCP server"


### PR DESCRIPTION
The Server schema should not have its own `id` property as the ID is managed by the registry system through the `_meta["io.modelcontextprotocol.registry"].id` field.

Fixes #336

🤖 Generated with [Claude Code](https://claude.ai/code)