### PR TITLE
deploy: fix: update Grafana ingress host format for consistency

### DIFF
--- a/deploy/pkg/k8s/monitoring.go
+++ b/deploy/pkg/k8s/monitoring.go
@@ -279,7 +279,7 @@ func deployGrafana(ctx *pulumi.Context, cluster *providers.ProviderInfo, ns *cor
 	}
 
 	// Create ingress for external access
-	grafanaHost := "grafana.registry." + environment + ".modelcontextprotocol.io"
+	grafanaHost := "grafana." + environment + ".registry.modelcontextprotocol.io"
 
 	_, err = networkingv1.NewIngress(ctx, "grafana-ingress", &networkingv1.IngressArgs{
 		Metadata: &metav1.ObjectMetaArgs{


### PR DESCRIPTION
## Motivation and Context

Consistency with https://staging.registry.modelcontextprotocol.io/ URL format (i.e. `<env>.<service>`, rather than `<service>.<env>`

## How Has This Been Tested?

Deployed in staging

## Breaking Changes

Grafana URL changes, but it's only just launched so fine.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update