### PR TITLE
Update community projects with mcp-registry-spec-sdk

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -8,7 +8,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [mcp-insights](https://github.com/joelverhagen/mcp-insights/) - Analytics and insights for the MCP Registry
-- [Open Chat MCP Registry Client](https://github.com/cameronapak/open-chat/blob/main/apps/server/src/lib/mcp-registry/index.ts) - TypeScript client for the MCP Registry
+- [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
 - [MCP Server for MCP Registry](https://github.com/formulahendry/mcp-server-mcp-registry) - MCP Server to discover and search for available MCP servers in the registry
 - Add your project here!
 


### PR DESCRIPTION
Replace Open Chat MCP Registry Client link with the mcp-registry-spec-sdk npm package.