### PR TITLE
Fixing unhandled NUL Bytes in API Requests

### DIFF
--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -42,6 +42,8 @@ type ServerVersionsInput struct {
 }
 
 // RegisterServersEndpoints registers all server-related endpoints with a custom path prefix
+//
+//nolint:cyclop
 func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.RegistryService) {
 	// List servers endpoint
 	huma.Register(api, huma.Operation{
@@ -52,6 +54,10 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		Description: "Get a paginated list of MCP servers from the registry",
 		Tags:        []string{"servers"},
 	}, func(ctx context.Context, input *ListServersInput) (*Response[apiv0.ServerListResponse], error) {
+		if containsNULByte(input.Cursor) {
+			return nil, huma.Error400BadRequest("Invalid cursor: NUL byte not allowed")
+		}
+
 		// Build filter from input parameters
 		filter := &database.ServerFilter{}
 
@@ -119,11 +125,17 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		if err != nil {
 			return nil, huma.Error400BadRequest("Invalid server name encoding", err)
 		}
+		if containsNULByte(serverName) {
+			return nil, huma.Error400BadRequest("Invalid server name: NUL byte not allowed")
+		}
 
 		// URL-decode the version
 		version, err := url.PathUnescape(input.Version)
 		if err != nil {
 			return nil, huma.Error400BadRequest("Invalid version encoding", err)
+		}
+		if containsNULByte(version) {
+			return nil, huma.Error400BadRequest("Invalid version: NUL byte not allowed")
 		}
 
 		var serverResponse *apiv0.ServerResponse
@@ -160,6 +172,9 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		if err != nil {
 			return nil, huma.Error400BadRequest("Invalid server name encoding", err)
 		}
+		if containsNULByte(serverName) {
+			return nil, huma.Error400BadRequest("Invalid server name: NUL byte not allowed")
+		}
 
 		// Get all versions for this server
 		servers, err := registry.GetAllVersionsByServerName(ctx, serverName)
@@ -185,4 +200,8 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 			},
 		}, nil
 	})
+}
+
+func containsNULByte(s string) bool {
+	return strings.IndexByte(s, 0) >= 0
 }

--- a/internal/api/handlers/v0/servers_test.go
+++ b/internal/api/handlers/v0/servers_test.go
@@ -461,6 +461,8 @@ func TestServersEndpointEdgeCases(t *testing.T) {
 			{"limit too high", "?limit=1000", http.StatusUnprocessableEntity, "validation failed"},
 			{"negative limit", "?limit=-1", http.StatusUnprocessableEntity, "validation failed"},
 			{"invalid updated_since format", "?updated_since=invalid", http.StatusBadRequest, "Invalid updated_since format"},
+			{"cursor contains NUL", "?cursor=%00", http.StatusBadRequest, "Invalid cursor"},
+			{"cursor contains non NUL", "?cursor=server", http.StatusOK, ""},
 			{"future updated_since", "?updated_since=2030-01-01T00:00:00Z", http.StatusOK, ""},
 			{"very old updated_since", "?updated_since=1990-01-01T00:00:00Z", http.StatusOK, ""},
 			{"empty search parameter", "?search=", http.StatusOK, ""},
@@ -487,6 +489,16 @@ func TestServersEndpointEdgeCases(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("path parameter NUL byte rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v0/servers/%00/versions", nil)
+		w := httptest.NewRecorder()
+
+		mux.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "Invalid server name")
 	})
 
 	t.Run("response structure validation", func(t *testing.T) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
The changes fixes https://github.com/modelcontextprotocol/registry/issues/862 by checking Null Byte in the string.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
https://github.com/modelcontextprotocol/registry/issues/862

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
UTs.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
