### PR TITLE
Promote prod to v1.3.9

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.3.8  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.3.9  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
Deploys v1.3.9 to production.

## Changes in v1.3.9
- New web UI for browsing the registry (#757)
- Fixed namespace match validation for websiteUrl and remote URL (#769)
- Added releases administration guide (#764)
- Updated community projects documentation
- Multiple dependency updates

Release notes: https://github.com/modelcontextprotocol/registry/releases/tag/v1.3.9

The [deploy-production workflow](https://github.com/modelcontextprotocol/registry/actions/workflows/deploy-production.yml) will automatically deploy once this PR is merged.