### PR TITLE
enhancement: streamline command handling and enhance help output

### DIFF
--- a/cmd/publisher/main.go
+++ b/cmd/publisher/main.go
@@ -27,23 +27,37 @@ func main() {
 		os.Exit(1)
 	}
 
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	// Handle global help/version
+	if cmd == "--version" || cmd == "-v" || cmd == "version" {
+		log.Printf("mcp-publisher %s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
+		return
+	}
+	if cmd == "--help" || cmd == "-h" || cmd == "help" {
+		printUsage()
+		return
+	}
+
+	// Print command-specific help if --help or -h or help is the first argument to a subcommand
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+		printCommandHelp(cmd)
+		return
+	}
+
 	var err error
-	switch os.Args[1] {
+	switch cmd {
 	case "init":
 		err = commands.InitCommand()
 	case "login":
-		err = commands.LoginCommand(os.Args[2:])
+		err = commands.LoginCommand(args)
 	case "logout":
 		err = commands.LogoutCommand()
 	case "publish":
-		err = commands.PublishCommand(os.Args[2:])
-	case "--version", "-v", "version":
-		log.Printf("mcp-publisher %s (commit: %s, built: %s)", Version, GitCommit, BuildTime)
-		return
-	case "--help", "-h", "help":
-		printUsage()
+		err = commands.PublishCommand(args)
 	default:
-		fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", os.Args[1])
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", cmd)
 		printUsage()
 		os.Exit(1)
 	}
@@ -51,6 +65,76 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func printCommandHelp(command string) {
+	switch command {
+	case "init":
+		_, _ = fmt.Fprintln(os.Stdout, "Usage: mcp-publisher init")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Description:")
+		_, _ = fmt.Fprintln(os.Stdout, "  Create a server.json file template in the current directory.")
+		_, _ = fmt.Fprintln(os.Stdout, "  This template includes all required and optional fields for")
+		_, _ = fmt.Fprintln(os.Stdout, "  publishing your MCP server to the registry.")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Example:")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher init")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "The generated server.json file should be customized with your")
+		_, _ = fmt.Fprintln(os.Stdout, "server's specific details before publishing.")
+	case "login":
+		_, _ = fmt.Fprintln(os.Stdout, "Usage: mcp-publisher login <method>")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Description:")
+		_, _ = fmt.Fprintln(os.Stdout, "  Authenticate with the registry using one of the supported")
+		_, _ = fmt.Fprintln(os.Stdout, "  authentication methods. Authentication is required before")
+		_, _ = fmt.Fprintln(os.Stdout, "  you can publish servers to the registry.")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Available Methods:")
+		_, _ = fmt.Fprintln(os.Stdout, "  github-at        - GitHub Personal Access Token")
+		_, _ = fmt.Fprintln(os.Stdout, "  github-oidc      - GitHub OIDC (for CI/CD environments)")
+		_, _ = fmt.Fprintln(os.Stdout, "  http             - HTTP-based authentication")
+		_, _ = fmt.Fprintln(os.Stdout, "  dns              - DNS-based authentication")
+		_, _ = fmt.Fprintln(os.Stdout, "  none             - No authentication (for testing)")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Example:")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher login github-at")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Credentials are securely stored locally for subsequent publishes.")
+	case "logout":
+		_, _ = fmt.Fprintln(os.Stdout, "Usage: mcp-publisher logout")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Description:")
+		_, _ = fmt.Fprintln(os.Stdout, "  Clear saved authentication credentials from the local system.")
+		_, _ = fmt.Fprintln(os.Stdout, "  This removes all stored authentication tokens and sessions.")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Example:")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher logout")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "After logging out, you will need to run 'mcp-publisher login'")
+		_, _ = fmt.Fprintln(os.Stdout, "again before publishing.")
+	case "publish":
+		_, _ = fmt.Fprintln(os.Stdout, "Usage: mcp-publisher publish [options]")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Description:")
+		_, _ = fmt.Fprintln(os.Stdout, "  Publish your MCP server to the registry using the server.json")
+		_, _ = fmt.Fprintln(os.Stdout, "  file in the current directory. You must be authenticated before")
+		_, _ = fmt.Fprintln(os.Stdout, "  publishing (see 'mcp-publisher login').")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Options:")
+		_, _ = fmt.Fprintln(os.Stdout, "  --file <path>    - Specify a custom path to server.json")
+		_, _ = fmt.Fprintln(os.Stdout, "  --dry-run        - Validate the server.json without publishing")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "Example:")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher publish")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher publish --file ./my-server.json")
+		_, _ = fmt.Fprintln(os.Stdout, "  mcp-publisher publish --dry-run")
+		_, _ = fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintln(os.Stdout, "The server.json file must conform to the registry schema.")
+		_, _ = fmt.Fprintln(os.Stdout, "Run 'mcp-publisher init' to generate a template.")
+	default:
+		printUsage()
 	}
 }
 


### PR DESCRIPTION
This pull request improves the command-line interface of the `mcp-publisher` tool by adding enhanced help and usage messages for both global and command-specific contexts. It introduces structured help output for each command and refactors argument parsing for better clarity and maintainability.

Improvements to CLI help and usage:

* Added support for global `--help`, `-h`, `help`, `--version`, `-v`, and `version` flags, displaying usage or version information as appropriate.
* Introduced command-specific help output via a new `printCommandHelp` function, providing detailed usage, descriptions, options, and examples for each command (`init`, `login`, `logout`, `publish`).

Refactoring and maintainability:

* Refactored argument parsing by extracting the command and its arguments from `os.Args`, simplifying subsequent command handling and making the code more readable.
* Updated error messages and help prompts to use the extracted command variable, ensuring consistency in user feedback.<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions --> #735 
This pull request improves the command-line interface of the `mcp-publisher` tool by enhancing how help and version information is handled and by adding detailed, command-specific help messages. The changes make the tool more user-friendly and provide clearer guidance for each command.

**Improvements to CLI argument handling and help output:**

* Refactored the main command parsing logic in `cmd/publisher/main.go` to handle global `--help`, `-h`, `help`, `--version`, `-v`, and `version` flags before dispatching to subcommands, ensuring consistent behavior and output for these flags.
* Added support for displaying command-specific help when `--help`, `-h`, or `help` is passed as the first argument to any subcommand, improving discoverability of command usage.

**Addition of detailed command-specific help:**

* Implemented a new `printCommandHelp` function in `cmd/publisher/main.go` that provides detailed usage, descriptions, options, and examples for each supported command (`init`, `login`, `logout`, `publish`), making it easier for users to understand and use each command correctly.