### PR TITLE
schema: Implemented simulated discriminated union for transports and arguments

### DIFF
--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -87,17 +87,21 @@
           ]
         },
         "transport": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StdioTransport"
-            },
-            {
-              "$ref": "#/definitions/StreamableHttpTransport"
-            },
-            {
-              "$ref": "#/definitions/SseTransport"
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["stdio", "streamable-http", "sse"]
             }
-          ],
+          },
+          "required": ["type"],
+          "if": {"properties": {"type": {"const": "stdio"}}},
+          "then": {"$ref": "#/definitions/StdioTransport"},
+          "else": {
+            "if": {"properties": {"type": {"const": "streamable-http"}}},
+            "then": {"$ref": "#/definitions/StreamableHttpTransport"},
+            "else": {"$ref": "#/definitions/SseTransport"}
+          },
           "description": "Transport protocol configuration for the package"
         },
         "runtimeArguments": {
@@ -292,14 +296,17 @@
     },
     "Argument": {
       "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PositionalArgument"
-        },
-        {
-          "$ref": "#/definitions/NamedArgument"
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["positional", "named"]
         }
-      ]
+      },
+      "required": ["type"],
+      "if": {"properties": {"type": {"const": "positional"}}},
+      "then": {"$ref": "#/definitions/PositionalArgument"},
+      "else": {"$ref": "#/definitions/NamedArgument"}
     },
     "StdioTransport": {
       "type": "object",
@@ -334,6 +341,7 @@
         },
         "url": {
           "type": "string",
+          "pattern": "^https?://[^\\s]+$",
           "description": "URL template for the streamable-http transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
           "example": "https://api.example.com/mcp"
         },
@@ -363,8 +371,8 @@
         },
         "url": {
           "type": "string",
-          "format": "uri",
-          "description": "Server-Sent Events endpoint URL",
+          "pattern": "^https?://[^\\s]+$",
+          "description": "URL template for the sse transport. Variables in {curly_braces} reference argument valueHints, argument names, or environment variable names. After variable substitution, this should produce a valid URI.",
           "example": "https://mcp-fs.example.com/sse"
         },
         "headers": {
@@ -490,14 +498,17 @@
         "remotes": {
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/StreamableHttpTransport"
-              },
-              {
-                "$ref": "#/definitions/SseTransport"
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["streamable-http", "sse"]
               }
-            ]
+            },
+            "required": ["type"],
+            "if": {"properties": {"type": {"const": "streamable-http"}}},
+            "then": {"$ref": "#/definitions/StreamableHttpTransport"},
+            "else": {"$ref": "#/definitions/SseTransport"}
           }
         },
         "_meta": {


### PR DESCRIPTION
When using `anyOf` in schema7 and no element matches, schema errors from validations of all child elements are produced, which makes it hard to understand the actual schema error.  This will be increasingly important when we move toward providing a schema validation command in `mcp-publisher` and eventually enforcing schema compliance in `/v0/publish` as I will put forward in a later PR. 

## Motivation and Context
When validating schema and there is any failure in an `anyOf` element, the set of schema validation erros returned makes it difficult to understand the issue.  For example, with the old `anyOf` when validating an SSE transport with no `url` you get these schema validation errors:

1. [error] packages.0.transport.type (schema)
   value must be "stdio"
   Reference: #/definitions/StdioTransport/properties/type/enum

2. [error] packages.0.transport (schema)
   missing required fields: 'url'
   Reference: #/definitions/StreamableHttpTransport/required

3. [error] packages.0.transport.type (schema)
   value must be "streamable-http"
   Reference: #/definitions/StreamableHttpTransport/properties/type/enum

4. [error] packages.0.transport (schema)
   missing required fields: 'url'
   Reference: #/definitions/SseTransport/require

Schema7 lacks discriminated union support, but we can use if/then/else to achieve something similar (as I have done in this PR).  When validating the same server.json as above using the if/then/else schema in this PR you get only the correct schema error:

1. [error] packages.0.transport (schema)
   missing required fields: 'url'
   Reference: #/definitions/SseTransport/required

I tried a few variations of validating the `type` under `anyOf` to make something a little more human readable, but I could not induce the correct behavior (even when "filtering" on `type` inside the `anyOf`, all `anyOf` elements were still evaluated and produced schema validation errors).

## How Has This Been Tested?
I validated using a new `validate` command of `mcp-publisher` (that is part of an upcoming PR), with specific test scenarios triggering `anyOf` failures (that validation used the Go lib in this project, santhosh-tekuri/jsonschema/v5).

I also ran the same test scenario using my TypeScript [MCP registry validator](https://github.com/TeamSparkAI/ToolCatalog/blob/main/packages/mcp-registry-validator/README.md), which uses Ajv (the standard schema validator for Javascript).

Lastly I used my validator to run the new schema against all published servers and compared the results to the output using the previous schema.

Note: I also made changes to the `uri` format for the StreamableHttpTransport and SseTransport (required for currently published SSE servers that use tokens in their `url` to pass schema validation).  This will likely be replaced by a better solution in https://github.com/modelcontextprotocol/registry/pull/570 but I think it's worth fixing this now while that is pending (given that it impacts currently published servers).

I think this is the last of the schema changes I'm going to suggest based on my work evaluating existing published servers and implementing schema validation (aforementioned upcoming PR).

## Breaking Changes
This schema is functionally identical the the version it replaces with respect to the transport and argument changes.  The only difference is in the schema validation errors produced (currently no code in the project performs schema validation, so I don't consider that a breaking change).

This schema will also now catch a StreamableHttpTransport `uri` that doesn't start with an http scheme - but there are no such servers currently published (and if there were, they would be in error).  And it will allow tokens in SseTransport `uri` properties, allowing some existing published servers to pass that would have failed (but again, I don't think anyone is actually doing schema validation yet).  I suppose if you really wanted it, you could call the failure to allow a non-http streamable uri a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
