### PR TITLE
Add `go-mcp-registry` to community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -14,6 +14,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 - [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry)🔎 - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
+- [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK for the MCP Registry API
 - **Add your project here!**
 
 🔎 = Browse the official MCP Registry in your browser!


### PR DESCRIPTION
Adds [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) to the Community Projects documentation

## Motivation and Context
Wanted to add my project to your community projects documentation

## How Has This Been Tested?
No testing necessary

## Breaking Changes
None

## Types of changes
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
