### PR TITLE
docs: add community resources section with OtherVibes/mcp-publish-action

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -5,6 +5,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 ## Featured Projects
 
 - [TeamSparkAI: Tool Catalog](https://github.com/TeamSparkAI/ToolCatalog) - Browse and discover servers from the official MCP Registry
+- [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - Add your project here!
 
 ## Adding Your Project

--- a/docs/guides/publishing/github-actions.md
+++ b/docs/guides/publishing/github-actions.md
@@ -136,40 +136,6 @@ You can keep your package version and server.json version in sync automatically 
     jq --arg v "$VERSION" '.version = $v' server.json > tmp && mv tmp server.json
 ```
 
-## Community Resources
-
-**⚠️ Disclaimer**: The following are third-party, community-maintained tools that are not officially endorsed by the MCP Registry team. Use at your own discretion and review the source code before using in production.
-
-### Third-party GitHub Actions
-
-#### OtherVibes/mcp-publish-action
-
-A reusable GitHub Action that simplifies automated MCP server publishing by handling `server.json` creation and using the MCP Publisher CLI with GitHub OIDC authentication.
-
-**Repository**: [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action)
-
-**Key Features**:
-- Automatically constructs `server.json` using the official schema
-- Supports multiple registry types (PyPI, npm, OCI, NuGet, MCPB)
-- Supports multiple transport types (stdio, streamable-http, sse)
-- Uses GitHub OIDC authentication (no secrets required)
-- Reduces workflow boilerplate
-
-**Example Usage**:
-```yaml
-- name: Publish to MCP Registry
-  uses: OtherVibes/mcp-publish-action@v1
-  with:
-    name: io.github.owner/repo
-    description: "MCP server providing weather data and forecasts"
-    version: "1.0.0"
-    registry_type: pypi
-    identifier: my-server
-    transport_type: stdio
-```
-
-**Benefits**: Zero need to copy workflow YAML steps, keeps up with protocol changes, and aligns with OIDC best practices.
-
 ## Troubleshooting
 - **"Authentication failed"**: Ensure `id-token: write` permission is set for OIDC, or check secrets
 - **"Package validation failed"**: Verify your package published to your registry (NPM, PyPi etc.) successfully first, and that you have done the necessary validation steps in the [Publishing Tutorial](publish-server.md)

--- a/docs/guides/publishing/github-actions.md
+++ b/docs/guides/publishing/github-actions.md
@@ -136,6 +136,40 @@ You can keep your package version and server.json version in sync automatically 
     jq --arg v "$VERSION" '.version = $v' server.json > tmp && mv tmp server.json
 ```
 
+## Community Resources
+
+**⚠️ Disclaimer**: The following are third-party, community-maintained tools that are not officially endorsed by the MCP Registry team. Use at your own discretion and review the source code before using in production.
+
+### Third-party GitHub Actions
+
+#### OtherVibes/mcp-publish-action
+
+A reusable GitHub Action that simplifies automated MCP server publishing by handling `server.json` creation and using the MCP Publisher CLI with GitHub OIDC authentication.
+
+**Repository**: [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action)
+
+**Key Features**:
+- Automatically constructs `server.json` using the official schema
+- Supports multiple registry types (PyPI, npm, OCI, NuGet, MCPB)
+- Supports multiple transport types (stdio, streamable-http, sse)
+- Uses GitHub OIDC authentication (no secrets required)
+- Reduces workflow boilerplate
+
+**Example Usage**:
+```yaml
+- name: Publish to MCP Registry
+  uses: OtherVibes/mcp-publish-action@v1
+  with:
+    name: io.github.owner/repo
+    description: "MCP server providing weather data and forecasts"
+    version: "1.0.0"
+    registry_type: pypi
+    identifier: my-server
+    transport_type: stdio
+```
+
+**Benefits**: Zero need to copy workflow YAML steps, keeps up with protocol changes, and aligns with OIDC best practices.
+
 ## Troubleshooting
 - **"Authentication failed"**: Ensure `id-token: write` permission is set for OIDC, or check secrets
 - **"Package validation failed"**: Verify your package published to your registry (NPM, PyPi etc.) successfully first, and that you have done the necessary validation steps in the [Publishing Tutorial](publish-server.md)


### PR DESCRIPTION
## Summary

Add Community Resources section to GitHub Actions guide referencing OtherVibes/mcp-publish-action as requested in discussion #518.

## Changes

- Add "Community Resources" section to `docs/guides/publishing/github-actions.md`
- Include reference to OtherVibes/mcp-publish-action with appropriate disclaimers
- Provide example usage and key features
- Position after Tips section for discoverability
- Structure allows for future community tool additions

## Context

This addresses the community request in discussion #518 where @OtherVibes suggested adding a reference to their reusable GitHub Action in the publishing docs. The maintainers (@tadasant, @domdomegg) approved adding a community resources section with appropriate disclaimers.

The implementation follows the original request to add the reference specifically to the GitHub Actions guide (`docs/guides/publishing/github-actions.md`) rather than creating a separate page.

## Benefits

- Provides users with a streamlined, community-built option for MCP server publishing
- Reduces workflow boilerplate for developers
- Includes clear disclaimers about third-party tools
- Maintains documentation cohesion by keeping everything in the relevant file

Closes #518