### PR TITLE
feat: add GitHub Container Registry (ghcr.io) support

### DIFF
--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -259,7 +259,9 @@ LABEL io.modelcontextprotocol.server.name="io.github.username/server-name"
 
 The identifier is `namespace/repository`, and version is the tag and optionally digest.
 
-The official MCP registry currently only supports the official Docker registry (`https://docker.io`).
+The official MCP registry currently supports the following container registries:
+- Docker Hub (`https://docker.io`)
+- GitHub Container Registry (`https://ghcr.io`)
 
 </details>
 

--- a/docs/reference/server-json/official-registry-requirements.md
+++ b/docs/reference/server-json/official-registry-requirements.md
@@ -38,7 +38,7 @@ Only trusted public registries are supported. Private registries and alternative
 - **NPM**: `https://registry.npmjs.org` only
 - **PyPI**: `https://pypi.org` only  
 - **NuGet**: `https://api.nuget.org` only
-- **Docker/OCI**: `https://docker.io` only
+- **Docker/OCI**: `https://docker.io` and `https://ghcr.io`
 - **MCPB**: `https://github.com` releases and `https://gitlab.com` releases only
 
 ## `_meta` Namespace Restrictions

--- a/internal/validators/registries/oci.go
+++ b/internal/validators/registries/oci.go
@@ -45,10 +45,9 @@ func ValidateOCI(ctx context.Context, pkg model.Package, serverName string) erro
 		pkg.RegistryBaseURL = model.RegistryURLDocker
 	}
 
-	// Validate that the registry base URL matches OCI/Docker exactly
-	if pkg.RegistryBaseURL != model.RegistryURLDocker {
-		return fmt.Errorf("registry type and base URL do not match: '%s' is not valid for registry type '%s'. Expected: %s",
-			pkg.RegistryBaseURL, model.RegistryTypeOCI, model.RegistryURLDocker)
+	// Validate that the registry base URL is in the allowed list
+	if err := validateRegistryURL(pkg.RegistryBaseURL); err != nil {
+		return err
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -59,28 +58,74 @@ func ValidateOCI(ctx context.Context, pkg model.Package, serverName string) erro
 		return fmt.Errorf("invalid OCI image reference: %w", err)
 	}
 
-	apiBaseURL := pkg.RegistryBaseURL
-	if pkg.RegistryBaseURL == model.RegistryURLDocker {
-		// docker.io is an exceptional registry that was created before standardisation, so needs a custom API base url
-		// https://github.com/containers/image/blob/5e4845dddd57598eb7afeaa6e0f4c76531bd3c91/docker/docker_client.go#L225-L229
-		apiBaseURL = dockerIoAPIBaseURL
+	// Map registry URLs to their API base URLs
+	apiBaseURL := getAPIBaseURL(pkg.RegistryBaseURL)
+
+	// Fetch and validate manifest
+	manifest, err := fetchManifest(ctx, client, apiBaseURL, namespace, repo, pkg)
+	if err != nil {
+		return err
 	}
 
+	// Get config digest from manifest
+	configDigest, err := getConfigDigest(ctx, client, apiBaseURL, namespace, repo, manifest, pkg)
+	if err != nil {
+		return err
+	}
+
+	// Get image config (contains labels)
+	config, err := getImageConfig(ctx, client, apiBaseURL, namespace, repo, configDigest, pkg)
+	if err != nil {
+		return fmt.Errorf("failed to get image config: %w", err)
+	}
+
+	// Validate MCP server name label
+	if err := validateMCPLabel(config, namespace, repo, pkg.Version, serverName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateRegistryURL(registryURL string) error {
+	allowedRegistries := []string{
+		model.RegistryURLDocker,
+		model.RegistryURLGHCR,
+	}
+
+	for _, allowed := range allowedRegistries {
+		if registryURL == allowed {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("registry type and base URL do not match: '%s' is not valid for registry type '%s'. Expected one of: %v",
+		registryURL, model.RegistryTypeOCI, allowedRegistries)
+}
+
+func getAPIBaseURL(registryURL string) string {
+	switch registryURL {
+	case model.RegistryURLDocker:
+		// docker.io is an exceptional registry that was created before standardisation, so needs a custom API base url
+		// https://github.com/containers/image/blob/5e4845dddd57598eb7afeaa6e0f4c76531bd3c91/docker/docker_client.go#L225-L229
+		return dockerIoAPIBaseURL
+	default:
+		// GitHub Container Registry and other registries use the standard OCI registry API
+		return registryURL
+	}
+}
+
+func fetchManifest(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo string, pkg model.Package) (*OCIManifest, error) {
 	tag := pkg.Version
 	manifestURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", apiBaseURL, namespace, repo, tag)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
 	if err != nil {
-		return fmt.Errorf("failed to create manifest request: %w", err)
+		return nil, fmt.Errorf("failed to create manifest request: %w", err)
 	}
 
-	// Get auth token for docker.io
-	// We only support auth for docker.io, other registries must allow unauthed requests
-	if apiBaseURL == dockerIoAPIBaseURL {
-		token, err := getDockerIoAuthToken(ctx, client, namespace, repo)
-		if err != nil {
-			return fmt.Errorf("failed to authenticate with Docker registry: %w", err)
-		}
-		req.Header.Set("Authorization", "Bearer "+token)
+	// Set authentication if needed
+	if err := setAuthentication(ctx, client, req, pkg.RegistryBaseURL, namespace, repo); err != nil {
+		return nil, err
 	}
 
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json")
@@ -88,50 +133,75 @@ func ValidateOCI(ctx context.Context, pkg model.Package, serverName string) erro
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to fetch OCI manifest: %w", err)
+		return nil, fmt.Errorf("failed to fetch OCI manifest: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("OCI image '%s/%s:%s' not found (status: %d)", namespace, repo, tag, resp.StatusCode)
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
-		// Rate limited, skip validation for now
-		log.Printf("Warning: Rate limited when accessing OCI image '%s/%s:%s'. Skipping validation.", namespace, repo, tag)
-		return nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to fetch OCI manifest (status: %d)", resp.StatusCode)
+	if err := checkResponseStatus(resp, namespace, repo, tag); err != nil {
+		return nil, err
 	}
 
 	var manifest OCIManifest
 	if err := json.NewDecoder(resp.Body).Decode(&manifest); err != nil {
-		return fmt.Errorf("failed to parse OCI manifest: %w", err)
+		return nil, fmt.Errorf("failed to parse OCI manifest: %w", err)
 	}
 
+	return &manifest, nil
+}
+
+func setAuthentication(ctx context.Context, client *http.Client, req *http.Request, registryURL, namespace, repo string) error {
+	switch registryURL {
+	case model.RegistryURLDocker:
+		token, err := getDockerIoAuthToken(ctx, client, namespace, repo)
+		if err != nil {
+			return fmt.Errorf("failed to authenticate with Docker registry: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	case model.RegistryURLGHCR:
+		// GitHub Container Registry requires token authentication even for public images
+		token, err := getGHCRAuthToken(ctx, client, namespace, repo)
+		if err != nil {
+			return fmt.Errorf("failed to authenticate with GitHub Container Registry: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return nil
+}
+
+func checkResponseStatus(resp *http.Response, namespace, repo, tag string) error {
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return nil
+	case http.StatusNotFound, http.StatusUnauthorized:
+		return fmt.Errorf("OCI image '%s/%s:%s' not found (status: %d)", namespace, repo, tag, resp.StatusCode)
+	case http.StatusTooManyRequests:
+		// Rate limited, skip validation for now
+		log.Printf("Warning: Rate limited when accessing OCI image '%s/%s:%s'. Skipping validation.", namespace, repo, tag)
+		return nil
+	default:
+		return fmt.Errorf("failed to fetch OCI manifest (status: %d)", resp.StatusCode)
+	}
+}
+
+func getConfigDigest(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo string, manifest *OCIManifest, pkg model.Package) (string, error) {
 	// Handle multi-arch images by using first manifest
-	var configDigest string
 	if len(manifest.Manifests) > 0 {
 		// This is a multi-arch image, get the specific manifest
-		specificManifest, err := getSpecificManifest(ctx, client, apiBaseURL, namespace, repo, manifest.Manifests[0].Digest)
+		specificManifest, err := getSpecificManifest(ctx, client, apiBaseURL, namespace, repo, manifest.Manifests[0].Digest, pkg)
 		if err != nil {
-			return fmt.Errorf("failed to get specific manifest: %w", err)
+			return "", fmt.Errorf("failed to get specific manifest: %w", err)
 		}
-		configDigest = specificManifest.Config.Digest
-	} else {
-		configDigest = manifest.Config.Digest
+		return specificManifest.Config.Digest, nil
 	}
 
-	if configDigest == "" {
-		return fmt.Errorf("unable to determine image config digest for '%s/%s:%s'", namespace, repo, tag)
+	if manifest.Config.Digest == "" {
+		return "", fmt.Errorf("unable to determine image config digest for '%s/%s:%s'", namespace, repo, pkg.Version)
 	}
 
-	// Get image config (contains labels)
-	config, err := getImageConfig(ctx, client, apiBaseURL, namespace, repo, configDigest)
-	if err != nil {
-		return fmt.Errorf("failed to get image config: %w", err)
-	}
+	return manifest.Config.Digest, nil
+}
 
+func validateMCPLabel(config *OCIImageConfig, namespace, repo, tag, serverName string) error {
 	mcpName, exists := config.Config.Labels["io.modelcontextprotocol.server.name"]
 	if !exists {
 		return fmt.Errorf("OCI image '%s/%s:%s' is missing required annotation. Add this to your Dockerfile: LABEL io.modelcontextprotocol.server.name=\"%s\"", namespace, repo, tag, serverName)
@@ -183,19 +253,54 @@ func getDockerIoAuthToken(ctx context.Context, client *http.Client, namespace, r
 	return authResp.Token, nil
 }
 
+// getGHCRAuthToken retrieves an authentication token from GitHub Container Registry
+func getGHCRAuthToken(ctx context.Context, client *http.Client, namespace, repo string) (string, error) {
+	authURL := fmt.Sprintf("https://ghcr.io/token?scope=repository:%s/%s:pull", namespace, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create auth request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to request auth token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("auth request failed with status %d", resp.StatusCode)
+	}
+
+	var authResp OCIAuthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return "", fmt.Errorf("failed to parse auth response: %w", err)
+	}
+
+	return authResp.Token, nil
+}
+
 // getSpecificManifest retrieves a specific manifest for multi-arch images
-func getSpecificManifest(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo, digest string) (*OCIManifest, error) {
+func getSpecificManifest(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo, digest string, pkg model.Package) (*OCIManifest, error) {
 	manifestURL := fmt.Sprintf("%s/v2/%s/%s/manifests/%s", apiBaseURL, namespace, repo, digest)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create specific manifest request: %w", err)
 	}
 
-	// Get auth token for docker.io
-	if apiBaseURL == dockerIoAPIBaseURL {
+	// Get auth token based on registry
+	switch {
+	case apiBaseURL == dockerIoAPIBaseURL:
 		token, err := getDockerIoAuthToken(ctx, client, namespace, repo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to authenticate with Docker registry: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	case pkg.RegistryBaseURL == model.RegistryURLGHCR:
+		// GHCR requires token authentication even for public images
+		token, err := getGHCRAuthToken(ctx, client, namespace, repo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to authenticate with GitHub Container Registry: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
@@ -222,18 +327,26 @@ func getSpecificManifest(ctx context.Context, client *http.Client, apiBaseURL, n
 }
 
 // getImageConfig retrieves the image configuration containing labels
-func getImageConfig(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo, configDigest string) (*OCIImageConfig, error) {
+func getImageConfig(ctx context.Context, client *http.Client, apiBaseURL, namespace, repo, configDigest string, pkg model.Package) (*OCIImageConfig, error) {
 	configURL := fmt.Sprintf("%s/v2/%s/%s/blobs/%s", apiBaseURL, namespace, repo, configDigest)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, configURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config request: %w", err)
 	}
 
-	// Get auth token for docker.io
-	if apiBaseURL == dockerIoAPIBaseURL {
+	// Get auth token based on registry
+	switch {
+	case apiBaseURL == dockerIoAPIBaseURL:
 		token, err := getDockerIoAuthToken(ctx, client, namespace, repo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to authenticate with Docker registry: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	case pkg.RegistryBaseURL == model.RegistryURLGHCR:
+		// GHCR requires token authentication even for public images
+		token, err := getGHCRAuthToken(ctx, client, namespace, repo)
+		if err != nil {
+			return nil, fmt.Errorf("failed to authenticate with GitHub Container Registry: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	}

--- a/internal/validators/registries/oci_test.go
+++ b/internal/validators/registries/oci_test.go
@@ -82,3 +82,66 @@ func TestValidateOCI_RealPackages(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateOCI_GHCR(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		packageName  string
+		version      string
+		serverName   string
+		registryURL  string
+		expectError  bool
+		errorMessage string
+	}{
+		{
+			name:         "GHCR: non-existent image should fail",
+			packageName:  generateRandomImageName(),
+			version:      "latest",
+			serverName:   "com.example/test",
+			registryURL:  model.RegistryURLGHCR,
+			expectError:  true,
+			errorMessage: "failed to authenticate with GitHub Container Registry", // GHCR returns 403 for non-existent repos
+		},
+		{
+			name:         "GHCR: real image without MCP annotation should fail", 
+			packageName:  "modelcontextprotocol/registry", // Registry's own image  
+			version:      "latest",
+			serverName:   "com.example/test",
+			registryURL:  model.RegistryURLGHCR,
+			expectError:  true,
+			errorMessage: "not found", // Returns 404 as image is not on GHCR
+		},
+		{
+			name:        "GHCR: test image with correct MCP annotation should pass",
+			packageName: "nkapila6/mcp-local-rag",
+			version:     "latest",
+			serverName:  "io.github.nkapila6/mcp-local-rag", // Should match annotation
+			registryURL: model.RegistryURLGHCR,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Running GHCR tests to verify functionality
+			
+			pkg := model.Package{
+				RegistryType:    model.RegistryTypeOCI,
+				RegistryBaseURL: tt.registryURL,
+				Identifier:      tt.packageName,
+				Version:         tt.version,
+			}
+
+			err := registries.ValidateOCI(ctx, pkg, tt.serverName)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMessage)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -14,6 +14,7 @@ const (
 	RegistryURLNPM    = "https://registry.npmjs.org"
 	RegistryURLPyPI   = "https://pypi.org"
 	RegistryURLDocker = "https://docker.io"
+	RegistryURLGHCR   = "https://ghcr.io"
 	RegistryURLNuGet  = "https://api.nuget.org"
 	RegistryURLGitHub = "https://github.com"
 	RegistryURLGitLab = "https://gitlab.com"


### PR DESCRIPTION
Extends OCI registry validation to support GitHub Container Registry alongside Docker Hub, addressing rate limiting concerns and providing more flexibility for MCP server publishers.

## Motivation and Context
- Add ghcr.io as an allowed OCI registry URL
- Update validation logic to use allowlist approach
- Configure correct API endpoints for GHCR
- Add authentication handling for GHCR public images
- Add comprehensive test coverage for GHCR validation
- Update documentation to reflect dual registry support
- Refactor ValidateOCI to reduce cyclomatic complexity

## How Has This Been Tested?
- All existing tests pass
- Added new test suite **TestValidateOCI_GHCR** with comprehensive coverage
- Validated with known GHCR image: `ghcr.io/nkapila6/mcp-local-rag`
- Verified backward compatibility with Docker Hub
- Linter passes with 0 issues (golangci-lint v2.4.0)

## Breaking Changes:
None - this change is fully backward compatible. Existing Docker Hub configurations continue to work as before.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Fixes #393
