### PR TITLE
Create rtbrick-docs.json for documentation access

### DIFF
--- a/rtbrick-docs.json
+++ b/rtbrick-docs.json
@@ -1,0 +1,52 @@
+{
+  "name": "rtbrick-docs",
+  "displayName": "RtBrick Documentation",
+  "description": "Access and search RtBrick's technical documentation including networking configuration guides, API references, and technical specifications",
+  "icon": "https://www.rtbrick.com/favicon.ico",
+  "author": {
+    "name": "Pravin Bhandarkar",
+    "url": "https://github.com/rtbrick"
+  },
+  "sourceUrl": "https://github.com/yourusername/rtb-doc-mcp-server",
+  "license": "MIT",
+  "runtime": "python",
+  "categories": [
+    "documentation",
+    "search",
+    "enterprise"
+  ],
+  "tags": [
+    "networking",
+    "documentation",
+    "rtbrick",
+    "technical-docs",
+    "search"
+  ],
+  "installation": {
+    "pip": "rtb-doc-mcp-server"
+  },
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "config_path": {
+        "type": "string",
+        "description": "Path to config.json file",
+        "required": false
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "search_documentation",
+      "description": "Search through RtBrick documentation with keywords"
+    },
+    {
+      "name": "get_document",
+      "description": "Retrieve full content of a specific documentation file"
+    },
+    {
+      "name": "list_all_documents",
+      "description": "List all available documentation files"
+    }
+  ]
+}


### PR DESCRIPTION
Added a JSON configuration file for RtBrick documentation including metadata, installation instructions, and available tools.

<!-- Provide a brief summary of your changes -->

Adding MCP server to parse open documentation on Rtbrick site and provide responses

## Motivation and Context
- Rtbrick's document server parses the available open documentation on the website to provide specific information about the technology, Rtbrick's implementation and feature set
- Provides responses about reference designs for the various use cases above and specific configuration that can ease validation, testing and eventually deployment of the features
- Provides information on the ODM platform that Rtbrick supports as well as optical interfaces

## How Has This Been Tested?
Yes. Number of queries with corner cases that are unlikely to be supported and well known reference designs that are adequately highlighted

## Breaking Changes
# Clone the repository
git clone https://github.com/rtbrick/rtb-doc-mcp-server.git
cd rtb-doc-mcp-server

## Types of changes

- [ NA ] Bug fix (non-breaking change which fixes an issue)
- [ NA ] New feature (non-breaking change which adds functionality)
- [ NA ] Breaking change (fix or feature that would cause existing functionality to change)
- [  X ] Documentation update

## Checklist

- [X ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X ] My code follows the repository's style guidelines
- [ X] New and existing tests pass locally
- [ X] I have added appropriate error handling
- [ X] I have added or updated documentation as needed

## Additional context- Review  Rtbrick's open  documentation for technology and configuration
- Rtbrick documentation for reference design and topology<!-- Add any other context, implementation notes, or design decisions -->
