### PR TITLE
feat: add architecture field to Package

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -524,6 +524,16 @@ components:
           description: "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity."
           example: "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"
           pattern: "^[a-f0-9]{64}$"
+        architecture:
+          type: string
+          description: "Target OS and architecture for the package (e.g., 'linux-amd64', 'darwin-arm64'). Allows clients to select the appropriate package for their platform without parsing identifiers."
+          examples:
+            - "linux-amd64"
+            - "linux-arm64"
+            - "darwin-amd64"
+            - "darwin-arm64"
+            - "windows-amd64"
+            - "windows-arm64"
         runtimeHint:
           type: string
           description: A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -206,6 +206,18 @@
     },
     "Package": {
       "properties": {
+        "architecture": {
+          "description": "Target OS and architecture for the package (e.g., 'linux-amd64', 'darwin-arm64'). Allows clients to select the appropriate package for their platform without parsing identifiers.",
+          "examples": [
+            "linux-amd64",
+            "linux-arm64",
+            "darwin-amd64",
+            "darwin-arm64",
+            "windows-amd64",
+            "windows-arm64"
+          ],
+          "type": "string"
+        },
         "environmentVariables": {
           "description": "A mapping of environment variables to be set when running the package.",
           "items": {

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -33,6 +33,16 @@ const (
 	RuntimeHintDNX    = "dnx"
 )
 
+// Architecture - OS and architecture combinations for packages
+const (
+	ArchLinuxAMD64   = "linux-amd64"
+	ArchLinuxARM64   = "linux-arm64"
+	ArchDarwinAMD64  = "darwin-amd64"
+	ArchDarwinARM64  = "darwin-arm64"
+	ArchWindowsAMD64 = "windows-amd64"
+	ArchWindowsARM64 = "windows-arm64"
+)
+
 // Schema versions
 const (
 	// CurrentSchemaVersion is the current supported schema version date

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -38,6 +38,8 @@ type Package struct {
 	Version string `json:"version,omitempty" minLength:"1" doc:"Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '>=1.2.3', '1.x', '1.*')." example:"1.0.2"`
 	// FileSHA256 is the SHA-256 hash for integrity verification (required for mcpb, optional for others)
 	FileSHA256 string `json:"fileSha256,omitempty" pattern:"^[a-f0-9]{64}$" doc:"SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity." example:"fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce"`
+	// Architecture specifies the target OS and architecture (e.g., "linux-amd64", "darwin-arm64")
+	Architecture string `json:"architecture,omitempty" doc:"Target OS and architecture for the package (e.g., 'linux-amd64', 'darwin-arm64'). Allows clients to select the appropriate package for their platform without parsing identifiers." example:"linux-amd64"`
 	// RunTimeHint suggests the appropriate runtime for the package
 	RunTimeHint string `json:"runtimeHint,omitempty" doc:"A hint to help clients determine the appropriate runtime for the package. This field should be provided when runtimeArguments are present." example:"npx"`
 	// Transport is required and specifies the transport protocol configuration


### PR DESCRIPTION
## Problem

When publishing MCPB packages that support multiple architectures, authors must create separate Package entries for each OS/architecture combination. Currently, clients have no standardized way to determine which package is appropriate for their platform without parsing the identifier URL.

For example, a server with Linux AMD64 and ARM64 builds requires two packages:

```json
{
  "packages": [
    {
      "registryType": "mcpb",
      "identifier": "https://github.com/NimbleBrainInc/mcp-echo/releases/download/v0.1.0/mcp-echo-v0.1.0-linux-amd64.mcpb",
      "version": "0.1.0",
      "fileSha256": "26ef091c...",
      "transport": { "type": "streamable-http", "url": "http://localhost:8000/mcp" },
      "environmentVariables": [...]
    },
    {
      "registryType": "mcpb",
      "identifier": "https://github.com/NimbleBrainInc/mcp-echo/releases/download/v0.1.0/mcp-echo-v0.1.0-linux-arm64.mcpb",
      "version": "0.1.0",
      "fileSha256": "c5941f02...",
      "transport": { "type": "streamable-http", "url": "http://localhost:8000/mcp" },
      "environmentVariables": [...]
    }
  ]
}
```

Clients must currently either:
1. Parse the URL to guess the architecture (this is what we're doing now, but it's fragile with no standard format)
2. Iterate through all packages and try each one (inefficient)

## Solution

Add an optional `architecture` field to the Package type that explicitly declares the target OS and architecture using the `{os}-{arch}` format (e.g., `linux-amd64`, `darwin-arm64`).

This follows the convention used by Go (`GOOS-GOARCH`), Docker, and other package ecosystems.

## Changes

| File | Change |
|------|--------|
| `pkg/model/constants.go` | Add architecture constants (`linux-amd64`, `linux-arm64`, `darwin-amd64`, `darwin-arm64`, `windows-amd64`, `windows-arm64`) |
| `pkg/model/types.go` | Add optional `Architecture` field to `Package` struct |
| `docs/reference/api/openapi.yaml` | Add `architecture` property to Package schema |
| `docs/reference/server-json/server.schema.json` | Auto-regenerated |

## Example Usage

```json
{
  "packages": [
    {
      "registryType": "mcpb",
      "architecture": "linux-amd64",
      "identifier": "https://github.com/.../mcp-echo-v0.1.0-linux-amd64.mcpb",
      "version": "0.1.0",
      "fileSha256": "26ef091c...",
      "transport": { "type": "streamable-http", "url": "http://localhost:8000/mcp" }
    },
    {
      "registryType": "mcpb",
      "architecture": "linux-arm64",
      "identifier": "https://github.com/.../mcp-echo-v0.1.0-linux-arm64.mcpb",
      "version": "0.1.0",
      "fileSha256": "c5941f02...",
      "transport": { "type": "streamable-http", "url": "http://localhost:8000/mcp" }
    }
  ]
}
```

Clients can now filter packages directly:

```go
for _, pkg := range server.Packages {
    if pkg.Architecture == runtime.GOOS + "-" + runtime.GOARCH {
        return pkg // Found matching package
    }
}
```

## Test plan

- [ ] Verify `make check` passes
- [ ] Review generated schema includes new field with examples
