### PR TITLE
docs: Split community projects into sections, and add Java client

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -12,6 +12,13 @@ Browse the official MCP Registry in your browser!
 - [MCP Registry Database](https://lite.datasette.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Frosmur%2Fofficial-mcp-registry-database%2Fmain%2Fofficial_mcp_registry.db#/official_mcp_registry/servers)🔎 - A minimal, web browsable, live database of the official MCP Registry [source code](https://github.com/rosmur/official-mcp-registry-database).
 - [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry)🔎 - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
 
+### MCP Registry Clients
+
+- [REST API](guides/consuming/use-rest-api.md) - HTTP API
+- [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK
+- [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
+- [LangChain4j MCP Registry Java client](https://docs.langchain4j.dev/tutorials/mcp/#mcp-registry-client) - Java API 
+
 ### Other
 
 - [MCP Registry Cheat Sheet](https://github.com/subbyte/mcp-registry-cheatsheet) - MCP Registry Cheat Sheet for MCP server developers, client developers, and registry admin
@@ -21,13 +28,6 @@ Browse the official MCP Registry in your browser!
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
-
-### MCP Registry Clients
-
-- [REST API](guides/consuming/use-rest-api.md) - HTTP API
-- [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK
-- [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
-- [LangChain4j MCP Registry Java client](https://docs.langchain4j.dev/tutorials/mcp/#mcp-registry-client) - Java API 
 
 ## Adding Your Project
 


### PR DESCRIPTION
## Motivation and Context

I found the current raw assorted list of community project a bit overwhelming and confusing at first.

So I gave some thought to it, and realized that at first I primarily wanted to see what there is to browse the registry - so that should probably go first? (The current magnifying glass icon, which was even missing on one of the links, wasn't obvious enough, for me.)

Also I was looking for a Java client, and realized there already Go and TS clients in this list - let's group those.

The Other section in the middle is for everything else (for now, it can always further evolve, later).

## How Has This Been Tested?

N/A, as documentation only.

## Breaking Changes

Nope, it's documentation only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
