### PR TITLE
docs: Update API changelog for v1.3.9 release

### DIFF
--- a/docs/reference/api/CHANGELOG.md
+++ b/docs/reference/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changes to the REST API endpoints and responses.
 
-## Unreleased
+## 2025-11-17
 
 ### Added
 


### PR DESCRIPTION
Updates the API changelog to reflect the v1.3.9 release date (2025-11-17).

This moves the 'Unreleased' section to a dated section as part of the v1.3.9 release process.