### PR TITLE
fix: detect server subfolder in init

### DIFF
--- a/cmd/publisher/commands/init.go
+++ b/cmd/publisher/commands/init.go
@@ -191,10 +191,8 @@ func buildGitHubServerName(repoURL, subfolder string) string {
 
 	// If we're in a subdirectory, use the current folder name
 	if subfolder != "" {
-		if cwd, err := os.Getwd(); err == nil {
-			folderName := filepath.Base(cwd)
-			return fmt.Sprintf("io.github.%s/%s", owner, folderName)
-		}
+		folderName := filepath.Base(subfolder)
+		return fmt.Sprintf("io.github.%s/%s", owner, folderName)
 	}
 
 	return fmt.Sprintf("io.github.%s/%s", owner, repo)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Discussion from this issue: https://github.com/modelcontextprotocol/registry/issues/538
We want to make it clearer that repo name & server name do not HAVE to be the same, especially in monorepos.

@tadasant this seems like a minor thing that doesn't have to be documented specifically, lmk if you disagree :) 

## How Has This Been Tested?
Tested the init flow locally, running the built `init` command from a subfolder and the repo root.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
