### PR TITLE
feat: add community project link to browsable database

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -6,6 +6,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 
 - [MCP Bench](https://mcpbench.ai/)🔎 - Explore the MCP registry with richer filters, community stars, and LLM-generated classification tags.
 - [MCP Registry Cheat Sheet](https://github.com/subbyte/mcp-registry-cheatsheet) - MCP Registry Cheat Sheet for MCP server developers, client developers, and registry admin
+-[MCP Registry Database](https://lite.datasette.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Frosmur%2Fofficial-mcp-registry-database%2Fmain%2Fofficial_mcp_registry.db#/official_mcp_registry/servers) - A minimal, web browsable, live database of the official MCP Registry [source code](https://github.com/rosmur/official-mcp-registry-database).
 - [MCP Registry Remote MCP Server](https://github.com/jaw9c/mcp-registry-mcp) - Open Remote MCP server for the Registry at `https://registry-mcp.remote-mcp.com`
 - [MCP Server for MCP Registry](https://github.com/formulahendry/mcp-server-mcp-registry) - MCP Server to discover and search for available MCP servers in the registry
 - [mcp-insights](https://github.com/joelverhagen/mcp-insights/) - Analytics and insights for the MCP Registry


### PR DESCRIPTION
Adds a link to a new community project

## Motivation and Context
This addresses the need to have a web browsable, live page of the MCP server registry.  

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Additional context
Provides both a web browsable link and a SQLite database. Database can be connected to or downloaded. 
