### PR TITLE
Remove Azure/AKS deployment configuration from deploy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -63,53 +63,29 @@ Pre-requisites:
 11. Access the repository via the ingress load balancer. You can find its external IP with: `kubectl get svc ingress-nginx-controller -n ingress-nginx`.
    Then run `curl -H "Host: prod.registry.modelcontextprotocol.io" -k https://<EXTERNAL-IP>/v0/ping` to check that the service is up.
 
-<!--
-
-### Production Deployment (Azure)
-
-**Note:** This is how the production deployment will be set up once. But then the plan will be future updates are effectively a login + `pulumi up` from GitHub Actions.
-
-Pre-requisites:
-- [Pulumi CLI installed](https://www.pulumi.com/docs/iac/download-install/)
-- A Microsoft Azure account
-- [Azure CLI](https://learn.microsoft.com/en-gb/cli/azure/get-started-with-azure-cli) installed
-
-1. Login to Azure: `az login`
-2. Create a resource group: `az group create --name official-mcp-registry-prod --location eastus`
-3. Add the storage resource provider: `az provider register --namespace Microsoft.Storage`
-4. Create a storage account: `az storage account create --name officialmcpregistryprod --resource-group official-mcp-registry-prod --location eastus --sku Standard_LRS`
-5. Add the 'Storage Blob Data Contributor' role assignment for yourself on the storage account: `az role assignment create --assignee $(az ad signed-in-user show --query id -o tsv) --role "Storage Blob Data Contributor" --scope "/subscriptions/$(az account show --query id -o tsv)/resourceGroups/official-mcp-registry-prod"`
-6. Create a container: `az storage container create --name pulumi-state --account-name officialmcpregistryprod`
-7. Set Pulumi's backend to Azure: `pulumi login 'azblob://pulumi-state?storage_account=officialmcpregistryprod'`
-8. Init the production stack: `pulumi stack init aksProd`
-  - TODO: This has a password that maybe needs to be shared with select contributors?
-9. Deploy: `go build && PULUMI_CONFIG_PASSPHRASE="" pulumi up --yes`
-10. Access the repository via the ingress load balancer. You can find its external IP with `kubectl get svc ingress-nginx-controller -n ingress-nginx` or view it in the Pulumi outputs. Then run `curl -H "Host: prod.registry.modelcontextprotocol.io" -k https://<EXTERNAL-IP>/v0/ping` to check that the service is up.
-
--->
 
 ## Structure
 
 ```
-├── main.go              # Pulumi program entry point
-├── Pulumi.yaml          # Project configuration
-├── Pulumi.local.yaml    # Local stack configuration
-├── Pulumi.prod.yaml     # Production stack configuration (Azure)
-├── Pulumi.gcp.yaml      # Production stack configuration (GCP)
-├── Makefile             # Build and deployment targets
-├── go.mod               # Go module dependencies
-├── go.sum               # Go module checksums
-└── pkg/                 # Infrastructure packages
-    ├── k8s/             # Kubernetes deployment components
+├── main.go                 # Pulumi program entry point
+├── Pulumi.yaml             # Project configuration
+├── Pulumi.local.yaml       # Local stack configuration
+├── Pulumi.gcpProd.yaml     # GCP production stack configuration
+├── Pulumi.gcpStaging.yaml  # GCP staging stack configuration
+├── Makefile                # Build and deployment targets
+├── go.mod                  # Go module dependencies
+├── go.sum                  # Go module checksums
+└── pkg/                    # Infrastructure packages
+    ├── k8s/                # Kubernetes deployment components
     │   ├── backup.go          # Database backup configuration
     │   ├── cert_manager.go    # SSL certificate management
     │   ├── deploy.go          # Deployment orchestration
     │   ├── ingress.go         # Ingress controller setup
+    │   ├── monitoring.go      # Metrics and monitoring setup
     │   ├── postgres.go        # PostgreSQL database deployment
     │   └── registry.go        # MCP Registry deployment
-    └── providers/       # Kubernetes cluster providers
+    └── providers/          # Kubernetes cluster providers
         ├── types.go           # Provider interface definitions
-        ├── aks/               # Azure Kubernetes Service provider
         ├── gcp/               # Google Kubernetes Engine provider
         └── local/             # Local kubeconfig provider
 ```
@@ -119,21 +95,22 @@ Pre-requisites:
 #### Deployment Flow
 1. Pulumi program starts in `main.go`
 2. Configuration is loaded from Pulumi config files
-3. Provider factory creates appropriate cluster provider (AKS or local)
+3. Provider factory creates appropriate cluster provider (GCP or local)
 4. Cluster provider sets up Kubernetes access
 5. `k8s.DeployAll()` orchestrates complete deployment:
    - Certificate manager for SSL/TLS
    - Ingress controller for external access
    - Database for data persistence
    - Backup infrastructure for database
+   - Monitoring and metrics collection
    - MCP Registry application
 
 ## Configuration
 
 | Parameter | Description | Required |
 |-----------|-------------|----------|
-| `environment` | Deployment environment (dev/prod) | Yes |
-| `provider` | Kubernetes provider (local/aks/gcp) | No (default: local) |
+| `environment` | Deployment environment (local/staging/prod) | Yes |
+| `provider` | Kubernetes provider (local/gcp) | No (default: local) |
 | `githubClientId` | GitHub OAuth Client ID | Yes |
 | `githubClientSecret` | GitHub OAuth Client Secret | Yes |
 | `gcpProjectId` | GCP Project ID (required when provider=gcp) | No |

--- a/deploy/pkg/k8s/ingress.go
+++ b/deploy/pkg/k8s/ingress.go
@@ -52,10 +52,7 @@ func SetupIngressController(ctx *pulumi.Context, cluster *providers.ProviderInfo
 			"controller": pulumi.Map{
 				"service": pulumi.Map{
 					"type": serviceType,
-					"annotations": pulumi.Map{
-						// Add Azure Load Balancer health probe annotation as otherwise it defaults to / which fails
-						"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": pulumi.String("/healthz"),
-					},
+					"annotations": pulumi.Map{},
 				},
 				"config": pulumi.Map{
 					// Disable strict path validation, to work around a bug in ingress-nginx


### PR DESCRIPTION
## Summary
- Removed Azure deployment section and references from README
- Updated project structure to reflect current GCP prod/staging configs  
- Removed Azure Load Balancer annotation from ingress controller
- Updated provider documentation to show GCP and local options only
- Added monitoring.go to project structure documentation

This cleans up outdated Azure/AKS deployment configuration that is no longer used, leaving only the current GCP-based deployment structure.