### PR TITLE
Restrict @claude bot to mcp org only, fix fork behavior

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,10 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
       actions: read
     steps:
       # Only allow modelcontextprotocol org members to trigger @claude


### PR DESCRIPTION
Written by Claude Code, reviewed by me.

## Summary

Fixes `@claude` to work on external fork PRs by:
1. Restricting triggers to modelcontextprotocol org members only
2. Properly checking out fork PR code via `refs/pull/N/head`

## Background

The `@claude` GitHub app was failing on external forks ([example](https://github.com/modelcontextprotocol/registry/actions/runs/19938435814/job/57169634431)) because the action tried to fetch branches by name, which doesn't work for forks.

## Changes

### Org membership check
- Fetches the member list from [`modelcontextprotocol/access`](https://github.com/modelcontextprotocol/access) repo's `users.ts`
- Only org members can trigger `@claude` (prevents strangers from using it)
- Uses `github.triggering_actor` so the person commenting must be an org member

### Fork PR checkout fix
- Detects when a comment is on a fork PR
- Uses `refs/pull/{number}/head` to checkout fork code (instead of branch name)
- This works because GitHub exposes all PRs via special refs on the base repo

## How it works

1. Org member comments `@claude` on a fork PR
2. Workflow checks if commenter is in the `modelcontextprotocol/access` member list
3. Workflow detects it's a fork PR and checks out via `refs/pull/N/head`
4. Claude runs with access to the fork's code

🤖 Generated with [Claude Code](https://claude.com/claude-code)