### PR TITLE
Add hint icon to in-browser UI community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -4,7 +4,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 
 ## Featured Projects
 
-- [MCP Bench](https://mcpbench.ai/) - Explore the MCP registry with richer filters, community stars, and LLM-generated classification tags.
+- [MCP Bench](https://mcpbench.ai/)🔎 - Explore the MCP registry with richer filters, community stars, and LLM-generated classification tags.
 - [MCP Registry Cheat Sheet](https://github.com/subbyte/mcp-registry-cheatsheet) - MCP Registry Cheat Sheet for MCP server developers, client developers, and registry admin
 - [MCP Registry Remote MCP Server](https://github.com/jaw9c/mcp-registry-mcp) - Open Remote MCP server for the Registry at `https://registry-mcp.remote-mcp.com`
 - [MCP Server for MCP Registry](https://github.com/formulahendry/mcp-server-mcp-registry) - MCP Server to discover and search for available MCP servers in the registry
@@ -12,8 +12,10 @@ The following is a list of notable community-driven projects in the ecosystem re
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
-- [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry) - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
+- [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry)🔎 - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
 - **Add your project here!**
+
+🔎 = Browse the official MCP Registry in your browser!
 
 ## Adding Your Project
 


### PR DESCRIPTION
This PR contains a few commits, but the punchline is that we add a "🔎" icon next to community projects that provide an in-browser UI for the registry.  The intention is that these projects can serve as a stopgap or substitute for https://github.com/modelcontextprotocol/registry/issues/99.

This is just a first take.  Very open to feedback!
