### PR TITLE
fix: make seed imports idempotent by ignoring duplicate version_id

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -356,6 +356,7 @@ func (db *PostgreSQL) CreateServer(ctx context.Context, server *apiv0.ServerJSON
 	query := `
 		INSERT INTO servers (version_id, value)
 		VALUES ($1, $2)
+		ON CONFLICT (version_id) DO NOTHING
 	`
 
 	_, err = db.pool.Exec(ctx, query, versionID, valueJSON)
@@ -385,7 +386,7 @@ func (db *PostgreSQL) UpdateServer(ctx context.Context, id string, server *apiv0
 
 	// Update the complete server record using version_id
 	query := `
-		UPDATE servers 
+		UPDATE servers
 		SET value = $1
 		WHERE version_id = $2
 	`


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->
Fix seed imports to be idempotent by handling duplicate version_id conflicts

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
During seed data imports, duplicate version_id entries could cause database constraint violations and prevent the seed process from completing successfully. This fix makes the seed import
process idempotent by gracefully handling duplicate version_id conflicts using PostgreSQL's `ON CONFLICT DO NOTHING` clause.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Tested seed import process with existing data in the database
- Verified that duplicate version_id entries are silently ignored without errors
- Confirmed that the seed process can be run multiple times without failures

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This is a backwards-compatible bug fix that improves the robustness of the seed import process.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The fix modifies the `CreateServer` method in `internal/database/postgres.go` to use `ON CONFLICT (version_id) DO NOTHING` when inserting servers. This PostgreSQL-specific syntax ensures that if
a server with the same version_id already exists, the insert operation is silently ignored rather than throwing a constraint violation error.