### PR TITLE
feat: implement user-based daily publish rate limiting (#21)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,15 @@ MCP_REGISTRY_OIDC_EXTRA_CLAIMS=[{"hd":"modelcontextprotocol.io"}]
 # Grant admin permissions to OIDC-authenticated users
 MCP_REGISTRY_OIDC_EDIT_PERMISSIONS=*
 MCP_REGISTRY_OIDC_PUBLISH_PERMISSIONS=*
+
+# Rate Limiting Configuration
+# Enable/disable rate limiting for publish operations
+MCP_REGISTRY_RATE_LIMIT_ENABLED=true
+
+# Maximum number of servers a user can publish per day
+MCP_REGISTRY_RATE_LIMIT_PER_DAY=10
+
+# Comma-separated list of authenticated users (auth subjects) exempt from rate limiting
+# Supports wildcards: anthropic/* to exempt all users under anthropic domain
+# Examples: modelcontextprotocol, anthropic/*, specific-username
+MCP_REGISTRY_RATE_LIMIT_EXEMPTIONS=

--- a/docs/guides/administration/admin-operations.md
+++ b/docs/guides/administration/admin-operations.md
@@ -44,3 +44,27 @@ export SERVER_ID="<server-uuid>"
 ```
 
 This soft deletes the server. If you need to delete the content of a server (usually only where legally necessary), use the edit workflow above to scrub it all.
+
+## Rate Limiting Configuration
+
+The registry enforces daily publish rate limits to prevent abuse:
+
+### Environment Variables
+
+- `MCP_REGISTRY_RATE_LIMIT_ENABLED`: Enable/disable rate limiting (default: true)
+- `MCP_REGISTRY_RATE_LIMIT_PER_DAY`: Maximum publishes per user per day (default: 10)
+- `MCP_REGISTRY_RATE_LIMIT_EXEMPTIONS`: Comma-separated list of exempt users or patterns
+
+### Exemption Patterns
+
+Exemptions support wildcard patterns:
+- Exact match: `anthropic` (exempts user "anthropic")
+- Wildcard: `anthropic/*` (exempts "anthropic", "anthropic.claude", etc.)
+- Multiple exemptions: `anthropic/*,modelcontextprotocol,github/*`
+
+### Notes
+
+- Rate limits are per authenticated user (not per namespace)
+- Users with global admin permissions automatically bypass rate limits
+- Limits reset on a rolling 24-hour window
+- The counter is stored in the `publish_attempts` database table

--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -414,6 +414,9 @@ With authentication complete, publish your server:
 mcp-publisher publish
 ```
 
+> [!NOTE]
+> **Rate Limits**: The registry enforces a limit of 10 publishes per user per day to prevent abuse. If you exceed this limit, you'll receive an error message with your current count. If you need a higher limit for legitimate use cases, please [open an issue](https://github.com/modelcontextprotocol/registry/issues).
+
 You'll see output like:
 ```
 ✓ Successfully published

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -90,6 +90,18 @@ Yes, extensions under the `x-publisher` property are preserved when publishing t
 
 At time of last update, this was open for discussion in [#104](https://github.com/modelcontextprotocol/registry/issues/104).
 
+### What are the rate limits for publishing?
+
+The registry enforces daily rate limits to prevent abuse:
+
+- **Default limit**: 10 publishes per authenticated user per day (rolling 24-hour window)
+- **Who is affected**: All users except those with global admin permissions
+- **What counts**: Each successful publish counts toward your daily limit
+- **Exemptions**: Specific users or organizations can be exempted from rate limiting
+- **Error message**: If you exceed the limit, you'll receive an error with your current count
+
+If you need a higher limit for legitimate use cases, please open an issue at https://github.com/modelcontextprotocol/registry/issues
+
 ### Can I publish a private server?
 
 Private servers are those that are only accessible to a narrow set of users. For example, servers published on a private network (like `mcp.acme-corp.internal`) or on private package registries (e.g. `npx -y @acme/mcp --registry https://artifactory.acme-corp.internal/npm`).
@@ -118,9 +130,15 @@ The MVP delegates security scanning to:
 - Namespace authentication requirements
 - Character limits and regex validation on free-form fields
 - Manual takedown of spam or malicious servers
+- Daily publish rate limiting per authenticated user (10 publishes per day by default)
+
+The rate limiting system:
+- Limits are per authenticated user (not per namespace)
+- Default limit is 10 publishes per 24-hour period
+- Administrators with global permissions bypass rate limits
+- Specific users or patterns can be exempted from rate limiting
 
 In future we might explore:
-- Stricter rate limiting (e.g., 10 new servers per user per day)
 - Potential AI-based spam detection
 - Community reporting and admin blacklisting capabilities
 

--- a/internal/api/handlers/v0/edit_test.go
+++ b/internal/api/handlers/v0/edit_test.go
@@ -36,7 +36,7 @@ func TestEditServerEndpoint(t *testing.T) {
 		},
 		Version: "1.0.0",
 	}
-	published, err := registryService.Publish(testServer)
+	published, err := registryService.Publish(testServer, "testuser", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, published)
 	assert.NotNil(t, published.Meta)
@@ -56,7 +56,7 @@ func TestEditServerEndpoint(t *testing.T) {
 		},
 		Version: "1.0.0",
 	}
-	otherPublished, err := registryService.Publish(otherServer)
+	otherPublished, err := registryService.Publish(otherServer, "testuser", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, otherPublished)
 	assert.NotNil(t, otherPublished.Meta)
@@ -76,7 +76,7 @@ func TestEditServerEndpoint(t *testing.T) {
 		},
 		Version: "1.0.0",
 	}
-	deletedPublished, err := registryService.Publish(deletedServer)
+	deletedPublished, err := registryService.Publish(deletedServer, "testuser", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, deletedPublished)
 	assert.NotNil(t, deletedPublished.Meta)

--- a/internal/api/handlers/v0/publish.go
+++ b/internal/api/handlers/v0/publish.go
@@ -53,8 +53,17 @@ func RegisterPublishEndpoint(api huma.API, registry service.RegistryService, cfg
 			return nil, huma.Error403Forbidden(buildPermissionErrorMessage(input.Body.Name, claims.Permissions))
 		}
 
+		// Check if user has global permissions (admin)
+		hasGlobalPermissions := false
+		for _, perm := range claims.Permissions {
+			if perm.ResourcePattern == "*" {
+				hasGlobalPermissions = true
+				break
+			}
+		}
+
 		// Publish the server with extensions
-		publishedServer, err := registry.Publish(input.Body)
+		publishedServer, err := registry.Publish(input.Body, claims.AuthMethodSubject, hasGlobalPermissions)
 		if err != nil {
 			return nil, huma.Error400BadRequest("Failed to publish server", err)
 		}

--- a/internal/api/handlers/v0/publish_test.go
+++ b/internal/api/handlers/v0/publish_test.go
@@ -192,7 +192,7 @@ func TestPublishEndpoint(t *testing.T) {
 						ID:     "example/test-server-existing",
 					},
 				}
-				_, _ = registry.Publish(existingServer)
+				_, _ = registry.Publish(existingServer, "testuser", false)
 			},
 			expectedStatus: http.StatusBadRequest,
 			expectedError:  "invalid version: cannot publish duplicate version",

--- a/internal/api/handlers/v0/servers_test.go
+++ b/internal/api/handlers/v0/servers_test.go
@@ -52,8 +52,8 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "2.0.0",
 				}
-				_, _ = registry.Publish(server1)
-				_, _ = registry.Publish(server2)
+				_, _ = registry.Publish(server1, "testuser", false)
+				_, _ = registry.Publish(server2, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -71,7 +71,7 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "1.5.0",
 				}
-				_, _ = registry.Publish(server)
+				_, _ = registry.Publish(server, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -141,8 +141,8 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "1.0.0",
 				}
-				_, _ = registry.Publish(server1)
-				_, _ = registry.Publish(server2)
+				_, _ = registry.Publish(server1, "testuser", false)
+				_, _ = registry.Publish(server2, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -160,7 +160,7 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "1.0.0",
 				}
-				_, _ = registry.Publish(server)
+				_, _ = registry.Publish(server, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -188,8 +188,8 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "2.0.0",
 				}
-				_, _ = registry.Publish(server1)
-				_, _ = registry.Publish(server2) // This will be marked as latest
+				_, _ = registry.Publish(server1, "testuser", false)
+				_, _ = registry.Publish(server2, "testuser", false) // This will be marked as latest
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -217,8 +217,8 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "1.0.0",
 				}
-				_, _ = registry.Publish(server1)
-				_, _ = registry.Publish(server2)
+				_, _ = registry.Publish(server1, "testuser", false)
+				_, _ = registry.Publish(server2, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -274,10 +274,10 @@ func TestServersListEndpoint(t *testing.T) {
 					},
 					Version: "3.0.0",
 				}
-				_, _ = registry.Publish(server1v1)
-				_, _ = registry.Publish(server1v2)
-				_, _ = registry.Publish(server2)
-				_, _ = registry.Publish(server3)
+				_, _ = registry.Publish(server1v1, "testuser", false)
+				_, _ = registry.Publish(server1v2, "testuser", false)
+				_, _ = registry.Publish(server2, "testuser", false)
+				_, _ = registry.Publish(server3, "testuser", false)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -384,7 +384,7 @@ func TestServersDetailEndpoint(t *testing.T) {
 		Name:        "com.example/test-server",
 		Description: "A test server",
 		Version:     "1.0.0",
-	})
+	}, "testuser", false)
 	assert.NoError(t, err)
 
 	testCases := []struct {
@@ -472,7 +472,7 @@ func TestServersEndpointsIntegration(t *testing.T) {
 		Version: "1.0.0",
 	}
 
-	published, err := registryService.Publish(testServer)
+	published, err := registryService.Publish(testServer, "testuser", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, published)
 

--- a/internal/api/handlers/v0/telemetry_test.go
+++ b/internal/api/handlers/v0/telemetry_test.go
@@ -31,7 +31,7 @@ func TestPrometheusHandler(t *testing.T) {
 			ID:     "example/test-server",
 		},
 		Version: "2.0.0",
-	})
+	}, "testuser", false)
 	assert.NoError(t, err)
 
 	cfg := config.NewConfig()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	OIDCExtraClaims  string `env:"OIDC_EXTRA_CLAIMS" envDefault:""`
 	OIDCEditPerms    string `env:"OIDC_EDIT_PERMISSIONS" envDefault:""`
 	OIDCPublishPerms string `env:"OIDC_PUBLISH_PERMISSIONS" envDefault:""`
+	
+	// Rate Limiting Configuration
+	RateLimitEnabled    bool   `env:"RATE_LIMIT_ENABLED" envDefault:"true"`
+	RateLimitPerDay     int    `env:"RATE_LIMIT_PER_DAY" envDefault:"10"`
+	RateLimitExemptions string `env:"RATE_LIMIT_EXEMPTIONS" envDefault:""` // comma-separated
 }
 
 // NewConfig creates a new configuration with default values

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -40,6 +40,13 @@ type Database interface {
 	UpdateServer(ctx context.Context, id string, server *apiv0.ServerJSON) (*apiv0.ServerJSON, error)
 	// Close closes the database connection
 	Close() error
+	
+	// Rate limiting methods
+	IncrementPublishCount(ctx context.Context, authMethodSubject string) error
+	GetPublishCount(ctx context.Context, authMethodSubject string, date time.Time) (int, error)
+	// CheckAndIncrementPublishCount atomically checks if the count is under the limit and increments if so
+	// Returns the current count and whether the increment was successful
+	CheckAndIncrementPublishCount(ctx context.Context, authMethodSubject string, limit int) (currentCount int, incrementSuccessful bool, err error)
 }
 
 // ConnectionType represents the type of database connection

--- a/internal/database/migrations/005_add_publish_rate_limiting.sql
+++ b/internal/database/migrations/005_add_publish_rate_limiting.sql
@@ -1,0 +1,21 @@
+-- Add rate limiting table to track publish attempts by authenticated user and date
+CREATE TABLE publish_attempts (
+    auth_method_subject VARCHAR(255) NOT NULL,
+    attempt_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    first_attempt_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_attempt_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    PRIMARY KEY (auth_method_subject, attempt_date)
+);
+
+-- Index for efficient lookups by auth_method_subject
+CREATE INDEX idx_publish_attempts_auth_subject ON publish_attempts(auth_method_subject);
+
+-- Index for cleanup queries by date
+CREATE INDEX idx_publish_attempts_date ON publish_attempts(attempt_date);
+
+-- Comment for documentation
+COMMENT ON TABLE publish_attempts IS 'Tracks daily publish attempts per authenticated user for rate limiting';
+COMMENT ON COLUMN publish_attempts.auth_method_subject IS 'The authenticated user identifier (e.g., GitHub username)';
+COMMENT ON COLUMN publish_attempts.attempt_date IS 'The date of the attempts (resets daily)';
+COMMENT ON COLUMN publish_attempts.attempt_count IS 'Number of successful publishes on this date';

--- a/internal/database/rate_limit_db_test.go
+++ b/internal/database/rate_limit_db_test.go
@@ -1,0 +1,483 @@
+package database_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/registry/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAuthMethodSubject = "io.github.testuser"
+
+// TestDatabaseRateLimitPersistence tests that rate limit data persists correctly
+func TestDatabaseRateLimitPersistence(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+		// PostgreSQL tests would require a test database connection
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+			today := time.Now()
+
+			// Initial count should be 0
+			count, err := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Initial count should be 0")
+
+			// Increment count
+			err = tc.db.IncrementPublishCount(ctx, authMethodSubject)
+			assert.NoError(t, err)
+
+			// Count should be 1
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, count, "Count should be 1 after first increment")
+
+			// Increment multiple times
+			for i := 0; i < 4; i++ {
+				err = tc.db.IncrementPublishCount(ctx, authMethodSubject)
+				assert.NoError(t, err)
+			}
+
+			// Count should be 5
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 5, count, "Count should be 5 after 5 increments")
+
+			// Different authMethodSubject should have independent count
+			authMethodSubject2 := "io.github.otheruser"
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject2, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Different authMethodSubject should have 0 count")
+
+			err = tc.db.IncrementPublishCount(ctx, authMethodSubject2)
+			assert.NoError(t, err)
+
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject2, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, count, "Different authMethodSubject should have independent count")
+
+			// Original authMethodSubject count should be unchanged
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 5, count, "Original authMethodSubject count should be unchanged")
+		})
+	}
+}
+
+// TestDatabaseRateLimitDateIsolation tests that counts are isolated by date
+func TestDatabaseRateLimitDateIsolation(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+			today := time.Now()
+			yesterday := today.AddDate(0, 0, -1)
+			tomorrow := today.AddDate(0, 0, 1)
+
+			// Increment count for today
+			for i := 0; i < 3; i++ {
+				err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+				assert.NoError(t, err)
+			}
+
+			// Today's count should be 3
+			count, err := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 3, count, "Today's count should be 3")
+
+			// Yesterday's count should be 0
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject, yesterday)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Yesterday's count should be 0")
+
+			// Tomorrow's count should be 0
+			count, err = tc.db.GetPublishCount(ctx, authMethodSubject, tomorrow)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Tomorrow's count should be 0")
+		})
+	}
+}
+
+// TestDatabaseRateLimitConcurrency tests concurrent increments
+func TestDatabaseRateLimitConcurrency(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+			today := time.Now()
+			numGoroutines := 100
+			incrementsPerGoroutine := 10
+
+			var wg sync.WaitGroup
+			wg.Add(numGoroutines)
+
+			// Launch concurrent increments
+			for i := 0; i < numGoroutines; i++ {
+				go func() {
+					defer wg.Done()
+					for j := 0; j < incrementsPerGoroutine; j++ {
+						err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+						if err != nil {
+							t.Errorf("Unexpected error during increment: %v", err)
+						}
+					}
+				}()
+			}
+
+			wg.Wait()
+
+			// Verify final count is correct
+			expectedCount := numGoroutines * incrementsPerGoroutine
+			count, err := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedCount, count, "Final count should be %d", expectedCount)
+		})
+	}
+}
+
+// TestDatabaseRateLimitMultipleAuthMethodSubjects tests operations across multiple authMethodSubjects
+func TestDatabaseRateLimitMultipleAuthMethodSubjects(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			today := time.Now()
+			authMethodSubjects := []string{
+				"io.github.user1",
+				"io.github.user2",
+				"com.example.app",
+				"org.nonprofit.project",
+			}
+
+			// Increment each authMethodSubject a different number of times
+			for i, ns := range authMethodSubjects {
+				for j := 0; j <= i; j++ {
+					err := tc.db.IncrementPublishCount(ctx, ns)
+					assert.NoError(t, err)
+				}
+			}
+
+			// Verify each authMethodSubject has the correct count
+			for i, ns := range authMethodSubjects {
+				count, err := tc.db.GetPublishCount(ctx, ns, today)
+				assert.NoError(t, err)
+				assert.Equal(t, i+1, count, "AuthMethodSubject %s should have count %d", ns, i+1)
+			}
+		})
+	}
+}
+
+// TestDatabaseRateLimitAtomicity tests that increments are atomic
+func TestDatabaseRateLimitAtomicity(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+			today := time.Now()
+
+			// Run many concurrent increments and reads
+			numOperations := 1000
+			var wg sync.WaitGroup
+			wg.Add(numOperations * 2)
+
+			incrementCount := 0
+			var mu sync.Mutex
+
+			// Half doing increments
+			for i := 0; i < numOperations; i++ {
+				go func() {
+					defer wg.Done()
+					err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+					if err == nil {
+						mu.Lock()
+						incrementCount++
+						mu.Unlock()
+					}
+				}()
+			}
+
+			// Half doing reads (to test read/write races)
+			counts := make([]int, numOperations)
+			for i := 0; i < numOperations; i++ {
+				go func(idx int) {
+					defer wg.Done()
+					count, _ := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+					counts[idx] = count
+				}(i)
+			}
+
+			wg.Wait()
+
+			// Final count should match successful increments
+			finalCount, err := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, incrementCount, finalCount, "Final count should match successful increments")
+
+			// All read counts should be valid (between 0 and final count)
+			for _, count := range counts {
+				assert.GreaterOrEqual(t, count, 0, "Count should never be negative")
+				assert.LessOrEqual(t, count, finalCount, "Count should never exceed final count")
+			}
+		})
+	}
+}
+
+// TestDatabaseRateLimitZeroAndNegative tests edge cases with zero and boundary values
+func TestDatabaseRateLimitZeroAndNegative(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			today := time.Now()
+
+			// Empty authMethodSubject (edge case)
+			emptyNS := ""
+			count, err := tc.db.GetPublishCount(ctx, emptyNS, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Empty authMethodSubject should return 0")
+
+			_ = tc.db.IncrementPublishCount(ctx, emptyNS)
+			// The behavior for empty authMethodSubject might vary by implementation
+			// Just ensure it doesn't panic
+
+			// Very long authMethodSubject
+			longNS := "com." + string(make([]byte, 1000))
+			count, err = tc.db.GetPublishCount(ctx, longNS, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, count, "Long authMethodSubject should return 0 initially")
+
+			// Special characters in authMethodSubject
+			specialNS := "io.github.user-_.test@#$%"
+			err = tc.db.IncrementPublishCount(ctx, specialNS)
+			assert.NoError(t, err)
+
+			count, err = tc.db.GetPublishCount(ctx, specialNS, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, count, "Special character authMethodSubject should work")
+		})
+	}
+}
+
+// TestDatabaseRateLimitTimestamps tests timestamp recording functionality
+func TestDatabaseRateLimitTimestamps(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+			today := time.Now()
+
+			// First increment
+			beforeFirst := time.Now()
+			err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+			require.NoError(t, err)
+			afterFirst := time.Now()
+
+			// Small delay
+			time.Sleep(10 * time.Millisecond)
+
+			// Second increment
+			beforeSecond := time.Now()
+			err = tc.db.IncrementPublishCount(ctx, authMethodSubject)
+			require.NoError(t, err)
+			afterSecond := time.Now()
+
+			// Verify count is correct
+			count, err := tc.db.GetPublishCount(ctx, authMethodSubject, today)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, count)
+
+			// Note: Actual timestamp verification would require access to the
+			// first_attempt_at and last_attempt_at fields, which aren't exposed
+			// through the current interface. This test ensures the operations
+			// complete successfully with timing considerations.
+			_ = beforeFirst
+			_ = afterFirst
+			_ = beforeSecond
+			_ = afterSecond
+		})
+	}
+}
+
+// TestDatabaseRateLimitLargeScale tests with a large number of authMethodSubjects and operations
+func TestDatabaseRateLimitLargeScale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large scale test in short mode")
+	}
+
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			today := time.Now()
+			numAuthMethodSubjects := 100
+			incrementsPerAuthMethodSubject := 50
+
+			// Create many authMethodSubjects
+			authMethodSubjects := make([]string, numAuthMethodSubjects)
+			for i := 0; i < numAuthMethodSubjects; i++ {
+				authMethodSubjects[i] = fmt.Sprintf("io.github.user%d", i)
+			}
+
+			// Increment each authMethodSubject multiple times concurrently
+			var wg sync.WaitGroup
+			wg.Add(numAuthMethodSubjects)
+
+			for _, ns := range authMethodSubjects {
+				go func(authMethodSubject string, expectedCount int) {
+					defer wg.Done()
+					for j := 0; j < expectedCount; j++ {
+						err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+						if err != nil {
+							t.Errorf("Error incrementing %s: %v", authMethodSubject, err)
+						}
+					}
+				}(ns, incrementsPerAuthMethodSubject)
+			}
+
+			wg.Wait()
+
+			// Verify all counts
+			for _, ns := range authMethodSubjects {
+				count, err := tc.db.GetPublishCount(ctx, ns, today)
+				assert.NoError(t, err)
+				assert.Equal(t, incrementsPerAuthMethodSubject, count, "AuthMethodSubject %s should have correct count", ns)
+			}
+		})
+	}
+}
+
+// TestDatabaseRateLimitDateBoundaries tests behavior around date boundaries
+func TestDatabaseRateLimitDateBoundaries(t *testing.T) {
+	testCases := []struct {
+		name string
+		db   database.Database
+	}{
+		{
+			name: "MemoryDB",
+			db:   database.NewMemoryDB(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			authMethodSubject := testAuthMethodSubject
+
+			// Test with various dates
+			dates := []time.Time{
+				time.Now(),                          // Today
+				time.Now().AddDate(0, 0, -1),        // Yesterday
+				time.Now().AddDate(0, 0, 1),         // Tomorrow
+				time.Now().AddDate(-1, 0, 0),        // Last year
+				time.Now().AddDate(1, 0, 0),         // Next year
+				time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), // Y2K
+				time.Date(2038, 1, 19, 3, 14, 7, 0, time.UTC), // Near Unix timestamp limit
+			}
+
+			for _, date := range dates {
+				count, err := tc.db.GetPublishCount(ctx, authMethodSubject, date)
+				assert.NoError(t, err)
+				assert.Equal(t, 0, count, "Count for date %v should be 0", date)
+			}
+
+			// Increment today's count
+			err := tc.db.IncrementPublishCount(ctx, authMethodSubject)
+			assert.NoError(t, err)
+
+			// Only today should have a count
+			count, err := tc.db.GetPublishCount(ctx, authMethodSubject, time.Now())
+			assert.NoError(t, err)
+			assert.Equal(t, 1, count, "Today's count should be 1")
+
+			// All other dates should still be 0
+			for _, date := range dates[1:] {
+				count, err = tc.db.GetPublishCount(ctx, authMethodSubject, date)
+				assert.NoError(t, err)
+				assert.Equal(t, 0, count, "Count for date %v should still be 0", date)
+			}
+		})
+	}
+}
+

--- a/internal/service/publish_rate_limit_test.go
+++ b/internal/service/publish_rate_limit_test.go
@@ -1,0 +1,314 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/registry/internal/config"
+	"github.com/modelcontextprotocol/registry/internal/database"
+	"github.com/modelcontextprotocol/registry/internal/service"
+	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/modelcontextprotocol/registry/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestServer(name string, version string) apiv0.ServerJSON {
+	return apiv0.ServerJSON{
+		Name:        name,
+		Description: "A test server",
+		Repository: model.Repository{
+			URL:    "https://github.com/testuser/test-repo",
+			Source: "github",
+			ID:     "testuser/test-repo",
+		},
+		Version: version,
+	}
+}
+
+func TestPublish_RateLimiting(t *testing.T) {
+	tests := []struct {
+		name                 string
+		authMethodSubject    string
+		hasGlobalPermissions bool
+		existingCount        int
+		limit                int
+		enabled              bool
+		exemptions           string
+		expectError          bool
+		errorContains        string
+	}{
+		{
+			name:                 "under limit allows publish",
+			authMethodSubject:    "testuser",
+			hasGlobalPermissions: false,
+			existingCount:        5,
+			limit:                10,
+			enabled:              true,
+			expectError:          false,
+		},
+		{
+			name:                 "at limit blocks publish",
+			authMethodSubject:    "testuser",
+			hasGlobalPermissions: false,
+			existingCount:        10,
+			limit:                10,
+			enabled:              true,
+			expectError:          true,
+			errorContains:        "rate limit exceeded",
+		},
+		{
+			name:                 "disabled allows any",
+			authMethodSubject:    "testuser",
+			hasGlobalPermissions: false,
+			existingCount:        100,
+			limit:                10,
+			enabled:              false,
+			expectError:          false,
+		},
+		{
+			name:                 "global permissions bypasses",
+			authMethodSubject:    "testuser",
+			hasGlobalPermissions: true,
+			existingCount:        100,
+			limit:                10,
+			enabled:              true,
+			expectError:          false,
+		},
+		{
+			name:                 "exempt user bypasses",
+			authMethodSubject:    "exemptuser",
+			hasGlobalPermissions: false,
+			existingCount:        100,
+			limit:                10,
+			enabled:              true,
+			exemptions:           "exemptuser",
+			expectError:          false,
+		},
+		{
+			name:                 "wildcard exemption works",
+			authMethodSubject:    "anthropic.claude",
+			hasGlobalPermissions: false,
+			existingCount:        100,
+			limit:                10,
+			enabled:              true,
+			exemptions:           "anthropic/*",
+			expectError:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			db := database.NewMemoryDB()
+			cfg := &config.Config{
+				RateLimitEnabled:         tt.enabled,
+				RateLimitPerDay:          tt.limit,
+				RateLimitExemptions:      tt.exemptions,
+				EnableRegistryValidation: false,
+			}
+
+			// Pre-populate existing attempts
+			ctx := context.Background()
+			for i := 0; i < tt.existingCount; i++ {
+				err := db.IncrementPublishCount(ctx, tt.authMethodSubject)
+				require.NoError(t, err)
+			}
+
+			// Test
+			svc := service.NewRegistryService(db, cfg)
+			testServer := createTestServer("io.github.test/server", "1.0.0")
+			_, err := svc.Publish(testServer, tt.authMethodSubject, tt.hasGlobalPermissions)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPublish_ConcurrentRateLimiting(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewMemoryDB()
+	cfg := &config.Config{
+		RateLimitEnabled:         true,
+		RateLimitPerDay:          10,
+		EnableRegistryValidation: false,
+	}
+	svc := service.NewRegistryService(db, cfg)
+
+	authMethodSubject := "testuser"
+	numGoroutines := 20
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	successCount := 0
+	var mu sync.Mutex
+	errors := make([]error, 0)
+
+	// Launch concurrent publish attempts
+	for i := 0; i < numGoroutines; i++ {
+		go func(version int) {
+			defer wg.Done()
+			testServer := createTestServer("io.github.test/server", fmt.Sprintf("1.0.%d", version))
+			_, err := svc.Publish(testServer, authMethodSubject, false)
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				successCount++
+			} else {
+				errors = append(errors, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// With the atomic check-and-increment operation, exactly 10 should succeed
+	assert.Equal(t, 10, successCount, "Expected exactly 10 successful publishes")
+	assert.Equal(t, 10, len(errors), "Expected exactly 10 rate limit errors")
+
+	// Verify all errors are rate limit errors
+	for _, err := range errors {
+		assert.Contains(t, err.Error(), "rate limit exceeded")
+	}
+
+	// Verify the database count is exactly 10
+	count, err := db.GetPublishCount(ctx, authMethodSubject, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 10, count, "Database should show exactly 10 publishes")
+}
+
+func TestPublish_DifferentUsersIndependentLimits(t *testing.T) {
+	cfg := &config.Config{
+		RateLimitEnabled:         true,
+		RateLimitPerDay:          3,
+		EnableRegistryValidation: false,
+	}
+	db := database.NewMemoryDB()
+	svc := service.NewRegistryService(db, cfg)
+
+	user1 := "user1"
+	user2 := "user2"
+
+	// Fill up user1's limit
+	for i := 0; i < 3; i++ {
+		testServer := createTestServer("io.github.test/server1", fmt.Sprintf("1.0.%d", i))
+		_, err := svc.Publish(testServer, user1, false)
+		assert.NoError(t, err)
+	}
+
+	// user1 should be blocked
+	testServer := createTestServer("io.github.test/server1", "1.0.99")
+	_, err := svc.Publish(testServer, user1, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+
+	// user2 should still have full quota
+	for i := 0; i < 3; i++ {
+		testServer := createTestServer("io.github.test/server2", fmt.Sprintf("1.0.%d", i))
+		_, err := svc.Publish(testServer, user2, false)
+		assert.NoError(t, err, "user2 publish %d should succeed", i+1)
+	}
+
+	// Now user2 should also be blocked
+	testServer = createTestServer("io.github.test/server2", "1.0.99")
+	_, err = svc.Publish(testServer, user2, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+}
+
+func TestPublish_ExemptionPatterns(t *testing.T) {
+	tests := []struct {
+		name              string
+		exemptions        string
+		authMethodSubject string
+		isExempt          bool
+	}{
+		{
+			name:              "exact match exemption",
+			exemptions:        "modelcontextprotocol",
+			authMethodSubject: "modelcontextprotocol",
+			isExempt:          true,
+		},
+		{
+			name:              "wildcard root match",
+			exemptions:        "anthropic/*",
+			authMethodSubject: "anthropic",
+			isExempt:          true,
+		},
+		{
+			name:              "wildcard subdomain match",
+			exemptions:        "anthropic/*",
+			authMethodSubject: "anthropic.claude",
+			isExempt:          true,
+		},
+		{
+			name:              "wildcard deep subdomain match",
+			exemptions:        "anthropic/*",
+			authMethodSubject: "anthropic.claude.test.deep",
+			isExempt:          true,
+		},
+		{
+			name:              "no match for partial",
+			exemptions:        "anthropic/*",
+			authMethodSubject: "anthropi",
+			isExempt:          false,
+		},
+		{
+			name:              "multiple exemptions",
+			exemptions:        "test1,example/*,foo.bar",
+			authMethodSubject: "example.app",
+			isExempt:          true,
+		},
+		{
+			name:              "empty exemptions",
+			exemptions:        "",
+			authMethodSubject: "anyone",
+			isExempt:          false,
+		},
+		{
+			name:              "whitespace in exemptions",
+			exemptions:        "test1, example/*, foo.bar",
+			authMethodSubject: "example.app",
+			isExempt:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				RateLimitEnabled:         true,
+				RateLimitPerDay:          1,
+				RateLimitExemptions:      tt.exemptions,
+				EnableRegistryValidation: false,
+			}
+			db := database.NewMemoryDB()
+			svc := service.NewRegistryService(db, cfg)
+
+			// Pre-fill the limit
+			ctx := context.Background()
+			err := db.IncrementPublishCount(ctx, tt.authMethodSubject)
+			require.NoError(t, err)
+
+			// Try to publish
+			testServer := createTestServer("io.github.test/server", "1.0.0")
+			_, err = svc.Publish(testServer, tt.authMethodSubject, false)
+
+			if tt.isExempt {
+				assert.NoError(t, err, "Exempt user should be able to publish")
+			} else {
+				assert.Error(t, err, "Non-exempt user should be rate limited")
+				assert.Contains(t, err.Error(), "rate limit exceeded")
+			}
+		})
+	}
+}

--- a/internal/service/registry_service_test.go
+++ b/internal/service/registry_service_test.go
@@ -38,7 +38,7 @@ func TestValidateNoDuplicateRemoteURLs(t *testing.T) {
 	service := NewRegistryService(memDB, &config.Config{EnableRegistryValidation: false})
 
 	for _, server := range existingServers {
-		_, err := service.Publish(*server)
+		_, err := service.Publish(*server, "testuser", false)
 		if err != nil {
 			t.Fatalf("failed to publish server: %v", err)
 		}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -12,7 +12,7 @@ type RegistryService interface {
 	// Retrieve a single server by registry metadata ID
 	GetByID(id string) (*apiv0.ServerJSON, error)
 	// Publish a server
-	Publish(req apiv0.ServerJSON) (*apiv0.ServerJSON, error)
+	Publish(req apiv0.ServerJSON, authMethodSubject string, hasGlobalPermissions bool) (*apiv0.ServerJSON, error)
 	// Update an existing server
 	EditServer(id string, req apiv0.ServerJSON) (*apiv0.ServerJSON, error)
 }

--- a/tests/integration/docker-compose.integration-test.yml
+++ b/tests/integration/docker-compose.integration-test.yml
@@ -3,6 +3,7 @@ services:
     environment:
       - MCP_REGISTRY_SEED_FROM=
       - MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false
+      - MCP_REGISTRY_RATE_LIMIT_PER_DAY=15
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/v0/servers"]
       interval: 1s


### PR DESCRIPTION
## Motivation and Context
Issue #21 

## How Has This Been Tested?
- All existing tests updated for new method signatures
- New tests for concurrent requests, exemptions, and user-specific limits

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- Rate limit by authenticated user `authMethodSubject` based off of #378 
- Admin bypass via hasGlobalPermissions parameter from auth handler
- Atomic database operations with separate publish_attempts table
- Integrated rate limiting directly into registry service
- Support for rate limit exemptions with wildcard patterns
- Comprehensive test coverage including concurrent request handling

### Configuration:
- MCP_REGISTRY_RATE_LIMIT_ENABLED: Enable/disable rate limiting (default: true)
- MCP_REGISTRY_RATE_LIMIT_PER_DAY: Daily publish limit per user (default: 10)
- MCP_REGISTRY_RATE_LIMIT_EXEMPTIONS: Comma-separated exempt users/patterns

### Database changes:
- New table: publish_attempts tracking auth_method_subject instead of namespace
- Atomic check-and-increment operation prevents race conditions

