### PR TITLE
docs: fix broken links in Documentation Index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ The MCP registry provides MCP clients with a list of MCP servers, like an app st
 
 ## Documentation Index
 
-- 🛠️ [How-To Guides: Task-focused instructions](./guides/)
-- 💡 [Explanations: Understanding-oriented content](./explanations/)
-- 📖 [Reference: Technical specifications and lookup material](./reference/)
+- 📄 [Public-facing docs](./modelcontextprotocol-io/) - Published on modelcontextprotocol.io
+- 🏗️ [Design documentation](./design/) - Architecture, vision, and roadmap
+- 📖 [Reference](./reference/) - Technical specifications
+- 🔧 [Contributing guides](./contributing/) - How to contribute
+- 🔒 [Administration](./administration/) - Admin operations


### PR DESCRIPTION
Update Documentation Index section to reflect the current directory structure after the docs reorganization in #728. The old links to ./guides/ and ./explanations/ no longer exist.

Fixes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
