### PR TITLE
Add failure modes telemetry

### DIFF
--- a/deploy/pkg/k8s/monitoring.go
+++ b/deploy/pkg/k8s/monitoring.go
@@ -232,26 +232,11 @@ func deployOtelCollectorDaemonSet(ctx *pulumi.Context, cluster *providers.Provid
 							pulumi.Map{
 								"type":       pulumi.String("regex_parser"),
 								"id":         pulumi.String("extract_metadata_from_filepath"),
-								"regex":      pulumi.String(`^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log`),
+								"regex":      pulumi.String(`^.*\/[^_]+_[^_]+_(?P<uid>[a-f0-9\-]{36})\/[^\._]+\/(?P<restart_count>\d+)\.log`),
 								"parse_from": pulumi.String("attributes[\"log.file.path\"]"),
 								"cache": pulumi.Map{
 									"size": pulumi.Int(128),
 								},
-							},
-							pulumi.Map{
-								"type": pulumi.String("move"),
-								"from": pulumi.String("attributes.container_name"),
-								"to":   pulumi.String("resource[\"k8s.container.name\"]"),
-							},
-							pulumi.Map{
-								"type": pulumi.String("move"),
-								"from": pulumi.String("attributes.namespace"),
-								"to":   pulumi.String("resource[\"k8s.namespace.name\"]"),
-							},
-							pulumi.Map{
-								"type": pulumi.String("move"),
-								"from": pulumi.String("attributes.pod_name"),
-								"to":   pulumi.String("resource[\"k8s.pod.name\"]"),
 							},
 							pulumi.Map{
 								"type": pulumi.String("move"),
@@ -300,17 +285,19 @@ func deployOtelCollectorDaemonSet(ctx *pulumi.Context, cluster *providers.Provid
 								pulumi.String("k8s.deployment.name"),
 								pulumi.String("k8s.namespace.name"),
 								pulumi.String("k8s.node.name"),
-								pulumi.String("k8s.cluster.uid"),
-							},
-							"labels": pulumi.Array{
-								pulumi.Map{
-									"tag_name": pulumi.String("app"),
-									"key":      pulumi.String("app"),
-									"from":     pulumi.String("pod"),
-								},
+								pulumi.String("container.image.name"),
+								pulumi.String("container.image.tag"),
 							},
 						},
 						"pod_association": pulumi.Array{
+							pulumi.Map{
+								"sources": pulumi.Array{
+									pulumi.Map{
+										"from": pulumi.String("resource_attribute"),
+										"name": pulumi.String("k8s.pod.ip"),
+									},
+								},
+							},
 							pulumi.Map{
 								"sources": pulumi.Array{
 									pulumi.Map{
@@ -322,8 +309,7 @@ func deployOtelCollectorDaemonSet(ctx *pulumi.Context, cluster *providers.Provid
 							pulumi.Map{
 								"sources": pulumi.Array{
 									pulumi.Map{
-										"from": pulumi.String("resource_attribute"),
-										"name": pulumi.String("k8s.node.name"),
+										"from": pulumi.String("connection"),
 									},
 								},
 							},
@@ -366,7 +352,7 @@ func deployOtelCollectorDaemonSet(ctx *pulumi.Context, cluster *providers.Provid
 					"pipelines": pulumi.Map{
 						"logs": pulumi.Map{
 							"receivers":  pulumi.StringArray{pulumi.String("filelog"), pulumi.String("k8s_events")},
-							"processors": pulumi.StringArray{pulumi.String("batch")},
+							"processors": pulumi.StringArray{pulumi.String("k8sattributes"), pulumi.String("batch")},
 							"exporters":  pulumi.StringArray{pulumi.String("otlphttp/victorialogs")},
 						},
 						"metrics": pulumi.Map{


### PR DESCRIPTION
Telemetry to cover failure modes which are not covered by container logs and metrics for finding resource constraints.

## Motivation and Context
When there is any issue with registry container we should be notified.

## How Has This Been Tested?
- Local seup

## Breaking Changes
- No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
- No additional exporter is used, taken advantage of opentelemetry collector 
- It covers metrics related to resource constraints, currently only limited to default namespace.
- Takes cares of kubernetes events as logs which are the source of figuring out any problem with service, covers all such scenarios where pod is not able to start yet and get missed because there are no container logs for such cases. Limited to default namespace.
- Taken care of daemonset deployment i.e. deploying otel collector as agent by using correct filtering.
- Cardinality contributing factors are only pod ids (but have to observe more), node ids will not increase cardinality as scale up will lead to limited nodes. 
- Shipping of metrics for resources happens every 60s and list of metrics that will be emitted [https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/metadata.yaml](url)

- Container errors

<img width="1440" height="816" alt="Screenshot 2025-10-10 at 1 21 14 AM" src="https://github.com/user-attachments/assets/ba90a217-2a49-4522-aa44-a98c02adf95b" />




- Resource metrics

<img width="1440" height="816" alt="Screenshot 2025-10-10 at 1 23 51 AM" src="https://github.com/user-attachments/assets/3467be96-db3c-4930-afa2-3cbf5f0ced8b" />
