### PR TITLE
deploy: Reduce resource requests and limits to unblock scheduling pods

### DIFF
--- a/deploy/pkg/k8s/monitoring.go
+++ b/deploy/pkg/k8s/monitoring.go
@@ -37,12 +37,11 @@ func DeployMonitoringStack(ctx *pulumi.Context, cluster *providers.ProviderInfo,
 				"retentionPeriod": pulumi.String("14d"),
 				"resources": pulumi.Map{
 					"requests": pulumi.Map{
-						"memory": pulumi.String("2Gi"),
-						"cpu":    pulumi.String("500m"),
+						"memory": pulumi.String("128Mi"),
+						"cpu":    pulumi.String("50m"),
 					},
 					"limits": pulumi.Map{
-						"memory": pulumi.String("4Gi"),
-						"cpu":    pulumi.String("1"),
+						"memory": pulumi.String("256Mi"),
 					},
 				},
 			},
@@ -93,12 +92,11 @@ func DeployMonitoringStack(ctx *pulumi.Context, cluster *providers.ProviderInfo,
 			},
 			"resources": pulumi.Map{
 				"requests": pulumi.Map{
-					"memory": pulumi.String("256Mi"),
-					"cpu":    pulumi.String("100m"),
+					"memory": pulumi.String("64Mi"),
+					"cpu":    pulumi.String("25m"),
 				},
 				"limits": pulumi.Map{
-					"memory": pulumi.String("512Mi"),
-					"cpu":    pulumi.String("200m"),
+					"memory": pulumi.String("128Mi"),
 				},
 			},
 		},
@@ -264,12 +262,11 @@ func deployGrafana(ctx *pulumi.Context, cluster *providers.ProviderInfo, ns *cor
 			},
 			"resources": pulumi.Map{
 				"requests": pulumi.Map{
-					"memory": pulumi.String("512Mi"),
-					"cpu":    pulumi.String("200m"),
+					"memory": pulumi.String("128Mi"),
+					"cpu":    pulumi.String("50m"),
 				},
 				"limits": pulumi.Map{
-					"memory": pulumi.String("1Gi"),
-					"cpu":    pulumi.String("500m"),
+					"memory": pulumi.String("256Mi"),
 				},
 			},
 		},

--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -170,6 +170,15 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 								InitialDelaySeconds: pulumi.Int(5),
 								TimeoutSeconds:      pulumi.Int(3),
 							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Requests: pulumi.StringMap{
+									"memory": pulumi.String("128Mi"),
+									"cpu":    pulumi.String("100m"),
+								},
+								Limits: pulumi.StringMap{
+									"memory": pulumi.String("256Mi"),
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Motivation and Context
After #328, the monitoring stack was failing to deploy because we hit resource limits. This PR reduces the resource requests to a level compatible with the cluster.

## How Has This Been Tested?
I've checked that everything still deploys happily in staging.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update