### PR TITLE
Add Agent Hub MCP server - crypto-native AI services

### DIFF
--- a/src/agent-hub/index.json
+++ b/src/agent-hub/index.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-hub",
+  "displayName": "Agent Hub",
+  "description": "Crypto-native AI services with USDC payments on Base Mainnet",
+  "longDescription": "Access 18 premium AI services including sentiment analysis, translation, research, web scraping, data extraction, content generation, code review, and more. All services accept USDC cryptocurrency payments on Base Mainnet with no subscriptions required.",
+  "repository": "https://github.com/SVG-campus/agent-hub",
+  "homepage": "https://web-production-4833.up.railway.app",
+  "categories": ["ai", "web3", "data", "content"],
+  "tags": ["crypto", "usdc", "base", "payment", "sentiment", "translation", "research", "scraping"],
+  "author": {
+    "name": "SVG-campus",
+    "url": "https://github.com/SVG-campus"
+  },
+  "license": "MIT",
+  "versions": {
+    "latest": "1.0.0"
+  }
+}

--- a/src/agent-hub/server/agent_hub_mcp.py
+++ b/src/agent-hub/server/agent_hub_mcp.py
@@ -1,0 +1,68 @@
+from mcp.server import Server
+from mcp.types import Tool, TextContent
+import httpx
+
+app = Server("agent-hub")
+BASE_URL = "https://web-production-4833.up.railway.app"
+
+@app.list_tools()
+async def list_tools():
+    return [
+        Tool(
+            name="sentiment_analysis",
+            description="Analyze sentiment ($0.05 USDC)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "payment_tx": {"type": "string"}
+                },
+                "required": ["text"]
+            }
+        ),
+        Tool(
+            name="translate",
+            description="Translate text ($0.05 USDC)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "target_language": {"type": "string"},
+                    "payment_tx": {"type": "string"}
+                },
+                "required": ["text", "target_language"]
+            }
+        ),
+        Tool(
+            name="web_research",
+            description="Research with sources ($0.30 USDC)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "payment_tx": {"type": "string"}
+                },
+                "required": ["query"]
+            }
+        )
+    ]
+
+@app.call_tool()
+async def call_tool(name, arguments):
+    headers = {}
+    if "payment_tx" in arguments:
+        headers["PAYMENT-SIGNATURE"] = arguments.pop("payment_tx")
+    
+    endpoint_map = {
+        "sentiment_analysis": "/agent/sentiment",
+        "translate": "/agent/translate",
+        "web_research": "/agent/research"
+    }
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{BASE_URL}{endpoint_map[name]}",
+            json=arguments,
+            headers=headers
+        )
+        return [TextContent(type="text", text=response.text)]

--- a/src/agent-hub/v1.0.0.json
+++ b/src/agent-hub/v1.0.0.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "runtime": "python",
+  "install": {
+    "pip": "pip install mcp httpx"
+  },
+  "config": {
+    "command": "python",
+    "args": ["-m", "agent_hub_mcp"]
+  },
+  "capabilities": [
+    "sentiment_analysis",
+    "translation",
+    "web_research",
+    "web_scraping",
+    "data_extraction",
+    "content_generation",
+    "code_review"
+  ],
+  "pricing": {
+    "model": "pay-per-use",
+    "currency": "USDC",
+    "network": "Base Mainnet",
+    "range": "$0.05 - $2.00 per service"
+  }
+}


### PR DESCRIPTION
Agent Hub provides 18 crypto-native AI services with USDC payments on Base Mainnet.

Services include sentiment analysis, translation, research, web scraping, data extraction, content generation, code review, SWOT analysis, competitive analysis, and more.

Features:

Pay-per-use pricing from $0.05 to $2.00

USDC payments on Base Mainnet L2

No subscriptions or API keys

x402 payment protocol

Already integrated with LangChain and OpenAI GPT

Live API: https://web-production-4833.up.railway.app/
Docs: https://web-production-4833.up.railway.app/docs
PyPI: pip install langchain-agent-hub