### PR TITLE
Add a PUT method to the OpenAPI specification

### DIFF
--- a/docs/reference/api/generic-registry-api.md
+++ b/docs/reference/api/generic-registry-api.md
@@ -18,6 +18,7 @@ The official registry has some more endpoints and restrictions on top of this. S
 - **`GET /v0.1/servers/{serverName}/versions`** - List all versions of a server
 - **`GET /v0.1/servers/{serverName}/versions/{version}`** - Get specific version of server. Use the special version `latest` to get the latest version.
 - **`POST /v0.1/publish`** - Publish new server (optional, registry-specific authentication)
+- **`PUT /v0.1/servers/{serverName}/versions/{version}`** - Update specific server version (optional, not implemented by official registry)
 - **`DELETE /v0.1/servers/{serverName}/versions/{version}`** - Delete specific server version (optional, not implemented by official registry)
 
 Server names and version strings should be URL-encoded in paths.

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -135,6 +135,95 @@ paths:
                   error:
                     type: string
                     example: "Server not found"
+    put:
+      tags: [publish]
+      summary: Update specific MCP server version (Optional)
+      description: |
+        Update a specific version of an MCP server in the registry.
+
+        **Note**: This endpoint is optional for registry implementations and is not implemented by the official MCP registry. It is included in the specification to standardize the update mechanism for registry implementations that choose to support it.
+
+        Authentication mechanism is registry-specific and may vary between implementations.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: serverName
+          in: path
+          required: true
+          description: URL-encoded server name (e.g., "com.example%2Fmy-server")
+          schema:
+            type: string
+            example: "com.example%2Fmy-server"
+        - name: version
+          in: path
+          required: true
+          description: URL-encoded version to update (e.g., "1.0.0" or "1.0.0%2B20130313144700" for versions with build metadata)
+          schema:
+            type: string
+            example: "1.0.0"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ServerDetail'
+      responses:
+        '200':
+          description: Successfully updated server version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerResponse'
+        '401':
+          description: Unauthorized - Invalid or missing authentication token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Invalid or expired Registry JWT token"
+        '403':
+          description: Forbidden - Insufficient permissions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "You do not have permission to update this server"
+        '404':
+          description: Server or version not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Server version not found"
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Failed to update server version"
+        '501':
+          description: Not Implemented - Registry does not support updates
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "Updates are not supported by this registry"
     delete:
       tags: [publish]
       summary: Delete specific MCP server version (Optional)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR adds a PUT method for updating a server version (optional, not implemented by the registry but still provides the ability for other registry implementations to standardise on it)

**Details:**
- Path: PUT /v0.1/servers/{serverName}/versions/{version}
- Purpose: Update a specific version of an MCP server in the registry
- Authentication: Uses bearer token authentication (registry-specific)
- Request Body: Accepts a ServerDetail schema
- Response: Returns a ServerResponse on success (200)
- Error Handling: Includes proper HTTP status codes:
  - 401: Unauthorized
  - 403: Forbidden - Insufficient permissions
  - 404: Server or version not found
  - 500: Internal server error
  - 501: Not Implemented - Registry doesn't support updates

  
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
