### PR TITLE
Use intermediate env vars for Pulumi passphrases

### DIFF
--- a/.github/workflows/cancel-pulumi-lock.yml
+++ b/.github/workflows/cancel-pulumi-lock.yml
@@ -58,15 +58,19 @@ jobs:
       - name: Cancel Pulumi Lock (Staging)
         if: inputs.environment == 'staging'
         working-directory: ./deploy
+        env:
+          PULUMI_STAGING_PASSPHRASE: ${{ secrets.PULUMI_STAGING_PASSPHRASE }}
         run: |
-          echo "${{ secrets.PULUMI_STAGING_PASSPHRASE }}" > passphrase.staging.txt
+          echo "$PULUMI_STAGING_PASSPHRASE" > passphrase.staging.txt
           pulumi login gs://mcp-registry-staging-pulumi-state
           PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.staging.txt pulumi cancel --stack gcpStaging --yes
 
       - name: Cancel Pulumi Lock (Production)
         if: inputs.environment == 'production'
         working-directory: ./deploy
+        env:
+          PULUMI_PROD_PASSPHRASE: ${{ secrets.PULUMI_PROD_PASSPHRASE }}
         run: |
-          echo "${{ secrets.PULUMI_PROD_PASSPHRASE }}" > passphrase.prod.txt
+          echo "$PULUMI_PROD_PASSPHRASE" > passphrase.prod.txt
           pulumi login gs://mcp-registry-prod-pulumi-state
           PULUMI_CONFIG_PASSPHRASE_FILE=passphrase.prod.txt pulumi cancel --stack gcpProd --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,8 +88,10 @@ jobs:
 
       - name: Deploy to Staging
         working-directory: ./deploy
+        env:
+          PULUMI_STAGING_PASSPHRASE: ${{ secrets.PULUMI_STAGING_PASSPHRASE }}
         run: |
-          echo "${{ secrets.PULUMI_STAGING_PASSPHRASE }}" > passphrase.staging.txt
+          echo "$PULUMI_STAGING_PASSPHRASE" > passphrase.staging.txt
           make staging-up
 
   deploy-production:
@@ -127,6 +129,8 @@ jobs:
 
       - name: Deploy to Production
         working-directory: ./deploy
+        env:
+          PULUMI_PROD_PASSPHRASE: ${{ secrets.PULUMI_PROD_PASSPHRASE }}
         run: |
-          echo "${{ secrets.PULUMI_PROD_PASSPHRASE }}" > passphrase.prod.txt
+          echo "$PULUMI_PROD_PASSPHRASE" > passphrase.prod.txt
           make prod-up


### PR DESCRIPTION
Addresses the security concern where secrets were directly interpolated in GitHub Actions run commands across multiple workflows.

Following [GitHub's security best practices](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable), secrets are now passed through intermediate environment variables (matching the secret names: `PULUMI_STAGING_PASSPHRASE` and `PULUMI_PROD_PASSPHRASE`) before being written to files.

## Changes

**deploy.yml:**
- Fixed staging deployment (line 92)
- Fixed production deployment (line 131)

**cancel-pulumi-lock.yml:**
- Fixed staging lock cancellation (line 62)
- Fixed production lock cancellation (line 70)

## Benefits

This approach:
- Fixes the security issue with direct secret interpolation in 4 locations
- Maintains compatibility with existing local development workflows
- Keeps the Makefile unchanged
- Uses environment variable names that match the secret names for clarity

The key improvement is that `${{ secrets.X }}` is no longer expanded directly in the run commands, reducing the risk of accidental disclosure if GitHub's masking fails or is bypassed.