### PR TITLE
Updated sse/streamable uri constraints

### DIFF
--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -402,7 +402,7 @@
         "url": {
           "type": "string",
           "pattern": "^https?://[^\\s]+$",
-          "description": "Server-Sent Events endpoint URL",
+          "description": "URL template for the sse transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
           "example": "https://mcp-fs.example.com/sse"
         },
         "headers": {

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -371,6 +371,7 @@
         },
         "url": {
           "type": "string",
+          "pattern": "^https?://[^\\s]+$",
           "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
           "example": "https://api.example.com/mcp"
         },
@@ -400,7 +401,7 @@
         },
         "url": {
           "type": "string",
-          "format": "uri",
+          "pattern": "^https?://[^\\s]+$",
           "description": "Server-Sent Events endpoint URL",
           "example": "https://mcp-fs.example.com/sse"
         },

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -133,10 +133,10 @@
               "$ref": "#/definitions/StdioTransport"
             },
             {
-              "$ref": "#/definitions/StreamableHttpTransport"
+              "$ref": "#/definitions/PackageStreamableHttpTransport"
             },
             {
-              "$ref": "#/definitions/SseTransport"
+              "$ref": "#/definitions/PackageSseTransport"
             }
           ],
           "description": "Transport protocol configuration for the package"
@@ -371,8 +371,8 @@
         },
         "url": {
           "type": "string",
-          "pattern": "^https?://[^\\s]+$",
-          "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+          "format": "uri",
+          "description": "Remote streamable-http endpoint URL",
           "example": "https://api.example.com/mcp"
         },
         "headers": {
@@ -401,8 +401,8 @@
         },
         "url": {
           "type": "string",
-          "pattern": "^https?://[^\\s]+$",
-          "description": "URL template for the sse transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+          "format": "uri",
+          "description": "Remote Server-Sent Events endpoint URL",
           "example": "https://mcp-fs.example.com/sse"
         },
         "headers": {
@@ -413,6 +413,40 @@
           }
         }
       }
+    },
+    "PackageStreamableHttpTransport": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/StreamableHttpTransport"
+        },
+        {
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https?://[^\\s]+$",
+              "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+              "example": "https://api.example.com/mcp"
+            }
+          }
+        }
+      ]
+    },
+    "PackageSseTransport": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SseTransport"
+        },
+        {
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https?://[^\\s]+$",
+              "description": "URL template for the sse transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+              "example": "https://mcp-fs.example.com/sse"
+            }
+          }
+        }
+      ]
     },
     "ServerDetail": {
       "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -372,7 +372,7 @@
         "url": {
           "type": "string",
           "format": "uri",
-          "description": "Remote streamable-http endpoint URL",
+          "description": "Streamable-http endpoint URL",
           "example": "https://api.example.com/mcp"
         },
         "headers": {
@@ -402,7 +402,7 @@
         "url": {
           "type": "string",
           "format": "uri",
-          "description": "Remote Server-Sent Events endpoint URL",
+          "description": "Server-Sent Events endpoint URL",
           "example": "https://mcp-fs.example.com/sse"
         },
         "headers": {
@@ -425,7 +425,7 @@
               "type": "string",
               "pattern": "^https?://[^\\s]+$",
               "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
-              "example": "https://api.example.com/mcp"
+              "example": "https://api.example.com:{port}/mcp"
             }
           }
         }
@@ -442,7 +442,7 @@
               "type": "string",
               "pattern": "^https?://[^\\s]+$",
               "description": "URL template for the sse transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
-              "example": "https://mcp-fs.example.com/sse"
+              "example": "https://mcp-fs.example.com:{port}/sse"
             }
           }
         }


### PR DESCRIPTION
Added token substitution support to SSE transport URIs to fix failing schema validations in public servers (bug fix)

Constrained token substitution to only package transport uris (where there is something to resolve tokens against)

## Motivation and Context
Quite a number of existing servers failed schema validation because of package SSE transports with tokens in their uris. It appears that the intent was to support variable substitution in both streamable and sse transport uris, but the change enabling that was only applied to streamable (where the `description` was updated and the `format: uri` was removed).

It also appears to be the case that variable substitution is only intended to be supported for transports inside of packages where there is something to resolve the variables against.  The original streamable change would have allowed for tokens in remote transport uris as well (which would be unresolvable).

This change makes StreamableHttpTransport and SseTransport work like they used to (restored `format: uri`, and reverted to simplified description).  And it makes new PackageStreamableHttpTransport and PackageSseTransport derived from those that overrides the uri properties with ones that support variable substitution (description, pattern, and examples with variable substitution).

## How Has This Been Tested?
I ran schema validation with a local typescript script against all servers with current schema version using Ajv before and after and verified results.  If there is a tooling in the repo that would be better, please let me know.

## Breaking Changes
No breaking changes

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
