### PR TITLE
Split registry and mcp-publisher into seperate release assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -118,4 +118,14 @@ signs:
 
 # This section defines the release format.
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  # Registry server archive
+  - id: registry
+    name_template: "registry_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    ids:
+      - registry
+  
+  # Publisher CLI archive
+  - id: publisher
+    name_template: "mcp-publisher_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    ids:
+      - publisher


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR splits the release assets into 2 - one for the registry and one for the mcp-publisher CLI.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
