### PR TITLE
Check for version and identifier for npm packages

### DIFF
--- a/internal/validators/registries/npm.go
+++ b/internal/validators/registries/npm.go
@@ -22,6 +22,18 @@ func ValidateNPM(ctx context.Context, pkg model.Package, serverName string) erro
 		pkg.RegistryBaseURL = model.RegistryURLNPM
 	}
 
+	if pkg.Identifier == "" {
+		return fmt.Errorf("package identifier is required for NPM packages")
+	}
+
+	// we need version to look up the package metadata
+	// not providing version will return all the versions
+	// and we won't be able to validate the mcpName field
+	// against the server name
+	if pkg.Version == "" {
+		return fmt.Errorf("package version is required for NPM packages")
+	}
+
 	// Validate that the registry base URL matches NPM exactly
 	if pkg.RegistryBaseURL != model.RegistryURLNPM {
 		return fmt.Errorf("registry type and base URL do not match: '%s' is not valid for registry type '%s'. Expected: %s",

--- a/internal/validators/registries/npm_test.go
+++ b/internal/validators/registries/npm_test.go
@@ -21,6 +21,30 @@ func TestValidateNPM_RealPackages(t *testing.T) {
 		errorMessage string
 	}{
 		{
+			name:         "empty package identifier should fail",
+			packageName:  "",
+			version:      "1.0.0",
+			serverName:   "com.example/test",
+			expectError:  true,
+			errorMessage: "package identifier is required for NPM packages",
+		},
+		{
+			name:         "empty package version should fail",
+			packageName:  "test-package",
+			version:      "",
+			serverName:   "com.example/test",
+			expectError:  true,
+			errorMessage: "package version is required for NPM packages",
+		},
+		{
+			name:         "both empty identifier and version should fail with identifier error first",
+			packageName:  "",
+			version:      "",
+			serverName:   "com.example/test",
+			expectError:  true,
+			errorMessage: "package identifier is required for NPM packages",
+		},
+		{
 			name:         "non-existent package should fail",
 			packageName:  generateRandomPackageName(),
 			version:      "1.0.0",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adding validation for version and identifier for packages.

## Motivation and Context
While debugging a bug, I found out that we need exact version to be there in package to fetch from npm, otherwise we won't be able to parse the response as it returns all versions. Even if we do, we still need to go and figure out which version have the mcpname associated with while iterating over all versions. So, we should make mandatory to have identifier and version present in the given package object if we want to validate package association with registries.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
UTs.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
