### PR TITLE
docs: Add preview disclaimer note to public documentation

### DIFF
--- a/docs/modelcontextprotocol-io/about.mdx
+++ b/docs/modelcontextprotocol-io/about.mdx
@@ -3,6 +3,10 @@ title: The MCP Registry
 sidebarTitle: About
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 The MCP Registry is the official centralized metadata repository for publicly accessible MCP servers, backed by major trusted contributors to the MCP ecosystem such as Anthropic, GitHub, PulseMCP, and Microsoft.
 
 The MCP Registry provides:

--- a/docs/modelcontextprotocol-io/authentication.mdx
+++ b/docs/modelcontextprotocol-io/authentication.mdx
@@ -3,6 +3,10 @@ title: How to Authenticate When Publishing to the Official MCP Registry
 sidebarTitle: Authentication
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 You must authenticate before publishing to the official MCP Registry. The MCP Registry supports different authentication methods. Which authentication method you choose determines the namespace of your server's name.
 
 If you choose GitHub-based authentication, your server's name in `server.json` **MUST** be of the form `io.github.username/*` (or `io.github.orgname/*`). For example, `io.github.alice/weather-server`.

--- a/docs/modelcontextprotocol-io/faq.mdx
+++ b/docs/modelcontextprotocol-io/faq.mdx
@@ -3,6 +3,10 @@ title: Frequently Asked Questions
 sidebarTitle: FAQ
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 ## General
 
 ### What is the difference between "Official MCP Registry", "MCP Registry", "MCP registry", "MCP Registry API", etc?

--- a/docs/modelcontextprotocol-io/github-actions.mdx
+++ b/docs/modelcontextprotocol-io/github-actions.mdx
@@ -3,6 +3,10 @@ title: How to Automate Publishing with GitHub Actions
 sidebarTitle: GitHub Actions
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 ## Step 1: Create a Workflow File
 
 In your server project directory, create a `.github/workflows/publish-mcp.yml` file. Here is an example for npm-based local server, but the MCP Registry publishing steps are the same for all package types:

--- a/docs/modelcontextprotocol-io/moderation-policy.mdx
+++ b/docs/modelcontextprotocol-io/moderation-policy.mdx
@@ -3,6 +3,10 @@ title: The MCP Registry Moderation Policy
 sidebarTitle: Moderation Policy
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 **TL;DR**: The MCP Registry is quite permissive! We only remove illegal content, malware, spam, and completely broken servers.
 
 ## Scope

--- a/docs/modelcontextprotocol-io/package-types.mdx
+++ b/docs/modelcontextprotocol-io/package-types.mdx
@@ -3,6 +3,10 @@ title: MCP Registry Supported Package Types
 sidebarTitle: Package Types
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 # Package Types
 
 The MCP Registry supports several different package types, and each package type has its own verification method.

--- a/docs/modelcontextprotocol-io/quickstart.mdx
+++ b/docs/modelcontextprotocol-io/quickstart.mdx
@@ -3,6 +3,10 @@ title: "Quickstart: Publish an MCP Server to the MCP Registry"
 sidebarTitle: "Quickstart: Publish a Server"
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 This tutorial will show you how to publish an MCP server written in TypeScript to the MCP Registry using the official `mcp-publisher` CLI tool.
 
 ## Prerequisites

--- a/docs/modelcontextprotocol-io/registry-aggregators.mdx
+++ b/docs/modelcontextprotocol-io/registry-aggregators.mdx
@@ -3,6 +3,10 @@ title: MCP Registry Aggregators
 sidebarTitle: Registry Aggregators
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 Aggregators are downstream consumers of the MCP Registry that provide additional value. For example, a server marketplace that provides user ratings and security scanning.
 
 The MCP Registry provides an unauthenticated read-only REST API that aggregators can use to populate their data stores. Aggregators are expected to scrape data on a regular but infrequent basis (e.g., once per hour), and persist the data in their own data store. The MCP Registry **does not provide uptime or data durability guarantees**.

--- a/docs/modelcontextprotocol-io/remote-servers.mdx
+++ b/docs/modelcontextprotocol-io/remote-servers.mdx
@@ -3,6 +3,10 @@ title: Publishing Remote Servers
 sidebarTitle: Remote Servers
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 The MCP Registry supports remote MCP servers via the `remotes` property in `server.json`:
 
 ```json server.json highlight={7-12}

--- a/docs/modelcontextprotocol-io/terms-of-service.mdx
+++ b/docs/modelcontextprotocol-io/terms-of-service.mdx
@@ -3,6 +3,10 @@ title: Official MCP Registry Terms of Service
 sidebarTitle: Terms of Service
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 **Effective date: 2025-09-02**
 
 ## Overview

--- a/docs/modelcontextprotocol-io/versioning.mdx
+++ b/docs/modelcontextprotocol-io/versioning.mdx
@@ -3,6 +3,10 @@ title: Versioning Published MCP Servers
 sidebarTitle: Versioning
 ---
 
+<Note>
+  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+</Note>
+
 MCP servers **MUST** define a version string in `server.json`. For example:
 
 ```json server.json highlight={6}


### PR DESCRIPTION
Add a `<Note>` component to all MDX files in `docs/modelcontextprotocol-io/` informing readers that the MCP Registry is currently in preview and that breaking changes or data resets may occur before general availability.

The note also directs users to report issues on GitHub at https://github.com/modelcontextprotocol/registry/issues

---

@domdomegg @tadasant @rdimitrov We're not GA yet, but what do you think about publishing the Registry docs on https://modelcontextprotocol.io/ with a disclaimer at the top of each page?  It could let more users know about the Registry, and allow us to collect more feedback. :smiley: 