### PR TITLE
Set 429 status code responses in the config map

### DIFF
--- a/deploy/pkg/k8s/ingress.go
+++ b/deploy/pkg/k8s/ingress.go
@@ -74,6 +74,9 @@ func SetupIngressController(ctx *pulumi.Context, cluster *providers.ProviderInfo
 					// GCP L4 Passthrough Network Load Balancer does not set X-Forwarded-For
 					// Real client IP comes from TCP connection source with externalTrafficPolicy: Local
 					"use-forwarded-headers": pulumi.String("false"),
+
+					// Set rate limit rejection status code to 429 (Too Many Requests)
+					"limit-req-status-code": pulumi.String("429"),
 				},
 			},
 		},

--- a/deploy/pkg/k8s/registry.go
+++ b/deploy/pkg/k8s/registry.go
@@ -248,9 +248,9 @@ func DeployMCPRegistry(ctx *pulumi.Context, cluster *providers.ProviderInfo, env
 				"kubernetes.io/ingress.class":    pulumi.String("nginx"),
 			// Rate limiting to protect against abuse
 			// Allows 180 requests/minute (3 req/sec avg), with bursts up to 540 requests
+			// Status code 429 is set globally via NGINX ConfigMap (per-Ingress annotation doesn't work)
 			"nginx.ingress.kubernetes.io/limit-rpm":              pulumi.String("180"),
 			"nginx.ingress.kubernetes.io/limit-burst-multiplier": pulumi.String("3"),
-			"nginx.ingress.kubernetes.io/limit-req-status-code":  pulumi.String("429"),
 			},
 		},
 		Spec: &networkingv1.IngressSpecArgs{


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Seems that per ingress annotations were not working, so had to put them in the ingress configmap. Did tested this manually on staging so it's confirmed it's working (I was getting 429s instead of 503s) and no traffic was getting into the registry pod.
 
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
