### PR TITLE
Use 'latest' tag for mcp-publisher downloads

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -120,12 +120,12 @@ signs:
 archives:
   # Registry server archive
   - id: registry
-    name_template: "registry_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "registry_{{ .Os }}_{{ .Arch }}"
     ids:
       - registry
-  
+
   # Publisher CLI archive
   - id: publisher
-    name_template: "mcp-publisher_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "mcp-publisher_{{ .Os }}_{{ .Arch }}"
     ids:
       - publisher

--- a/docs/guides/publishing/github-actions.md
+++ b/docs/guides/publishing/github-actions.md
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install MCP Publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/latest/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -48,7 +48,7 @@ brew install mcp-publisher
 <summary><strong>⬇️ macOS/Linux/WSL: Pre-built binaries</strong></summary>
 
 ```bash
-curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+curl -L "https://github.com/modelcontextprotocol/registry/releases/download/latest/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
 ```
 
 </details>
@@ -74,7 +74,7 @@ export PATH=$PATH:$(pwd)/bin
 <summary><strong>🪟 Windows PowerShell: Pre-built binaries</strong></summary>
 
 ```powershell
-$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "Arm64") { "arm64" } else { "amd64" }; Invoke-WebRequest -Uri "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_windows_$arch.tar.gz" -OutFile "mcp-publisher.tar.gz"; tar xf mcp-publisher.tar.gz mcp-publisher.exe; rm mcp-publisher.tar.gz
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "Arm64") { "arm64" } else { "amd64" }; Invoke-WebRequest -Uri "https://github.com/modelcontextprotocol/registry/releases/download/latest/mcp-publisher_windows_$arch.tar.gz" -OutFile "mcp-publisher.tar.gz"; tar xf mcp-publisher.tar.gz mcp-publisher.exe; rm mcp-publisher.tar.gz
 # Move mcp-publisher.exe to a directory in your PATH
 ```
 


### PR DESCRIPTION
## Summary

This PR removes version numbers from release asset names and updates documentation to use GitHub's `latest` tag for mcp-publisher downloads.

## Changes

1. **Updated `.goreleaser.yaml`**: Removed `{{ .Version }}` from asset name templates
   - Changed from: `mcp-publisher_{{ .Version }}_{{ .Os }}_{{ .Arch }}`
   - Changed to: `mcp-publisher_{{ .Os }}_{{ .Arch }}`

2. **Updated documentation**: Changed all download URLs to use `latest` tag instead of version-pinned URLs
   - `docs/guides/publishing/publish-server.md`
   - `docs/guides/publishing/github-actions.md`

## Benefits

- Documentation stays automatically up-to-date without manual changes or workflows
- Users always get the latest version by default
- Version pinning still possible using specific tags (e.g., `https://github.com/modelcontextprotocol/registry/releases/download/v1.2.3/mcp-publisher_darwin_amd64.tar.gz`)
- Simpler maintenance and better user experience

## Notes

The new asset naming will take effect with the next release. After that, users can immediately start using the `latest` tag.

Fixes #607