### PR TITLE
Update prod to follow the release cycles

### DIFF
--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -32,6 +32,12 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 	conf := config.New(ctx, "mcp-registry")
 	githubClientId := conf.Require("githubClientId")
 
+	// Determine Docker image tag based on environment
+	imageTag := "main" // Default for staging
+	if environment == "prod" {
+		imageTag = "latest" // Use latest release for production
+	}
+
 	// Create Secret with sensitive configuration
 	secret, err := corev1.NewSecret(ctx, "mcp-registry-secrets", &corev1.SecretArgs{
 		Metadata: &metav1.ObjectMetaArgs{
@@ -83,7 +89,7 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:            pulumi.String("mcp-registry"),
-							Image:           pulumi.String("ghcr.io/modelcontextprotocol/registry:main"),
+							Image:           pulumi.Sprintf("ghcr.io/modelcontextprotocol/registry:%s", imageTag),
 							ImagePullPolicy: pulumi.String("Always"),
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR updates production to automatically receive new stable releases when GitHub releases are cut while staging will continue testing the latest main branch builds

Deails:
- Configures production deployment to **use latest stable** releases instead of main branch -`ghcr.io/modelcontextprotocol/registry:latest`(stable releases). Released CLI matches version of the prod service API.
- Staging continues to **use main branch** for testing latest development code - `ghcr.io/modelcontextprotocol/registry:main` (latest development). Building the CLI from main would match the version of the staging service API.
- Added environment-based Docker image tag selection logic

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
No
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
