### PR TITLE
Align golang types with openapi.yaml schema

### DIFF
--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -48,7 +48,7 @@ const (
 	FormatString   Format = "string"
 	FormatNumber   Format = "number"
 	FormatBoolean  Format = "boolean"
-	FormatFilePath Format = "file_path"
+	FormatFilePath Format = "filepath"
 )
 
 // Input represents a configuration input

--- a/scripts/test_publish.sh
+++ b/scripts/test_publish.sh
@@ -102,7 +102,7 @@ cat > "$PAYLOAD_FILE" << EOF
           "type": "positional",
           "name": "config",
           "description": "Configuration file path",
-          "format": "file_path",
+          "format": "filepath",
           "isRequired": false,
           "default": "./config.json"
         }


### PR DESCRIPTION
Change Format constant from `file_path` to `filepath` to match the OpenAPI schema definition.

This is not used by any servers yet, nor is it enforced by the database, so it's safe to change.