### PR TITLE
Make repository id optional in OpenAPI spec

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -252,7 +252,6 @@ components:
       required:
         - url
         - source
-        - id
       properties:
         url:
           type: string


### PR DESCRIPTION
The 'id' field in the Repository schema is now optional in both openapi.yaml and server.schema.json for consistency.