### PR TITLE
Improve stdio transport validation and function naming

### DIFF
--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -34,7 +34,7 @@ func ValidateServerJSON(serverJSON *apiv0.ServerJSON) error {
 
 	// Validate all remotes
 	for _, remote := range serverJSON.Remotes {
-		if err := validateTransport(&remote); err != nil {
+		if err := validateRemoteTransport(&remote); err != nil {
 			return err
 		}
 	}
@@ -173,7 +173,10 @@ func validatePackageTransport(transport *model.Transport, availableVariables []s
 	// Validate transport type is supported
 	switch transport.Type {
 	case model.TransportTypeStdio:
-		// No additional validation needed for stdio - URL should be empty
+		// Validate that URL is empty for stdio transport
+		if transport.URL != "" {
+			return fmt.Errorf("url must be empty for %s transport type, got: %s", transport.Type, transport.URL)
+		}
 		return nil
 	case model.TransportTypeStreamableHTTP, model.TransportTypeSSE:
 		// URL is required for streamable-http and sse
@@ -196,8 +199,8 @@ func validatePackageTransport(transport *model.Transport, availableVariables []s
 	}
 }
 
-// validateTransport validates a remote transport (no templating allowed)
-func validateTransport(obj *model.Transport) error {
+// validateRemoteTransport validates a remote transport (no templating allowed)
+func validateRemoteTransport(obj *model.Transport) error {
 	// Validate transport type is supported - remotes only support streamable-http and sse
 	switch obj.Type {
 	case model.TransportTypeStreamableHTTP, model.TransportTypeSSE:

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -736,7 +736,7 @@ func TestValidate_TransportValidation(t *testing.T) {
 	}{
 		// Package transport tests - stdio (no URL required)
 		{
-			name: "package transport stdio without URL",
+			name: "package transport stdio without URL should pass",
 			serverDetail: apiv0.ServerJSON{
 				Name:        "com.example/test-server",
 				Description: "A test server",
@@ -756,7 +756,7 @@ func TestValidate_TransportValidation(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			name: "package transport stdio with URL (should still work)",
+			name: "package transport stdio with URL (should fail)",
 			serverDetail: apiv0.ServerJSON{
 				Name:        "com.example/test-server",
 				Description: "A test server",
@@ -774,7 +774,7 @@ func TestValidate_TransportValidation(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "",
+			expectedError: "url must be empty for stdio transport type",
 		},
 		// Package transport tests - streamable-http (URL required)
 		{
@@ -1174,9 +1174,9 @@ func createValidServerWithArgument(arg model.Argument) apiv0.ServerJSON {
 		},
 		Packages: []model.Package{
 			{
-				Identifier:       "test-package",
-				RegistryType:     "npm",
-				RegistryBaseURL:  "https://registry.npmjs.org",
+				Identifier:      "test-package",
+				RegistryType:    "npm",
+				RegistryBaseURL: "https://registry.npmjs.org",
 				Transport: model.Transport{
 					Type: "stdio",
 				},


### PR DESCRIPTION
## Summary
- Add validation that URL must be empty for stdio transport types
- Rename `validateTransport` to `validateRemoteTransport` for better clarity
- Update corresponding test case to expect error when stdio transport has URL

## Context
This addresses two specific feedback comments from @domdomegg on PR #345:
1. "do we want to validate the the url _is_ empty?" - Now validates URL is empty for stdio
2. "maybe rename validateRemoteTransport or something?" - Renamed function for clarity

The changes enforce stricter validation while improving code readability through better naming.