### PR TITLE
Increase GKE node size to e2-standard-2

### DIFF
--- a/deploy/pkg/k8s/monitoring.go
+++ b/deploy/pkg/k8s/monitoring.go
@@ -410,6 +410,7 @@ func deployGrafana(ctx *pulumi.Context, cluster *providers.ProviderInfo, ns *cor
 		OtherFields: map[string]any{
 			"spec": map[string]any{
 				"instances": 1,
+				"enablePDB": false,
 				"storage": map[string]any{
 					"size": "10Gi",
 				},

--- a/deploy/pkg/k8s/postgres.go
+++ b/deploy/pkg/k8s/postgres.go
@@ -55,6 +55,7 @@ func DeployPostgresDatabases(ctx *pulumi.Context, cluster *providers.ProviderInf
 		OtherFields: map[string]any{
 			"spec": map[string]any{
 				"instances": 1,
+				"enablePDB": false,
 				"storage": map[string]any{
 					"size": "50Gi",
 				},

--- a/deploy/pkg/providers/gcp/provider.go
+++ b/deploy/pkg/providers/gcp/provider.go
@@ -129,7 +129,7 @@ func (p *Provider) CreateCluster(ctx *pulumi.Context, environment string) (*prov
 		// Node pool configuration
 		NodeCount: pulumi.Int(2),
 		NodeConfig: &container.NodePoolNodeConfigArgs{
-			MachineType: pulumi.String("e2-small"),
+			MachineType: pulumi.String("e2-standard-2"),
 			DiskSizeGb:  pulumi.Int(20),
 			DiskType:    pulumi.String("pd-standard"),
 		},


### PR DESCRIPTION
## Summary
Bumps the node machine type from e2-small to e2-standard-2 to provide more CPU and memory headroom for the cluster.

Also disables PodDisruptionBudgets (PDBs) for single-instance PostgreSQL clusters to prevent node upgrade operations from becoming blocked.

## Changes
- Increase GKE node machine type from e2-small to e2-standard-2
- Set `enablePDB: false` for registry and Grafana PostgreSQL clusters

## Context
The machine type increase addresses resource constraints causing deployment failures.

The PDB change prevents a specific issue where GKE node upgrades get stuck when trying to drain nodes containing single-instance PostgreSQL pods. With `minAvailable: 1` PDBs, evicting the only database instance violates the availability requirement, blocking the drain operation indefinitely. Disabling PDBs for these development/staging single-instance databases allows node maintenance to proceed smoothly.

For production deployments requiring high availability, the instances count should be increased to 3 with PDBs enabled.