### PR TITLE
Fix version mismatch in OpenAPI and changelog

### DIFF
--- a/docs/reference/api/CHANGELOG.md
+++ b/docs/reference/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changes to the REST API endpoints and responses.
 
-## 2025-11-17
+## 2025-10-17
 
 ### Added
 


### PR DESCRIPTION
## What this fixes

The API changelog had a section header dated `2025-11-17`, but the openapi.yaml version is `2025-10-17`. This was confusing because they appeared to be tracking the same thing but didn't match.

## What happened

1. Various API changes (v0.1 introduction, endpoint removal) were made in early-to-mid October
2. On **Oct 17**, commit 0828bc4 bumped the openapi.yaml version to `2025-10-17`
3. These changes sat under an "Unreleased" section in the changelog
4. On **Nov 17**, commit 7b3f01a converted "Unreleased" → `2025-11-17` as part of the v1.3.9 release process

The problem: `2025-11-17` was the date the release was cut, not the API version. Since there were no openapi.yaml changes between Oct 17 and Nov 17, the changelog section should match the API version (`2025-10-17`), not the internal release date.

## The fix

Change the changelog header from `## 2025-11-17` to `## 2025-10-17` to align with the openapi.yaml version that consumers actually use.

@domdomegg am I correct in thinking this was just a typo? Or was the distinction intentional?

Authored by Claude Code, reviewed by me.