### PR TITLE
Add support for ACR (Azure Container Registry) and MCR (Microsoft Container Registry)

### DIFF
--- a/docs/guides/publishing/publish-server.md
+++ b/docs/guides/publishing/publish-server.md
@@ -317,6 +317,8 @@ The official MCP registry supports:
 - Docker Hub (`docker.io`)
 - GitHub Container Registry (`ghcr.io`)
 - Google Artifact Registry (any `*.pkg.dev` domain)
+- Azure Container Registry (`*.azurecr.io`)
+- Microsoft Container Registry (`mcr.microsoft.com`)
 
 </details>
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -62,6 +62,9 @@ This applies to both locally-run and remote servers.
 - NuGet.org (.NET packages)
 - GitHub Container Registry (GHCR)
 - Docker Hub
+- Google Artifact Registry (`*.pkg.dev` domains)
+- Azure Container Registry (`*.azurecr.io` domains)
+- Microsoft Container Registry (MCR)
 
 More can be added as the community desires; feel free to open an issue if you are interested in building support for another registry.
 

--- a/docs/reference/server-json/official-registry-requirements.md
+++ b/docs/reference/server-json/official-registry-requirements.md
@@ -42,6 +42,8 @@ Only trusted public registries are supported. Private registries and alternative
   - Docker Hub (`docker.io`)
   - GitHub Container Registry (`ghcr.io`)
   - Google Artifact Registry (`*.pkg.dev`)
+  - Azure Container Registry (`*.azurecr.io`)
+  - Microsoft Container Registry (`mcr.microsoft.com`)
 - **MCPB**: `https://github.com` releases and `https://gitlab.com` releases only
 
 ## `_meta` Namespace Restrictions

--- a/internal/validators/registries/oci.go
+++ b/internal/validators/registries/oci.go
@@ -36,6 +36,7 @@ var allowedOCIRegistries = map[string]bool{
 	// Microsoft Container Registry
 	"mcr.microsoft.com": true,
 	// Google Artifact Registry (*.pkg.dev pattern handled in isAllowedRegistry)
+	// Azure Container Registry (*.azurecr.io pattern handled in isAllowedRegistry)
 }
 
 // ValidateOCI validates that an OCI image contains the correct MCP server name annotation.
@@ -149,6 +150,11 @@ func isAllowedRegistry(registry string) bool {
 	// Check for wildcard patterns
 	// Google Artifact Registry: *.pkg.dev (e.g., us-docker.pkg.dev, europe-west1-docker.pkg.dev)
 	if strings.HasSuffix(registry, ".pkg.dev") {
+		return true
+	}
+
+	// Azure Container Registry: *.azurecr.io
+	if strings.HasSuffix(registry, ".azurecr.io") {
 		return true
 	}
 

--- a/internal/validators/registries/oci_test.go
+++ b/internal/validators/registries/oci_test.go
@@ -40,12 +40,6 @@ func TestValidateOCI_RegistryAllowlist(t *testing.T) {
 			errorMsg:    "missing required annotation",
 		},
 		{
-			name:        "MCR should be allowed",
-			identifier:  "mcr.microsoft.com/dotnet/aspire-dashboard:9.5.0",
-			expectError: true,
-			errorMsg:    "missing required annotation",
-		},
-		{
 			name:        "Artifact Registry regional should be allowed",
 			identifier:  "us-central1-docker.pkg.dev/database-toolbox/toolbox/toolbox:latest",
 			expectError: true,
@@ -54,6 +48,18 @@ func TestValidateOCI_RegistryAllowlist(t *testing.T) {
 		{
 			name:        "Artifact Registry multi-region should be allowed",
 			identifier:  "us-docker.pkg.dev/berglas/berglas/berglas:latest",
+			expectError: true,
+			errorMsg:    "missing required annotation",
+		},
+		{
+			name:        "MCR should be allowed",
+			identifier:  "mcr.microsoft.com/dotnet/aspire-dashboard:9.5.0",
+			expectError: true,
+			errorMsg:    "missing required annotation",
+		},
+		{
+			name:        "ACR should be allowed",
+			identifier:  "azurearcjumpstart.azurecr.io/hello-arc:latest",
 			expectError: true,
 			errorMsg:    "missing required annotation",
 		},


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Microsoft uses `mcr.microsoft.com` to host our public containers. These are syndicated to Docker Hub but image references use `mcr.microsoft.com` which is not currently supported by the Official MCP Registry.

See https://github.com/modelcontextprotocol/registry/issues/753.

Microsoft teams want to use MCR-based images for Microsoft MCP servers.
I believe we should be adding ACR support as well, so that our customers using Azure Container Registry can use the MCP Registry as well.

In short, MCR is used for Microsoft managed containers. ACR is a solution for Azure customers to host their own containers.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Unit tests.

Manual test: local push of a server.json with `mcr.microsoft.com/azure-sdk/azure-mcp:2.0.0-beta.1` and `azurearcjumpstart.azurecr.io/hello-arc:latest` in it. The error is now about missing annotation not unsupported OCI registry.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
