### PR TITLE
Add NGINX ingress rate limiting to protect against traffic spikes

### DIFF
--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -247,9 +247,10 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 				"cert-manager.io/cluster-issuer": pulumi.String("letsencrypt-prod"),
 				"kubernetes.io/ingress.class":    pulumi.String("nginx"),
 			// Rate limiting to protect against abuse
-			// Allows 1 request/second sustained, with bursts up to 5 req/sec
-			"nginx.ingress.kubernetes.io/limit-rps":              pulumi.String("1"),
-			"nginx.ingress.kubernetes.io/limit-burst-multiplier": pulumi.String("5"),
+			// Allows 180 requests/minute (3 req/sec avg), with bursts up to 540 requests
+			"nginx.ingress.kubernetes.io/limit-rpm":              pulumi.String("180"),
+			"nginx.ingress.kubernetes.io/limit-burst-multiplier": pulumi.String("3"),
+			"nginx.ingress.kubernetes.io/limit-req-status-code":  pulumi.String("429"),
 			},
 		},
 		Spec: &networkingv1.IngressSpecArgs{


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following is an alternative solution to #833

Goal is to deploy and promote it to prod, then monitor the alerts for a week to see its effect and reassess. In case it's actual traffic that we've started blocking we can also up the replicas. I thought it doesn't make sense to up them now since it would be nice to isolate the result of this change first.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
