### PR TITLE
docs: clarify reverse DNS namespacing rules for server names and extension metadata

### DIFF
--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -778,7 +778,7 @@ components:
       properties:
         name:
           type: string
-          description: "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name."
+          description: "Unique MCP server identifier in reverse-DNS format. Must contain exactly one forward slash separating namespace from the server name. Include as many subdomain levels in the namespace as necessary for uniqueness."
           example: "io.github.user/weather"
           minLength: 3
           maxLength: 200
@@ -828,7 +828,7 @@ components:
             $ref: '#/components/schemas/RemoteTransport'
         _meta:
           type: object
-          description: "Extension metadata using reverse DNS namespacing for vendor-specific data"
+          description: "Optional extension metadata for vendor-specific data. Keys must use reverse-DNS namespacing to avoid collisions. Include as many subdomain levels as necessary for uniqueness."
           properties:
             io.modelcontextprotocol.registry/publisher-provided:
               type: object

--- a/docs/reference/server-json/generic-server-json.md
+++ b/docs/reference/server-json/generic-server-json.md
@@ -30,6 +30,13 @@ The optional `_meta` field allows publishers to include custom metadata alongsid
 
 When publishing to the official registry, custom metadata must be placed under the key `io.modelcontextprotocol.registry/publisher-provided`. See the [official registry requirements](./official-registry-requirements.md) for detailed restrictions and examples.
 
+## Reverse DNS Namespacing
+
+Both the `_meta` keys and the `name` field in a `server.json` file use reverse DNS format to provide a structured, globally unique namespace.
+
+Reverse DNS components (including subdomains) MAY be included as necessary for uniqueness.
+There is no fixed limit on the number of domain segments, as long as the namespace is derived from a domain name controlled by the publisher.
+
 ## Examples
 
 <!-- As a heads up, these are used as part of tests/integration/main.go -->

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -409,7 +409,7 @@
           "type": "string"
         },
         "_meta": {
-          "description": "Optional extension metadata for vendor-specific data. Keys must use reverse-DNS namespacing to avoid collisions. Include as many subdomain levels as necessary for uniqueness.",
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
           "properties": {
             "io.modelcontextprotocol.registry/publisher-provided": {
               "additionalProperties": true,
@@ -443,7 +443,7 @@
           "type": "array"
         },
         "name": {
-          "description": "Unique MCP server identifier in reverse-DNS format. Must contain exactly one forward slash separating namespace from the server name. Include as many subdomain levels in the namespace as necessary for uniqueness.",
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
           "example": "io.github.user/weather",
           "maxLength": 200,
           "minLength": 3,

--- a/docs/reference/server-json/server.schema.json
+++ b/docs/reference/server-json/server.schema.json
@@ -409,7 +409,7 @@
           "type": "string"
         },
         "_meta": {
-          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+          "description": "Optional extension metadata for vendor-specific data. Keys must use reverse-DNS namespacing to avoid collisions. Include as many subdomain levels as necessary for uniqueness.",
           "properties": {
             "io.modelcontextprotocol.registry/publisher-provided": {
               "additionalProperties": true,
@@ -443,7 +443,7 @@
           "type": "array"
         },
         "name": {
-          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "description": "Unique MCP server identifier in reverse-DNS format. Must contain exactly one forward slash separating namespace from the server name. Include as many subdomain levels in the namespace as necessary for uniqueness.",
           "example": "io.github.user/weather",
           "maxLength": 200,
           "minLength": 3,


### PR DESCRIPTION
Clarifies how reverse DNS namespacing is used in `server.json`, explicitly documenting that subdomains may be included as necessary for uniqueness, and that there is no fixed limit on the number of domain segments.

## Motivation and Context

The current specification and examples use reverse DNS identifiers, but do not explicitly state whether subdomains are allowed or how many domain segments are valid.

This has led to potential ambiguity, especially when examples appear to use a fixed number of segments, which can be interpreted as an implicit constraint rather than a convention.

This change adds a short clarification to make it explicit that:

- Subdomains may be included as necessary for uniqueness.
- There is no fixed limit on the number of reverse DNS components, as long as the namespace is derived from a domain controlled by the publisher.

This aligns the documentation with common reverse DNS usage and helps avoid accidental namespace collisions.

## How Has This Been Tested?

This change is documentation-only.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127
