### PR TITLE
Fix OpenAPI spec: use correct Remote type field name

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -439,12 +439,12 @@ components:
     Remote:
       type: object
       required:
-        - transport_type
+        - type
         - url
       properties:
-        transport_type:
+        type:
           type: string
-          enum: [streamable, sse]
+          enum: [streamable-http, sse]
           description: Transport protocol type
           example: "sse"
         url:


### PR DESCRIPTION
## Summary
- Fixed `Remote` schema in OpenAPI spec to use correct field name `type` instead of `transport_type`
- Updated enum values from `[streamable, sse]` to `[streamable-http, sse]` to match actual API

## Context
The OpenAPI spec was inconsistent with the actual API implementation. The live API at https://registry.modelcontextprotocol.io/v0/servers returns `type: 'sse'` and `type: 'streamable-http'`, but the spec defined `transport_type` with values `streamable` and `sse`.

This now matches:
- The Go constants in pkg/model/constants.go
- The actual API responses