### PR TITLE
Simplify OpenAPI schema by merging Server into ServerDetail

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -267,33 +267,6 @@ components:
           description: "Optional relative path from repository root to the server location within a monorepo structure"
           example: "src/everything"
 
-    Server:
-      type: object
-      required:
-        - name
-        - description
-        - version
-      properties:
-        name:
-          type: string
-          description: "Reverse DNS name of the MCP server"
-          example: "io.github.modelcontextprotocol/filesystem"
-        description:
-          type: string
-          description: "Human-readable description of the server's functionality"
-          example: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
-        repository:
-          $ref: '#/components/schemas/Repository'
-        version:
-          type: string
-          example: "1.0.2"
-          description: "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification."
-        websiteUrl:
-          type: string
-          format: uri
-          description: "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements."
-          example: "https://modelcontextprotocol.io/examples"
-
 
     ServerList:
       type: object
@@ -515,38 +488,59 @@ components:
 
     ServerDetail:
       description: Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.
-      allOf:
-        - $ref: '#/components/schemas/Server'
-        - type: object
+      type: object
+      required:
+        - name
+        - description
+        - version
+      properties:
+        name:
+          type: string
+          description: "Reverse DNS name of the MCP server"
+          example: "io.github.modelcontextprotocol/filesystem"
+        description:
+          type: string
+          description: "Human-readable description of the server's functionality"
+          example: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
+        repository:
+          $ref: '#/components/schemas/Repository'
+        version:
+          type: string
+          example: "1.0.2"
+          description: "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification."
+        websiteUrl:
+          type: string
+          format: uri
+          description: "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements."
+          example: "https://modelcontextprotocol.io/examples"
+        $schema:
+          type: string
+          format: uri
+          description: JSON Schema URI for this server.json format
+          example: "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
+        packages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Package'
+        remotes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Remote'
+        _meta:
+          type: object
+          description: Extension metadata using reverse DNS namespacing
           properties:
-            $schema:
-              type: string
-              format: uri
-              description: JSON Schema URI for this server.json format
-              example: "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
-            packages:
-              type: array
-              items:
-                $ref: '#/components/schemas/Package'
-            remotes:
-              type: array
-              items:
-                $ref: '#/components/schemas/Remote'
-            _meta:
+            io.modelcontextprotocol.registry/publisher-provided:
               type: object
-              description: Extension metadata using reverse DNS namespacing
-              properties:
-                io.modelcontextprotocol.registry/publisher-provided:
-                  type: object
-                  description: Publisher-specific metadata and build information
-                  additionalProperties: true
-                  example:
-                    tool: "publisher-cli"
-                    version: "1.2.3"
-                    buildInfo:
-                      commit: "abc123def456"
-                      timestamp: "2023-12-01T10:30:00Z"
-                      pipelineId: "build-789"
+              description: Publisher-specific metadata and build information
+              additionalProperties: true
+              example:
+                tool: "publisher-cli"
+                version: "1.2.3"
+                buildInfo:
+                  commit: "abc123def456"
+                  timestamp: "2023-12-01T10:30:00Z"
+                  pipelineId: "build-789"
 
     ServerResponse:
       description: API response format with separated server data and registry metadata

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -35,47 +35,6 @@
         }
       }
     },
-    "Server": {
-      "type": "object",
-      "required": [
-        "name",
-        "description",
-        "version"
-      ],
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
-          "example": "io.github.user/weather",
-          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
-          "minLength": 3,
-          "maxLength": 200
-        },
-        "description": {
-          "type": "string",
-          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
-          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
-          "minLength": 1,
-          "maxLength": 100
-        },
-        "repository": {
-          "$ref": "#/definitions/Repository",
-          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
-        },
-        "version": {
-          "type": "string",
-          "maxLength": 255,
-          "example": "1.0.2",
-          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
-        },
-        "websiteUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
-          "example": "https://modelcontextprotocol.io/examples"
-        }
-      }
-    },
     "Package": {
       "type": "object",
       "additionalProperties": false,
@@ -415,53 +374,82 @@
     },
     "ServerDetail": {
       "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Server"
+      "type": "object",
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+          "minLength": 3,
+          "maxLength": 200
         },
-        {
+        "description": {
+          "type": "string",
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
+        },
+        "version": {
+          "type": "string",
+          "maxLength": 255,
+          "example": "1.0.2",
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
+        },
+        "websiteUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples"
+        },
+        "$schema": {
+          "type": "string",
+          "format": "uri",
+          "description": "JSON Schema URI for this server.json format",
+          "example": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
+        },
+        "packages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Package"
+          }
+        },
+        "remotes": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/StreamableHttpTransport"
+              },
+              {
+                "$ref": "#/definitions/SseTransport"
+              }
+            ]
+          }
+        },
+        "_meta": {
           "type": "object",
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+          "additionalProperties": true,
           "properties": {
-            "$schema": {
-              "type": "string",
-              "format": "uri",
-              "description": "JSON Schema URI for this server.json format",
-              "example": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
-            },
-            "packages": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Package"
-              }
-            },
-            "remotes": {
-              "type": "array",
-              "items": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/StreamableHttpTransport"
-                  },
-                  {
-                    "$ref": "#/definitions/SseTransport"
-                  }
-                ]
-              }
-            },
-            "_meta": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
               "type": "object",
-              "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
-              "additionalProperties": true,
-              "properties": {
-                "io.modelcontextprotocol.registry/publisher-provided": {
-                  "type": "object",
-                  "description": "Publisher-provided metadata for downstream registries",
-                  "additionalProperties": true
-                }
-              }
+              "description": "Publisher-provided metadata for downstream registries",
+              "additionalProperties": true
             }
           }
         }
-      ]
+      }
     }
   }
 }


### PR DESCRIPTION
This PR simplifies the OpenAPI schema by merging the `Server` component into `ServerDetail`, addressing the issue where the `Server` component was never used independently.

## Changes
- Merged all Server properties directly into ServerDetail in both OpenAPI spec and JSON schema
- Removed allOf construct for clearer, standalone definitions
- Deleted unused Server components

## Benefits
- Clearer schema structure
- Easier to understand without inheritance tracing
- Reduced maintenance complexity
- No functionality loss

## Validation
All schemas and documentation examples continue to validate successfully.

Resolves #609

Generated with [Claude Code](https://claude.ai/code)