### PR TITLE
docs: fix server lookup instructions in publishing guide

### DIFF
--- a/docs/guides/consuming/use-rest-api.md
+++ b/docs/guides/consuming/use-rest-api.md
@@ -9,7 +9,7 @@ Integration patterns and best practices for building applications that consume M
 **Authentication**: Not required for read-only access
 
 - **`GET /v0/servers`** - List all servers with pagination
-- **`GET /v0/servers/{id}`** - Get full server details including packages and configuration
+- **`GET /v0/servers/{id}`** - Get server details by UUID
 
 See the [interactive API documentation](https://registry.modelcontextprotocol.io/docs) for complete request/response schemas.
 

--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -318,24 +318,18 @@ mcp-publisher publish
 
 You'll see output like:
 ```
-✓ Validating server.json
-✓ Checking package ownership
-✓ Publishing to registry
-✓ Server published successfully!
-
-Your server is now available at:
-https://registry.modelcontextprotocol.io/servers/io.github.yourname/weather-server
+✓ Successfully published
 ```
 
 ## Step 6: Verify Publication
 
-Check that your server appears in the registry:
+Check that your server appears in the registry by searching for it:
 
 ```bash
-curl https://registry.modelcontextprotocol.io/servers/io.github.yourname/weather-server
+curl "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.yourname/weather-server"
 ```
 
-You should see your server metadata returned as JSON.
+You should see your server metadata returned in the JSON response.
 
 ## Troubleshooting
 

--- a/docs/reference/api/generic-registry-api.md
+++ b/docs/reference/api/generic-registry-api.md
@@ -15,7 +15,7 @@ The official registry has some more endpoints and restrictions on top of this. S
 
 ### Core Endpoints
 - **`GET /v0/servers`** - List all servers with pagination
-- **`GET /v0/servers/{id}`** - Get detailed server information by ID  
+- **`GET /v0/servers/{id}`** - Get server details by UUID
 - **`POST /v0/publish`** - Publish new server (optional, registry-specific authentication)
 
 ### Authentication


### PR DESCRIPTION
The publishing guide incorrectly suggested users could verify their server by directly accessing `/servers/{server-name}` or `/v0/servers/{server-name}`, but the API only supports:

1. **Search by name**: `GET /v0/servers?search={server-name}`
2. **Get by UUID**: `GET /v0/servers/{uuid}`

This PR updates the documentation to show the correct verification method using the search endpoint.

Fixes #410