### PR TITLE
docs: Add optional GitHub Actions workflow step to show last registration

### DIFF
--- a/docs/guides/publishing/github-actions.md
+++ b/docs/guides/publishing/github-actions.md
@@ -70,6 +70,22 @@ jobs:
         run: ./mcp-publisher publish
 ```
 
+Optionally, at the end of your workflow, you can show the latest registration for your server as the GitHub Actions workflow job summary. Replace "<<your server name>>" with the name of the server in the YAML snippet below.
+
+```yaml
+      - name: Show MCP registration
+        shell: bash
+        if: always()
+        run: |
+          # Show last registered version
+          curl -s -X GET "https://registry.modelcontextprotocol.io/v0/servers?search=<<your server name>>" \
+            -H "accept: application/json" | \
+            jq '.servers[0] | {name, version, _meta}' > output.json
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          cat output.json >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+```
+
 ### Step 2: Configure Secrets
 
 You don't need any secrets for publishing to the MCP Registry using GitHub OIDC.


### PR DESCRIPTION
Add a step to the GitHub Actions workflow to show the results of the publish operation.

## Motivation and Context
It shows the success of the publish operation with the id of the registration on the MCP Server Registry.


## How Has This Been Tested?
By publish my own MCP Server with this workflow step included.

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [N/A] My code follows the repository's style guidelines
- [N/A] New and existing tests pass locally
- [N/A] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.
