### PR TITLE
docs: update download link of mcp-publisher in GitHub Actions to 1.1.0

### DIFF
--- a/docs/guides/publishing/github-actions.md
+++ b/docs/guides/publishing/github-actions.md
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
This pull request makes a minor update to the documentation for installing the MCP Publisher in GitHub Actions workflows. The change updates the installation command to use version 1.1.0 of the MCP Publisher instead of version 1.0.0.

## Motivation and Context
The `mcp-publisher` version in GitHub Actions has to be updated so it can publish the MCP server to the newest version of MCP Registry.

## How Has This Been Tested?
Documentation update only. No test needed.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
