### PR TITLE
Update Claude Code GitHub Action from beta to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -42,10 +42,7 @@ jobs:
 
           # Trigger when assigned to an issue
           assignee_trigger: "claude"
-          
-          # Allow Claude to run bash
-          # This should be safe given the repo is already public
-          allowed_tools: "Bash"
-          
-          custom_instructions: |
-            If posting a comment to GitHub, give a concise summary of the comment at the top and put all the details in a <details> block.
+
+          claude_args: |
+            --allowedTools Bash
+            --system-prompt "If posting a comment to GitHub, give a concise summary of the comment at the top and put all the details in a <details> block."


### PR DESCRIPTION
Updates the Claude Code GitHub Action to use the stable v1 GA release instead of the beta version.

## Changes
- Updates action version from `@beta` to `@v1`
- Migrates `allowed_tools` to `claude_args: --allowedTools`
- Migrates `custom_instructions` to `claude_args: --system-prompt`
- Retains `additional_permissions` and `assignee_trigger` (both still supported in v1)

## Behavior
The action continues to work the same way:
- Triggers on `@claude` mentions in comments, reviews, and issues
- Triggers when assigned to an issue as "claude"
- Allows Claude to run Bash commands
- Allows Claude to read CI results on PRs
- Applies custom instructions for posting concise summaries