### PR TITLE
Add NuGet to package deployment options

### DIFF
--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -24,7 +24,7 @@ By the end of this tutorial, you'll have:
 
 You can make your MCP server available in multiple ways:
 
-- **📦 Package deployment**: Published to registries (npm, PyPI, Docker Hub, etc.) and run locally by clients
+- **📦 Package deployment**: Published to registries (npm, PyPI, NuGet, Docker Hub, etc.) and run locally by clients
 - **🌐 Remote deployment**: Hosted as a web service that clients connect to directly  
 - **🔄 Hybrid deployment**: Offer both package and remote options for maximum flexibility
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

NuGet package deployment option is mentioned in the [guidelines](https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md#configure-deployment-methods) for publishing MCP Server to the registry, but `NuGet` is not mentioned in the top of the page.

<img width="617" height="134" alt="image (3)" src="https://github.com/user-attachments/assets/e64559f4-5ab5-44f3-922b-82dda1e781db" />

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Documentation update

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
