### PR TITLE
feat: add Fakturownia/InvoiceOcean MCP server to seed data

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,41 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.konradbachowski/fakturownia-invoiceocean-mcp",
+    "title": "Fakturownia / InvoiceOcean",
+    "description": "Comprehensive MCP server for managing invoices, clients, products, and payments on Fakturownia.pl and InvoiceOcean platforms.",
+    "repository": {
+      "url": "https://github.com/konradbachowski/fakturownia-invoiceocean-mcp.git",
+      "source": "github"
+    },
+    "version": "0.1.0",
+    "packages": [
+      {
+        "registryType": "pypi",
+        "identifier": "fakturownia-invoiceocean-mcp",
+        "version": "0.1.0",
+        "runtimeHint": "python",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "name": "FAKTUROWNIA_API_TOKEN",
+            "description": "Your Fakturownia API token",
+            "isRequired": true,
+            "isSecret": true
+          },
+          {
+            "name": "FAKTUROWNIA_DOMAIN",
+            "description": "Your Fakturownia subdomain (e.g. 'mycompany')",
+            "isRequired": true,
+            "isSecret": false
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Summary
Added the **Fakturownia / InvoiceOcean** MCP server to the official registry. This server allows AI agents to manage invoices, clients, products, and payments across all global versions of the platform (Fakturownia.pl, InvoiceOcean.com, BitFactura.es, VosFactures.fr).

 Motivation and Context
Fakturownia (and its global brand InvoiceOcean) is a leading invoicing platform. This integration enables business automation by allowing AI agents to perform real-time accounting tasks like issuing invoices or checking payment statuses via simple natural language commands.

 How Has This Been Tested?
The server has been tested sequentially using a live test account on the `heyneurontest.fakturownia.pl` domain.
Tested scenarios:
- Listing and creating clients.
- Listing products and checking stock levels.
- Listing invoices and creating new VAT invoices with multiple positions.
- Registering payments and linking them to existing invoices.
- Listing account departments.

 Breaking Changes
None. This is a new server addition to the seed data.
 Types of changes
- [x] New feature (non-breaking change which adds functionality)
 Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

 Additional context
The server is built using **FastMCP (Python)** and is fully packaged with `pyproject.toml`. It includes a verification tag in the README (`mcp-name`) as required by the registry standards. The metadata is added to `data/seed.json` to ensure immediate availability in the built-in server list.