### PR TITLE
Fix PR #435 followups: move version range docs to description field

### DIFF
--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -110,13 +110,12 @@
         },
         "version": {
           "type": "string",
-          "description": "Package version",
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*').",
           "not": {
             "const": "latest"
           },
           "example": "1.0.2",
-          "minLength": 1,
-          "remarks": "Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
+          "minLength": 1
         },
         "file_sha256": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Move package version 'remarks' to 'description' field in JSON schema (remarks is not a standard JSON schema field)
- Confirmed non-semver version test coverage already exists

Addresses followup comments from #435.