### PR TITLE
Enable a gitops way of promoting to prod

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,6 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
+  mcp-registry:imageTag: latest  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,7 +29,15 @@ PULUMI_CONFIG_PASSPHRASE="" pulumi config set mcp-registry:githubClientSecret --
 
 ### Production Deployment (GCP)
 
-**Note:** The production deployment is automatically handled by GitHub Actions. All merges to the `main` branch trigger an automatic deployment to GCP via [the configured GitHub Actions workflow](../.github/workflows/deploy.yml). The steps below are preserved as a log of what we did, or if a manual override is needed.
+**Note:** The production deployment is automatically handled by GitHub Actions. All merges to the `main` branch trigger an automatic deployment the `staging` environment at GCP via [the configured GitHub Actions workflow](../.github/workflows/deploy.yml).
+
+**Important:** Deployment to `prod` require explicit configuration of the Docker image tag in `Pulumi.gcpProd.yaml`. This prevents automatic promotion of new releases and provides manual control over production versions. To deploy a specific version:
+
+1. Update `mcp-registry:imageTag` in `Pulumi.gcpProd.yaml` to the desired version (e.g., `v1.0.0`, `main-20250930-abc123d`)
+2. Commit the changes and open a PR to `main`
+3. Once merged, the GitHub Actions workflow will deploy the specified version
+
+The steps below are preserved as a log of what we did, or if a manual override is needed.
 
 Pre-requisites:
 - [Pulumi CLI installed](https://www.pulumi.com/docs/iac/download-install/)
@@ -113,6 +121,7 @@ Pre-requisites:
 | `provider` | Kubernetes provider (local/gcp) | No (default: local) |
 | `githubClientId` | GitHub OAuth Client ID | Yes |
 | `githubClientSecret` | GitHub OAuth Client Secret | Yes |
+| `imageTag` | Docker image tag for production environment | Yes (prod only) |
 | `gcpProjectId` | GCP Project ID (required when provider=gcp) | No |
 | `gcpRegion` | GCP Region (default: us-central1) | No |
 

--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -35,7 +35,9 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 	// Determine Docker image tag based on environment
 	imageTag := "main" // Default for staging
 	if environment == "prod" {
-		imageTag = "latest" // Use latest release for production
+		// Use explicitly configured image tag for production
+		// This prevents automatic promotion and requires manual control of production releases
+		imageTag = conf.Require("imageTag") // Explicit configuration required - no fallback
 	}
 
 	// Create Secret with sensitive configuration

--- a/docs/guides/contributing/releasing.md
+++ b/docs/guides/contributing/releasing.md
@@ -21,6 +21,8 @@ The release workflow will automatically:
   - `ghcr.io/modelcontextprotocol/registry:vX.Y.Z` - Specific release version
 - Binaries can be downloaded from the GitHub release page
 
+**Note:** Releases do not automatically deploy to production. See the [deployment documentation](../../deploy/README.md) for production deployment instructions.
+
 ## Docker Image Tags
 
 The registry publishes different Docker image tags for different use cases:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR moves away from automatically promoting latest releases to production in favour of specifying the released version explicitly via a PR & Review process.

Still sets the image tag to latest for now so we can enable it separately whenever we decide 👍 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
