### PR TITLE
docs: fix DNS authentication to use root domain instead of _mcp-registry subdomain

### DIFF
--- a/docs/explanations/namespacing.md
+++ b/docs/explanations/namespacing.md
@@ -22,7 +22,7 @@ Publishing to a namespace requires proving you control the corresponding identit
 - OIDC tokens in GitHub Actions workflows
 
 **Domain namespaces** (`com.company.*`):
-- DNS verification: TXT record at `_mcp-registry.company.com`
+- DNS verification: TXT record at `company.com`
 - HTTP verification: File at `https://company.com/.well-known/mcp-registry-auth`
 
 ## Namespace Scoping

--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -302,7 +302,7 @@ This opens your browser for OAuth authentication.
 openssl genpkey -algorithm Ed25519 -out key.pem
 
 # Get public key for DNS record
-echo "_mcp-registry.yourcompany.com. IN TXT \"v=MCPv1; k=ed25519; p=$(openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)\""
+echo "yourcompany.com. IN TXT \"v=MCPv1; k=ed25519; p=$(openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)\""
 
 # Add the TXT record to your DNS, then login
 mcp-publisher login dns --domain yourcompany.com --private-key $(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')

--- a/docs/reference/cli/commands.md
+++ b/docs/reference/cli/commands.md
@@ -91,7 +91,7 @@ openssl genpkey -algorithm Ed25519 -out key.pem
 openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64
 
 # Add DNS TXT record:
-# _mcp-registry.example.com. IN TXT "v=MCPv1; k=ed25519; p=PUBLIC_KEY"
+# example.com. IN TXT "v=MCPv1; k=ed25519; p=PUBLIC_KEY"
 
 # Extract private key for login
 openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n'


### PR DESCRIPTION
Fixes #385

Updates DNS authentication documentation to correctly specify that TXT records should be placed at the root domain (e.g., `example.com`) rather than the `_mcp-registry` subdomain.

The implementation correctly looks up TXT records at the root domain, but the documentation incorrectly instructed users to create records at `_mcp-registry.<domain>`. This mismatch was causing authentication failures.

## Why use root domain instead of subdomain?

Using the root domain is simpler and more intuitive:
- Authenticating with `example.com` grants permissions for `com.example/*` and `com.example.*`
- Users don't need to figure out which subdomain to use for verification
- Avoids confusion where `_mcp-registry.api.example.com` would only grant `com.example.api.*` permissions, not the intended `com.example.*`

The root domain approach is clearer: if you want to publish to `com.example/my-server`, you authenticate with `example.com`.

## Changes
- Updated publish-server.md to remove `_mcp-registry.` prefix from DNS examples
- Updated CLI commands reference documentation  
- Updated namespacing explanation documentation