### PR TITLE
docs(community): update project link and name to ToolSDK MCP Registry

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -15,7 +15,7 @@ The following is a list of notable community-driven projects in the ecosystem re
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry)🔎 - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
 - [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK for the MCP Registry API
-- [Awesome MCP Registry](https://github.com/toolsdk-ai/awesome-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
+- [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
 - **Add your project here!**
 
 🔎 = Browse the official MCP Registry in your browser!


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Updated the project entry from **Awesome MCP Registry** to **ToolSDK MCP Registry**, reflecting the new GitHub repository name and official project name. 

> We’re honored that our Sub Registry project has been included in the official MCP Registry. To better reflect its purpose and maintain a more professional naming convention, we’re updating the entry name from **Awesome MCP Registry** to **ToolSDK MCP Registry**. This change replaces the earlier, more generic name “Awesome” with a clearer and more representative title for the project.
>
> *Based on GitHub’s renaming mechanism, the old link remains valid and will automatically redirect to the new repository.*

## Motivation and Context

The project repository has been renamed and migrated from [`toolsdk-ai/awesome-mcp-registry`](https://github.com/toolsdk-ai/awesome-mcp-registry) → [`toolsdk-ai/toolsdk-mcp-registry`](https://github.com/toolsdk-ai/toolsdk-mcp-registry).

This update ensures that the community registry points to the **correct and active repository**, while maintaining the same project description and context. The **ToolSDK MCP Registry** continues to extend the MCP Registry with **API-based MCP execution**, **private deployment**, and **secure sandbox isolation**.

---

## How Has This Been Tested?

Verified that the new link is accessible and points to the correct repository. All descriptions and formatting remain consistent with other community entries.

---

## Breaking Changes

No breaking changes — documentation update only.

---

## Types of changes

* [x] Documentation update

---

## Checklist

* [x] I have verified the new link and repository name
* [x] I have followed the repository’s documentation style
* [x] The update aligns with MCP community contribution guidelines

---

## Additional context

This change reflects a **repository rename** for clarity and branding consistency. The project functionality and scope remain the same.