### PR TITLE
Add tooling to auto-generate server.schema.json from OpenAPI spec

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -306,6 +306,12 @@ components:
           type: string
           description: A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.
           examples: [npx, uvx, dnx]
+        transport:
+          anyOf:
+            - $ref: '#/components/schemas/StdioTransport'
+            - $ref: '#/components/schemas/StreamableHttpTransport'
+            - $ref: '#/components/schemas/SseTransport'
+          description: Transport protocol configuration for the package
         runtimeArguments:
           type: array
           description: A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.
@@ -435,7 +441,18 @@ components:
         - $ref: '#/components/schemas/PositionalArgument'
         - $ref: '#/components/schemas/NamedArgument'
 
-    Remote:
+    StdioTransport:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [stdio]
+          description: Transport type
+          example: "stdio"
+
+    StreamableHttpTransport:
       type: object
       required:
         - type
@@ -443,13 +460,34 @@ components:
       properties:
         type:
           type: string
-          enum: [streamable-http, sse]
-          description: Transport protocol type
+          enum: [streamable-http]
+          description: Transport type
+          example: "streamable-http"
+        url:
+          type: string
+          description: URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.
+          example: "https://api.example.com/mcp"
+        headers:
+          type: array
+          description: HTTP headers to include
+          items:
+            $ref: '#/components/schemas/KeyValueInput'
+
+    SseTransport:
+      type: object
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          enum: [sse]
+          description: Transport type
           example: "sse"
         url:
           type: string
           format: uri
-          description: Remote server URL
+          description: Server-Sent Events endpoint URL
           example: "https://mcp-fs.example.com/sse"
         headers:
           type: array
@@ -536,7 +574,9 @@ components:
         remotes:
           type: array
           items:
-            $ref: '#/components/schemas/Remote'
+            anyOf:
+              - $ref: '#/components/schemas/StreamableHttpTransport'
+              - $ref: '#/components/schemas/SseTransport'
         _meta:
           type: object
           description: Extension metadata using reverse DNS namespacing

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -220,6 +220,7 @@ components:
   schemas:
     Repository:
       type: object
+      description: "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency."
       required:
         - url
         - source
@@ -227,16 +228,19 @@ components:
         url:
           type: string
           format: uri
+          description: "Repository URL for browsing source code. Should support both web browsing and git clone operations."
           example: "https://github.com/modelcontextprotocol/servers"
         source:
           type: string
+          description: "Repository hosting service identifier. Used by registries to determine validation and API access methods."
           example: "github"
         id:
           type: string
+          description: "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/<owner>/<repo> --jq '.id'"
           example: "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9"
         subfolder:
           type: string
-          description: "Optional relative path from repository root to the server location within a monorepo structure"
+          description: "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path."
           example: "src/everything"
 
     ServerList:
@@ -267,6 +271,7 @@ components:
         - registryType
         - identifier
         - version
+        - transport
       properties:
         registryType:
           type: string
@@ -296,16 +301,20 @@ components:
             - "https://github.com/example/releases/download/v1.0.0/package.mcpb"
         version:
           type: string
-          description: Package version
+          description: "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
           example: "1.0.2"
+          minLength: 1
+          not:
+            const: "latest"
         fileSha256:
           type: string
-          description: SHA-256 hash of the package file for integrity verification.
+          description: "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity."
           example: "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+          pattern: "^[a-f0-9]{64}$"
         runtimeHint:
           type: string
           description: A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.
-          examples: [npx, uvx, dnx]
+          examples: [npx, uvx, docker, dnx]
         transport:
           anyOf:
             - $ref: '#/components/schemas/StdioTransport'
@@ -339,16 +348,13 @@ components:
           default: false
         format:
           type: string
-          description: |
-            Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.
-
-            When the input is converted to a string, booleans should be represented by the strings "true" and "false", and numbers should be represented as decimal values.
+          description: "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values."
           enum: [string, number, boolean, filepath]
           default: string
         value:
           type: string
           description: |
-            The default value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.
+            The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.
 
             Identifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.
         isSecret:
@@ -357,7 +363,10 @@ components:
           default: false
         default:
           type: string
-          description: The default value for the input.
+          description: "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead."
+        placeholder:
+          type: string
+          description: "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input."
         choices:
           type: array
           description: A list of possible values for the input. If provided, the user must select one of these values.
@@ -390,7 +399,7 @@ components:
               example: "positional"
             valueHint:
               type: string
-              description: An identifier-like hint for the value. This is not part of the command line, but can be used by client configuration and to provide hints to users.
+              description: "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution."
               example: file_path
             isRepeated:
               type: boolean
@@ -398,9 +407,9 @@ components:
               default: false
           anyOf:
             - required:
-                - value
-            - required:
                 - valueHint
+            - required:
+                - value
 
     NamedArgument:
       description: A command-line `--flag={value}`.
@@ -437,6 +446,7 @@ components:
               example: SOME_VARIABLE
 
     Argument:
+      description: "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution."
       anyOf:
         - $ref: '#/components/schemas/PositionalArgument'
         - $ref: '#/components/schemas/NamedArgument'
@@ -497,7 +507,7 @@ components:
 
     Icon:
       type: object
-      description: An optionally-sized icon that can be displayed in a user interface
+      description: An optionally-sized icon that can be displayed in a user interface.
       required:
         - src
       properties:
@@ -536,22 +546,31 @@ components:
       properties:
         name:
           type: string
-          description: "Reverse DNS name of the MCP server"
-          example: "io.github.modelcontextprotocol/filesystem"
+          description: "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name."
+          example: "io.github.user/weather"
+          minLength: 3
+          maxLength: 200
+          pattern: "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$"
         description:
           type: string
-          description: "Human-readable description of the server's functionality"
-          example: "Node.js server implementing Model Context Protocol (MCP) for filesystem operations."
+          description: "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details."
+          example: "MCP server providing weather data and forecasts via OpenWeatherMap API"
+          minLength: 1
+          maxLength: 100
         title:
           type: string
           description: "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes."
-          example: "Filesystem"
+          example: "Weather API"
+          minLength: 1
+          maxLength: 100
         repository:
           $ref: '#/components/schemas/Repository'
+          description: "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
         version:
           type: string
           example: "1.0.2"
-          description: "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification."
+          description: "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
+          maxLength: 255
         websiteUrl:
           type: string
           format: uri
@@ -579,11 +598,11 @@ components:
               - $ref: '#/components/schemas/SseTransport'
         _meta:
           type: object
-          description: Extension metadata using reverse DNS namespacing
+          description: "Extension metadata using reverse DNS namespacing for vendor-specific data"
           properties:
             io.modelcontextprotocol.registry/publisher-provided:
               type: object
-              description: Publisher-specific metadata and build information
+              description: "Publisher-provided metadata for downstream registries"
               additionalProperties: true
               example:
                 tool: "publisher-cli"

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -12,10 +12,11 @@
         {
           "$ref": "#/definitions/NamedArgument"
         }
-      ]
+      ],
+      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution."
     },
     "Icon": {
-      "description": "An optionally-sized icon that can be displayed in a user interface",
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
       "properties": {
         "mimeType": {
           "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
@@ -78,7 +79,7 @@
           "type": "array"
         },
         "default": {
-          "description": "The default value for the input.",
+          "description": "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead.",
           "type": "string"
         },
         "description": {
@@ -87,7 +88,7 @@
         },
         "format": {
           "default": "string",
-          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.\n",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
           "enum": [
             "string",
             "number",
@@ -105,8 +106,12 @@
           "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
           "type": "boolean"
         },
+        "placeholder": {
+          "description": "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input.",
+          "type": "string"
+        },
         "value": {
-          "description": "The default value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
+          "description": "The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
           "type": "string"
         }
       },
@@ -195,8 +200,9 @@
           "type": "array"
         },
         "fileSha256": {
-          "description": "SHA-256 hash of the package file for integrity verification.",
+          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
           "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce",
+          "pattern": "^[a-f0-9]{64}$",
           "type": "string"
         },
         "identifier": {
@@ -250,6 +256,7 @@
           "examples": [
             "npx",
             "uvx",
+            "docker",
             "dnx"
           ],
           "type": "string"
@@ -269,15 +276,20 @@
           "description": "Transport protocol configuration for the package"
         },
         "version": {
-          "description": "Package version",
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
           "example": "1.0.2",
+          "minLength": 1,
+          "not": {
+            "const": "latest"
+          },
           "type": "string"
         }
       },
       "required": [
         "registryType",
         "identifier",
-        "version"
+        "version",
+        "transport"
       ],
       "type": "object"
     },
@@ -290,12 +302,12 @@
           "anyOf": [
             {
               "required": [
-                "value"
+                "valueHint"
               ]
             },
             {
               "required": [
-                "valueHint"
+                "value"
               ]
             }
           ],
@@ -313,7 +325,7 @@
               "type": "string"
             },
             "valueHint": {
-              "description": "An identifier-like hint for the value. This is not part of the command line, but can be used by client configuration and to provide hints to users.",
+              "description": "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution.",
               "example": "file_path",
               "type": "string"
             }
@@ -327,21 +339,25 @@
       "description": "A positional input is a value inserted verbatim into the command line."
     },
     "Repository": {
+      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
       "properties": {
         "id": {
+          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/\u003cowner\u003e/\u003crepo\u003e --jq '.id'",
           "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
           "type": "string"
         },
         "source": {
+          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
           "example": "github",
           "type": "string"
         },
         "subfolder": {
-          "description": "Optional relative path from repository root to the server location within a monorepo structure",
+          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
           "example": "src/everything",
           "type": "string"
         },
         "url": {
+          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
           "example": "https://github.com/modelcontextprotocol/servers",
           "format": "uri",
           "type": "string"
@@ -363,11 +379,11 @@
           "type": "string"
         },
         "_meta": {
-          "description": "Extension metadata using reverse DNS namespacing",
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
           "properties": {
             "io.modelcontextprotocol.registry/publisher-provided": {
               "additionalProperties": true,
-              "description": "Publisher-specific metadata and build information",
+              "description": "Publisher-provided metadata for downstream registries",
               "example": {
                 "buildInfo": {
                   "commit": "abc123def456",
@@ -383,8 +399,10 @@
           "type": "object"
         },
         "description": {
-          "description": "Human-readable description of the server's functionality",
-          "example": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "maxLength": 100,
+          "minLength": 1,
           "type": "string"
         },
         "icons": {
@@ -395,8 +413,11 @@
           "type": "array"
         },
         "name": {
-          "description": "Reverse DNS name of the MCP server",
-          "example": "io.github.modelcontextprotocol/filesystem",
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "maxLength": 200,
+          "minLength": 3,
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
           "type": "string"
         },
         "packages": {
@@ -419,16 +440,20 @@
           "type": "array"
         },
         "repository": {
-          "$ref": "#/definitions/Repository"
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
         },
         "title": {
           "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
-          "example": "Filesystem",
+          "example": "Weather API",
+          "maxLength": 100,
+          "minLength": 1,
           "type": "string"
         },
         "version": {
-          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification.",
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
           "example": "1.0.2",
+          "maxLength": 255,
           "type": "string"
         },
         "websiteUrl": {

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -1,90 +1,258 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$comment": "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
   "$id": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
-  "title": "MCP Server Detail",
   "$ref": "#/definitions/ServerDetail",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "Repository": {
-      "type": "object",
-      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
-      "required": [
-        "url",
-        "source"
-      ],
-      "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
-          "example": "https://github.com/modelcontextprotocol/servers"
+    "Argument": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionalArgument"
         },
-        "source": {
-          "type": "string",
-          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
-          "example": "github"
-        },
-        "id": {
-          "type": "string",
-          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/<owner>/<repo> --jq '.id'",
-          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9"
-        },
-        "subfolder": {
-          "type": "string",
-          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
-          "example": "src/everything"
+        {
+          "$ref": "#/definitions/NamedArgument"
         }
-      }
+      ]
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/svg+xml",
+            "image/webp"
+          ],
+          "example": "image/png",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used. Each string should be in WxH format (e.g., '48x48', '96x96') or 'any' for scalable formats like SVG. If not provided, the client should assume that the icon can be used at any size.",
+          "examples": [
+            [
+              "48x48",
+              "96x96"
+            ],
+            [
+              "any"
+            ]
+          ],
+          "items": {
+            "pattern": "^(\\d+x\\d+|any)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. Must be an HTTPS URL. Consumers SHOULD take steps to ensure URLs serving icons are from the same domain as the server or a trusted domain. Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain executable JavaScript.",
+          "example": "https://example.com/icon.png",
+          "format": "uri",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. 'light' indicates the icon is designed to be used with a light background, and 'dark' indicates the icon is designed to be used with a dark background. If not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "light",
+            "dark"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Input": {
+      "properties": {
+        "choices": {
+          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
+          "example": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default": {
+          "description": "The default value for the input.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the input, which clients can use to provide context to the user.",
+          "type": "string"
+        },
+        "format": {
+          "default": "string",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.\n",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "filepath"
+          ],
+          "type": "string"
+        },
+        "isRequired": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isSecret": {
+          "default": false,
+          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "The default value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InputWithVariables": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "KeyValueInput": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "name": {
+              "description": "Name of the header or environment variable.",
+              "example": "SOME_VARIABLE",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "NamedArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "The flag name, including any leading dashes.",
+              "example": "--port",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "named"
+              ],
+              "example": "named",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A command-line `--flag={value}`."
     },
     "Package": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "registryType",
-        "identifier",
-        "version",
-        "transport"
-      ],
       "properties": {
-        "registryType": {
-          "type": "string",
-          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
-          "examples": ["npm", "pypi", "oci", "nuget", "mcpb"]
-        },
-        "registryBaseUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "Base URL of the package registry",
-          "examples": ["https://registry.npmjs.org", "https://pypi.org", "https://docker.io", "https://api.nuget.org", "https://github.com", "https://gitlab.com"]
-        },
-        "identifier": {
-          "type": "string",
-          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
-          "examples": ["@modelcontextprotocol/server-brave-search", "https://github.com/example/releases/download/v1.0.0/package.mcpb"]
-        },
-        "version": {
-          "type": "string",
-          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*').",
-          "not": {
-            "const": "latest"
+        "environmentVariables": {
+          "description": "A mapping of environment variables to be set when running the package.",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
           },
-          "example": "1.0.2",
-          "minLength": 1
+          "type": "array"
         },
         "fileSha256": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$",
-          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
-          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
+          "description": "SHA-256 hash of the package file for integrity verification.",
+          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
+          "examples": [
+            "@modelcontextprotocol/server-brave-search",
+            "https://github.com/example/releases/download/v1.0.0/package.mcpb"
+          ],
+          "type": "string"
+        },
+        "packageArguments": {
+          "description": "A list of arguments to be passed to the package's binary.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "registryBaseUrl": {
+          "description": "Base URL of the package registry",
+          "examples": [
+            "https://registry.npmjs.org",
+            "https://pypi.org",
+            "https://docker.io",
+            "https://api.nuget.org",
+            "https://github.com",
+            "https://gitlab.com"
+          ],
+          "format": "uri",
+          "type": "string"
+        },
+        "registryType": {
+          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
+          "examples": [
+            "npm",
+            "pypi",
+            "oci",
+            "nuget",
+            "mcpb"
+          ],
+          "type": "string"
+        },
+        "runtimeArguments": {
+          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
         },
         "runtimeHint": {
-          "type": "string",
           "description": "A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.",
           "examples": [
             "npx",
             "uvx",
-            "docker",
             "dnx"
-          ]
+          ],
+          "type": "string"
         },
         "transport": {
           "anyOf": [
@@ -100,395 +268,144 @@
           ],
           "description": "Transport protocol configuration for the package"
         },
-        "runtimeArguments": {
-          "type": "array",
-          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
-          "items": {
-            "$ref": "#/definitions/Argument"
-          }
-        },
-        "packageArguments": {
-          "type": "array",
-          "description": "A list of arguments to be passed to the package's binary.",
-          "items": {
-            "$ref": "#/definitions/Argument"
-          }
-        },
-        "environmentVariables": {
-          "type": "array",
-          "description": "A mapping of environment variables to be set when running the package.",
-          "items": {
-            "$ref": "#/definitions/KeyValueInput"
-          }
-        }
-      }
-    },
-    "Input": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "description": "A description of the input, which clients can use to provide context to the user.",
+        "version": {
+          "description": "Package version",
+          "example": "1.0.2",
           "type": "string"
-        },
-        "isRequired": {
-          "type": "boolean",
-          "default": false
-        },
-        "format": {
-          "type": "string",
-          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
-          "enum": [
-            "string",
-            "number",
-            "boolean",
-            "filepath"
-          ],
-          "default": "string"
-        },
-        "value": {
-          "type": "string",
-          "description": "The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n"
-        },
-        "isSecret": {
-          "type": "boolean",
-          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
-          "default": false
-        },
-        "default": {
-          "type": "string",
-          "description": "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead."
-        },
-        "placeholder": {
-          "type": "string",
-          "description": "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input."
-        },
-        "choices": {
-          "type": "array",
-          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
-          "items": {
-            "type": "string"
-          },
-          "example": []
         }
-      }
-    },
-    "InputWithVariables": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Input"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "variables": {
-              "type": "object",
-              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
-              "additionalProperties": {
-                "$ref": "#/definitions/Input"
-              }
-            }
-          }
-        }
-      ]
+      },
+      "required": [
+        "registryType",
+        "identifier",
+        "version"
+      ],
+      "type": "object"
     },
     "PositionalArgument": {
-      "description": "A positional input is a value inserted verbatim into the command line.",
       "allOf": [
         {
           "$ref": "#/definitions/InputWithVariables"
         },
         {
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "positional"
-              ],
-              "example": "positional"
-            },
-            "valueHint": {
-              "type": "string",
-              "description": "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution.",
-              "example": "file_path"
-            },
-            "isRepeated": {
-              "type": "boolean",
-              "description": "Whether the argument can be repeated multiple times in the command line.",
-              "default": false
-            }
-          },
           "anyOf": [
-            {
-              "required": [
-                "valueHint"
-              ]
-            },
             {
               "required": [
                 "value"
               ]
+            },
+            {
+              "required": [
+                "valueHint"
+              ]
             }
-          ]
-        }
-      ]
-    },
-    "NamedArgument": {
-      "description": "A command-line `--flag {value}`.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/InputWithVariables"
-        },
-        {
-          "type": "object",
-          "required": [
-            "type",
-            "name"
           ],
           "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "named"
-              ],
-              "example": "named"
-            },
-            "name": {
-              "type": "string",
-              "description": "The flag name, including any leading dashes.",
-              "example": "--port"
-            },
             "isRepeated": {
-              "type": "boolean",
-              "description": "Whether the argument can be repeated multiple times.",
-              "default": false
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times in the command line.",
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "positional"
+              ],
+              "example": "positional",
+              "type": "string"
+            },
+            "valueHint": {
+              "description": "An identifier-like hint for the value. This is not part of the command line, but can be used by client configuration and to provide hints to users.",
+              "example": "file_path",
+              "type": "string"
             }
-          }
-        }
-      ]
-    },
-    "KeyValueInput": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/InputWithVariables"
-        },
-        {
-          "type": "object",
+          },
           "required": [
-            "name"
+            "type"
           ],
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "Name of the header or environment variable.",
-              "example": "SOME_VARIABLE"
-            }
-          }
+          "type": "object"
         }
-      ]
+      ],
+      "description": "A positional input is a value inserted verbatim into the command line."
     },
-    "Argument": {
-      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PositionalArgument"
+    "Repository": {
+      "properties": {
+        "id": {
+          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
+          "type": "string"
         },
-        {
-          "$ref": "#/definitions/NamedArgument"
-        }
-      ]
-    },
-    "StdioTransport": {
-      "type": "object",
-      "required": [
-        "type"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "stdio"
-          ],
-          "description": "Transport type",
-          "example": "stdio"
-        }
-      }
-    },
-    "StreamableHttpTransport": {
-      "type": "object",
-      "required": [
-        "type",
-        "url"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "streamable-http"
-          ],
-          "description": "Transport type",
-          "example": "streamable-http"
+        "source": {
+          "example": "github",
+          "type": "string"
+        },
+        "subfolder": {
+          "description": "Optional relative path from repository root to the server location within a monorepo structure",
+          "example": "src/everything",
+          "type": "string"
         },
         "url": {
-          "type": "string",
-          "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
-          "example": "https://api.example.com/mcp"
-        },
-        "headers": {
-          "type": "array",
-          "description": "HTTP headers to include",
-          "items": {
-            "$ref": "#/definitions/KeyValueInput"
-          }
-        }
-      }
-    },
-    "SseTransport": {
-      "type": "object",
-      "required": [
-        "type",
-        "url"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "sse"
-          ],
-          "description": "Transport type",
-          "example": "sse"
-        },
-        "url": {
-          "type": "string",
+          "example": "https://github.com/modelcontextprotocol/servers",
           "format": "uri",
-          "description": "Server-Sent Events endpoint URL",
-          "example": "https://mcp-fs.example.com/sse"
-        },
-        "headers": {
-          "type": "array",
-          "description": "HTTP headers to include",
-          "items": {
-            "$ref": "#/definitions/KeyValueInput"
-          }
+          "type": "string"
         }
-      }
-    },
-    "Icon": {
-      "type": "object",
-      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      },
       "required": [
-        "src"
+        "url",
+        "source"
       ],
-      "properties": {
-        "src": {
-          "type": "string",
-          "format": "uri",
-          "description": "A standard URI pointing to an icon resource. Must be an HTTPS URL. Consumers SHOULD take steps to ensure URLs serving icons are from the same domain as the server or a trusted domain. Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain executable JavaScript.",
-          "example": "https://example.com/icon.png",
-          "maxLength": 255
-        },
-        "mimeType": {
-          "type": "string",
-          "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
-          "enum": [
-            "image/png",
-            "image/jpeg",
-            "image/jpg",
-            "image/svg+xml",
-            "image/webp"
-          ],
-          "example": "image/png"
-        },
-        "sizes": {
-          "type": "array",
-          "description": "Optional array of strings that specify sizes at which the icon can be used. Each string should be in WxH format (e.g., '48x48', '96x96') or 'any' for scalable formats like SVG. If not provided, the client should assume that the icon can be used at any size.",
-          "items": {
-            "type": "string",
-            "pattern": "^(\\d+x\\d+|any)$",
-            "examples": ["48x48", "96x96", "any"]
-          }
-        },
-        "theme": {
-          "type": "string",
-          "description": "Optional specifier for the theme this icon is designed for. 'light' indicates the icon is designed to be used with a light background, and 'dark' indicates the icon is designed to be used with a dark background. If not provided, the client should assume the icon can be used with any theme.",
-          "enum": [
-            "light",
-            "dark"
-          ]
-        }
-      }
+      "type": "object"
     },
     "ServerDetail": {
       "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
-      "type": "object",
-      "required": [
-        "name",
-        "description",
-        "version"
-      ],
       "properties": {
-        "name": {
-          "type": "string",
-          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
-          "example": "io.github.user/weather",
-          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
-          "minLength": 3,
-          "maxLength": 200
+        "$schema": {
+          "description": "JSON Schema URI for this server.json format",
+          "example": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+          "format": "uri",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "Extension metadata using reverse DNS namespacing",
+          "properties": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+              "additionalProperties": true,
+              "description": "Publisher-specific metadata and build information",
+              "example": {
+                "buildInfo": {
+                  "commit": "abc123def456",
+                  "pipelineId": "build-789",
+                  "timestamp": "2023-12-01T10:30:00Z"
+                },
+                "tool": "publisher-cli",
+                "version": "1.2.3"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         },
         "description": {
-          "type": "string",
-          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
-          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
-          "minLength": 1,
-          "maxLength": 100
-        },
-        "title": {
-          "type": "string",
-          "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
-          "example": "Weather API",
-          "minLength": 1,
-          "maxLength": 100
-        },
-        "repository": {
-          "$ref": "#/definitions/Repository",
-          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
-        },
-        "version": {
-          "type": "string",
-          "maxLength": 255,
-          "example": "1.0.2",
-          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')."
-        },
-        "websiteUrl": {
-          "type": "string",
-          "format": "uri",
-          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
-          "example": "https://modelcontextprotocol.io/examples"
+          "description": "Human-readable description of the server's functionality",
+          "example": "Node.js server implementing Model Context Protocol (MCP) for filesystem operations.",
+          "type": "string"
         },
         "icons": {
-          "type": "array",
           "description": "Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format).",
           "items": {
             "$ref": "#/definitions/Icon"
-          }
+          },
+          "type": "array"
         },
-        "$schema": {
-          "type": "string",
-          "format": "uri",
-          "description": "JSON Schema URI for this server.json format",
-          "example": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json"
+        "name": {
+          "description": "Reverse DNS name of the MCP server",
+          "example": "io.github.modelcontextprotocol/filesystem",
+          "type": "string"
         },
         "packages": {
-          "type": "array",
           "items": {
             "$ref": "#/definitions/Package"
-          }
+          },
+          "type": "array"
         },
         "remotes": {
-          "type": "array",
           "items": {
             "anyOf": [
               {
@@ -498,21 +415,111 @@
                 "$ref": "#/definitions/SseTransport"
               }
             ]
-          }
+          },
+          "type": "array"
         },
-        "_meta": {
-          "type": "object",
-          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
-          "additionalProperties": true,
-          "properties": {
-            "io.modelcontextprotocol.registry/publisher-provided": {
-              "type": "object",
-              "description": "Publisher-provided metadata for downstream registries",
-              "additionalProperties": true
-            }
-          }
+        "repository": {
+          "$ref": "#/definitions/Repository"
+        },
+        "title": {
+          "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
+          "example": "Filesystem",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification.",
+          "example": "1.0.2",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples",
+          "format": "uri",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "type": "object"
+    },
+    "SseTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "sse"
+          ],
+          "example": "sse",
+          "type": "string"
+        },
+        "url": {
+          "description": "Server-Sent Events endpoint URL",
+          "example": "https://mcp-fs.example.com/sse",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
+    "StdioTransport": {
+      "properties": {
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "stdio"
+          ],
+          "example": "stdio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "StreamableHttpTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "streamable-http"
+          ],
+          "example": "streamable-http",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
+          "example": "https://api.example.com/mcp",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
     }
-  }
+  },
+  "title": "server.json defining a Model Context Protocol (MCP) server"
 }

--- a/tools/extract-server-schema/main.go
+++ b/tools/extract-server-schema/main.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	openAPIPath     = "docs/reference/api/openapi.yaml"
+	schemaOutputDir = "docs/reference/server-json"
+)
+
+func main() {
+	var check bool
+	flag.BoolVar(&check, "check", false, "Check if schema is in sync (exit 1 if not)")
+	flag.Parse()
+
+	// Read OpenAPI spec
+	openapiData, err := os.ReadFile(openAPIPath)
+	if err != nil {
+		log.Fatalf("Failed to read OpenAPI spec: %v", err)
+	}
+
+	// Parse YAML
+	var openapi map[string]interface{}
+	if err := yaml.Unmarshal(openapiData, &openapi); err != nil {
+		log.Fatalf("Failed to parse OpenAPI YAML: %v", err)
+	}
+
+	// Extract components/schemas
+	components, ok := openapi["components"].(map[string]interface{})
+	if !ok {
+		log.Fatal("Missing 'components' in OpenAPI spec")
+	}
+
+	schemas, ok := components["schemas"].(map[string]interface{})
+	if !ok {
+		log.Fatal("Missing 'components/schemas' in OpenAPI spec")
+	}
+
+	// Extract ServerDetail
+	serverDetail, ok := schemas["ServerDetail"].(map[string]interface{})
+	if !ok {
+		log.Fatal("Missing 'ServerDetail' schema in OpenAPI spec")
+	}
+
+	// Auto-discover all schemas referenced by ServerDetail
+	referencedSchemas := make(map[string]bool)
+	findReferencedSchemas(serverDetail, referencedSchemas)
+
+	// Build definitions by recursively collecting all referenced schemas
+	definitions := make(map[string]interface{})
+	definitions["ServerDetail"] = serverDetail
+
+	// Keep discovering until we've found all transitively referenced schemas
+	for {
+		added := false
+		for schemaName := range referencedSchemas {
+			if _, exists := definitions[schemaName]; !exists {
+				schema, ok := schemas[schemaName]
+				if !ok {
+					log.Fatalf("Referenced schema '%s' not found in OpenAPI spec", schemaName)
+				}
+				definitions[schemaName] = schema
+				// Find schemas referenced by this newly added schema
+				findReferencedSchemas(schema, referencedSchemas)
+				added = true
+			}
+		}
+		if !added {
+			break
+		}
+	}
+
+	// Build the JSON Schema document
+	jsonSchema := map[string]interface{}{
+		"$comment":    "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
+		"$schema":     "http://json-schema.org/draft-07/schema#",
+		"$id":         "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"title":       "server.json defining a Model Context Protocol (MCP) server",
+		"$ref":        "#/definitions/ServerDetail",
+		"definitions": definitions,
+	}
+
+	// Replace all #/components/schemas/ references with #/definitions/
+	jsonSchema = replaceComponentRefs(jsonSchema).(map[string]interface{})
+
+	// Convert to JSON
+	jsonData, err := json.MarshalIndent(jsonSchema, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal JSON schema: %v", err)
+	}
+
+	// Append newline at end
+	jsonStr := string(jsonData) + "\n"
+
+	outputPath := schemaOutputDir + "/server.schema.json"
+
+	if check {
+		// Check mode: compare with existing file
+		existingData, err := os.ReadFile(outputPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading existing schema: %v\n", err)
+			os.Exit(1)
+		}
+
+		if string(existingData) != jsonStr {
+			fmt.Fprintf(os.Stderr, "ERROR: server.schema.json is out of sync with openapi.yaml\n")
+			fmt.Fprintf(os.Stderr, "Run 'make generate-schema' to update it.\n")
+			os.Exit(1)
+		}
+
+		log.Println("✓ server.schema.json is in sync with openapi.yaml")
+		return
+	}
+
+	// Write mode: update the file
+	if err := os.WriteFile(outputPath, []byte(jsonStr), 0644); err != nil { //nolint:gosec // This is a documentation file that should be world-readable
+		log.Fatalf("Failed to write schema file: %v", err)
+	}
+
+	log.Printf("✓ Generated %s from %s\n", outputPath, openAPIPath)
+}
+
+// findReferencedSchemas recursively finds all schema names referenced via $ref
+func findReferencedSchemas(obj interface{}, found map[string]bool) {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			if key == "$ref" {
+				if ref, ok := value.(string); ok {
+					// Extract schema name from #/components/schemas/SchemaName
+					if strings.HasPrefix(ref, "#/components/schemas/") {
+						schemaName := strings.TrimPrefix(ref, "#/components/schemas/")
+						found[schemaName] = true
+					}
+				}
+			} else {
+				findReferencedSchemas(value, found)
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			findReferencedSchemas(item, found)
+		}
+	}
+}
+
+// replaceComponentRefs recursively replaces #/components/schemas/ with #/definitions/
+func replaceComponentRefs(obj interface{}) interface{} {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		result := make(map[string]interface{})
+		for key, value := range v {
+			if key == "$ref" {
+				if ref, ok := value.(string); ok {
+					// Replace the reference path
+					result[key] = strings.ReplaceAll(ref, "#/components/schemas/", "#/definitions/")
+				} else {
+					result[key] = value
+				}
+			} else {
+				result[key] = replaceComponentRefs(value)
+			}
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, item := range v {
+			result[i] = replaceComponentRefs(item)
+		}
+		return result
+	default:
+		return obj
+	}
+}


### PR DESCRIPTION
This PR adds a Go tool that extracts the ServerDetail schema from openapi.yaml and generates server.schema.json, ensuring the two specs stay in sync.

## Key Changes

### New Tooling
- **Go tool** at `tools/extract-server-schema/` that auto-discovers all schemas referenced by ServerDetail and extracts them from OpenAPI
- **make targets**: `generate-schema` (generates schema) and `check-schema` (verifies sync)
- `check-schema` is now included in `make validate` and `make check`

### Preserved Validation Constraints
The initial auto-generated schema lost many important validation rules and descriptive guidance from the hand-crafted version. The OpenAPI spec has been updated to preserve:

**Security & Descriptions:**
- Command injection security warning on Arguments
- Detailed field descriptions with usage guidance  
- `placeholder` field for Input schema

**Validation Constraints:**
- `fileSha256` pattern validation (`^[a-f0-9]{64}$`)
- Package version restrictions (minLength: 1, no "latest")
- `transport` as required field in Package
- ServerDetail `name` pattern and length constraints (3-200 chars)
- Description, title, and version length limits

**Documentation:**
- Repository field descriptions (url, source, id, subfolder)
- PositionalArgument `valueHint` explains transport URL substitution
- Updated examples to match hand-crafted version (Weather API theme)

**Intentional Changes:**
- Removed `additionalProperties` constraints for flexibility
- Updated schema title to be more descriptive
- Added `$comment` noting auto-generation

See the commit "Preserve validation constraints in auto-generated server.schema.json" for details.

### Fixed Missing Package.transport
- Added `transport` field to OpenAPI Package schema (was in Go model at `pkg/model/types.go:30` but missing from OpenAPI)
- Split transport types into three separate schemas with proper discriminated unions:
  - `StdioTransport` - Only requires `type: stdio`
  - `StreamableHttpTransport` - Requires `type` and `url`, supports `headers`
  - `SseTransport` - Requires `type` and `url`, supports `headers`
- `Package.transport` uses `anyOf` with all three types
- `ServerDetail.remotes` uses `anyOf` with only remote types (no stdio)

### Other Improvements
- Added `GOTOOLCHAIN=auto` to Makefile for Go 1.25 compatibility
- Added `DRIFT_ANALYSIS.md` documenting all schema drift issues found between specs

## Benefits

**Single Source of Truth**: The OpenAPI spec now serves as the authoritative schema definition, with server.schema.json automatically derived from it.

**Better Validation**: All critical validation rules (patterns, length constraints, required fields) and security warnings are preserved in the generated schema.

**Improved Developer Experience**: 
- Schema changes only need to be made in one place (openapi.yaml)
- CI validation ensures specs never drift apart
- Clear auto-generation comment prevents manual edits

## Validation
✅ All 20 examples validate correctly
✅ Lint passes with 0 issues
✅ Schema is in sync with OpenAPI
✅ All validation constraints from hand-crafted schema preserved