### PR TITLE
docs: clarify that PyPI/NuGet mcp-name can be in README comments

### DIFF
--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -152,7 +152,7 @@ Include your server name in your package README file using this format:
 
 **MCP name format**: `mcp-name: io.github.username/server-name`
 
-Add it to your README.md file (which becomes the package description on PyPI).
+Add it to your README.md file (which becomes the package description on PyPI). This can be in a comment if you want to hide it from display elsewhere.
 
 ### How It Works
 - Registry fetches `https://pypi.org/pypi/your-package/json`
@@ -184,7 +184,7 @@ Include your server name in your package's README using this format:
 
 **MCP name format**: `mcp-name: io.github.username/server-name`
 
-Add a README file to your NuGet package that includes the server name.
+Add a README file to your NuGet package that includes the server name. This can be in a comment if you want to hide it from display elsewhere.
 
 ### How It Works
 - Registry fetches README from `https://api.nuget.org/v3-flatcontainer/{id}/{version}/readme`


### PR DESCRIPTION
## Summary
- Clarifies that the `mcp-name` format can be included in comments within README files for both PyPI and NuGet packages
- This allows publishers to hide this technical detail from end-user documentation while still enabling registry discovery

## Context
The current documentation doesn't make it clear that the `mcp-name` line can be hidden in a comment, which might lead publishers to include visible technical details in their package documentation when they prefer to keep it clean for end users.