### PR TITLE
Add ExifTool MCP server

### DIFF
--- a/servers/io.github.joshmsimpson/exiftool/server.json
+++ b/servers/io.github.joshmsimpson/exiftool/server.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://registry.modelcontextprotocol.io/schemas/server-config.json",
+  "name": "exiftool",
+  "description": "MCP server for reading metadata from files using ExifTool. Supports over 150 file formats including images (JPEG, PNG, RAW), videos (MP4, MOV), audio files, PDFs, and documents.",
+  "version": "0.1.0",
+  "packages": [
+    {
+      "type": "pypi",
+      "name": "exiftool-mcp"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the ExifTool MCP server to the registry.

**Server Description:**
MCP server for reading, writing, and removing metadata from files using ExifTool.

**Supported Formats:**
- 150+ file formats
- Images: JPEG, PNG, TIFF, RAW formats, HEIC, WebP, etc.
- Videos: MP4, MOV, AVI, MKV, etc.
- Audio: MP3, FLAC, WAV, etc.
- Documents: PDF, DOCX, XLSX, etc.

**Features:**
- Read metadata from any supported file
- Write metadata with automatic backup
- Remove metadata selectively or completely
- Support for EXIF, IPTC, XMP, GPS metadata

**Package:**
- PyPI: https://pypi.org/project/exiftool-mcp/
- GitHub: https://github.com/joshmsimpson/exiftool_mcp

**Testing:**
Tested with MCP Inspector and Claude Desktop.

**Prerequisites:**
Requires ExifTool to be installed on the system.