### PR TITLE
Fix remaining broken links from docs reorganization

### DIFF
--- a/cmd/publisher/README.md
+++ b/cmd/publisher/README.md
@@ -2,7 +2,7 @@
 
 CLI tool for publishing MCP servers to the registry.
 
-> These docs are for contributors. See the [Publisher User Guide](../../docs/guides/publishing/publish-server.md) for end-user documentation.
+> These docs are for contributors. See the [Publisher User Guide](../../docs/modelcontextprotocol-io/quickstart.mdx) for end-user documentation.
 
 ## Quick Development Setup
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ The MCP registry provides MCP clients with a list of MCP servers, like an app st
 
 ## I want to...
 
-- **📤 Publish my MCP server** → [Publishing Guide](guides/publishing/publish-server.md)
-- **📥 Consume registry data** → [API Usage Guide](guides/consuming/use-rest-api.md)
-- **🔌 Understand the registry's purpose** → [Ecosystem vision](explanations/ecosystem-vision.md)
+- **📤 Publish my MCP server** → [Publishing Guide](modelcontextprotocol-io/quickstart.mdx)
+- **📥 Consume registry data** → [API Usage Guide](modelcontextprotocol-io/registry-aggregators.mdx)
+- **🔌 Understand the registry's purpose** → [Ecosystem vision](design/ecosystem-vision.md)
 - **📋 Look up specific information** → [server.json spec](reference/server-json/generic-server-json.md) | [API spec](reference/api/generic-registry-api.md) | [CLI reference](reference/cli/commands.md)
 - **🤝 Add reference to my community project** → [Community Projects](community-projects.md)
 

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -14,7 +14,7 @@ Browse the official MCP Registry in your browser!
 
 ### MCP Registry Clients
 
-- [REST API](guides/consuming/use-rest-api.md) - HTTP API
+- [REST API](modelcontextprotocol-io/registry-aggregators.mdx) - HTTP API
 - [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK
 - [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
 - [LangChain4j MCP Registry Java client](https://docs.langchain4j.dev/tutorials/mcp/#mcp-registry-client) - Java API 

--- a/docs/reference/api/official-registry-api.md
+++ b/docs/reference/api/official-registry-api.md
@@ -2,7 +2,7 @@
 
 This document describes the API for the official MCP Registry hosted at `registry.modelcontextprotocol.io`.
 
-This API is based on the [generic registry API](./generic-registry-api.md) with additional endpoints and authentication. For practical examples of consuming the API, see the [API usage guide](../../guides/consuming/use-rest-api.md). For publishing servers using the API, see the [publishing guide](../../guides/publishing/publish-server.md).
+This API is based on the [generic registry API](./generic-registry-api.md) with additional endpoints and authentication. For publishing servers using the API, see the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx).
 
 ## Base URLs
 

--- a/docs/reference/cli/commands.md
+++ b/docs/reference/cli/commands.md
@@ -2,7 +2,7 @@
 
 Complete command reference for the `mcp-publisher` CLI tool.
 
-See the [publishing guide](../../guides/publishing/publish-server.md) for a walkthrough of using the CLI to publish a server.
+See the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx) for a walkthrough of using the CLI to publish a server.
 
 ## Installation
 
@@ -72,7 +72,7 @@ mcp-publisher login github-oidc [--registry=URL]
 - Requires `id-token: write` permission in workflow
 - No browser interaction needed
 
-Also see [the guide to publishing from GitHub Actions](../../guides/publishing/github-actions.md).
+Also see [the guide to publishing from GitHub Actions](../../modelcontextprotocol-io/github-actions.mdx).
 
 #### DNS Verification
 ```bash
@@ -211,7 +211,7 @@ mcp-publisher login none [--registry=URL]
 
 Publish server to the registry.
 
-For detailed guidance on the publishing process, see the [publishing guide](../../guides/publishing/publish-server.md).
+For detailed guidance on the publishing process, see the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx).
 
 **Usage:**
 ```bash

--- a/docs/reference/server-json/generic-server-json.md
+++ b/docs/reference/server-json/generic-server-json.md
@@ -3,7 +3,7 @@
 A `server.json` file is a standardized way to describe MCP servers for registry publishing, client discovery, and package management.
 
 Also see:
-- For step-by-step instructions on creating and using server.json files, see the [publishing guide](../../guides/publishing/publish-server.md).
+- For step-by-step instructions on creating and using server.json files, see the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx).
 - For understanding the validation requirements when publishing to the official registry, see [official registry requirements](./official-registry-requirements.md).
 
 ## Browse the Complete Schema

--- a/docs/reference/server-json/official-registry-requirements.md
+++ b/docs/reference/server-json/official-registry-requirements.md
@@ -2,7 +2,7 @@
 
 This document describes the additional requirements and validation rules that apply when publishing to the official MCP Registry at `registry.modelcontextprotocol.io`.
 
-For step-by-step publishing instructions, see the [publishing guide](../../guides/publishing/publish-server.md).
+For step-by-step publishing instructions, see the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx).
 
 ## Overview
 
@@ -17,13 +17,13 @@ While the [generic server.json format](./generic-server-json.md) defines the bas
 
 Publishers must prove ownership of their namespace. For example to publish to `com.example/server`, the publisher must prove they own the `example.com` domain.
 
-See the [publishing guide](../../guides/publishing/publish-server.md) for authentication details for GitHub and domain namespaces.
+See the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx) for authentication details for GitHub and domain namespaces.
 
 ## Package Ownership Verification
 
 All packages must include metadata proving the publisher owns them. This prevents impersonation and ensures authenticity (see more reasoning in [#96](https://github.com/modelcontextprotocol/registry/issues/96)).
 
-For detailed verification requirements for each registry type, see the [publishing guide](../../guides/publishing/publish-server.md).
+For detailed verification requirements for each registry type, see the [publishing guide](../../modelcontextprotocol-io/quickstart.mdx).
 
 ## Restricted Registry Base URLs
 


### PR DESCRIPTION
Follow-up to #728.

This fixes broken links due to file renames.

Fixes #788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
