### PR TITLE
Force Pulumi to replace the resources in case of a conflict

### DIFF
--- a/deploy/pkg/k8s/monitoring.go
+++ b/deploy/pkg/k8s/monitoring.go
@@ -150,7 +150,7 @@ func deployVictoriaLogs(ctx *pulumi.Context, cluster *providers.ProviderInfo, ns
 				},
 			},
 		},
-	}, pulumi.Provider(cluster.Provider))
+	}, pulumi.Provider(cluster.Provider), pulumi.ReplaceOnChanges([]string{"*"}))
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func deployOtelCollectorDaemonSet(ctx *pulumi.Context, cluster *providers.Provid
 				},
 			},
 		},
-	}, pulumi.Provider(cluster.Provider))
+	}, pulumi.Provider(cluster.Provider), pulumi.ReplaceOnChanges([]string{"*"}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR aims to solve the server side apply errors in CI forcing Pulumi to replace the resources instead of trying to apply changes when field manager conflicts occur

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
