### PR TITLE
fix(spec): registryType, identifier, version should be required fields

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -291,6 +291,10 @@ components:
 
     Package:
       type: object
+      required:
+        - registryType
+        - identifier
+        - version
       properties:
         registryType:
           type: string


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This seems to be a regresion after rename, those fields were originally required:

https://github.com/modelcontextprotocol/registry/blob/8d7e471fd3f28fbaccb69f69e8b39483ac4c58c3/docs/server-registry-api/openapi.yaml#L247-L252

In https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json, those fields are also required.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
