### PR TITLE
Update registry launch announcement link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The MCP registry provides MCP clients with a list of MCP servers, like an app st
 
 ## Development Status
 
-**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://modelcontextprotocol.io/blog/registry-preview)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
+**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
 Current key maintainers:
 - **Adam Jones** (Anthropic) [@domdomegg](https://github.com/domdomegg)  


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix the registry announcement link to point to the actual blog post hosted at https://blog.modelcontextprotocol.io
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The existing link would redirect to https://modelcontextprotocol.io/docs/getting-started/intro.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
N/A
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
