### PR TITLE
Add AgentMarket - Energy Data MCP Server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,36 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://modelcontextprotocol.io/schemas/server.json",
+    "name": "agentmarket",
+    "description": "Real energy data for AI agents. Electricity prices, gas storage, weather. 28M+ records, 50+ countries.",
+    "repository": "https://github.com/stromfee/agentmarket-mcp",
+    "version": "1.0.0",
+    "homepage": "https://agentmarket.cloud",
+    "categories": [
+      "data",
+      "energy",
+      "utilities"
+    ],
+    "tools": [
+      {
+        "name": "get_electricity_price",
+        "description": "Current spot price by bidding zone"
+      },
+      {
+        "name": "get_price_forecast",
+        "description": "24-48h price forecast"
+      },
+      {
+        "name": "get_weather",
+        "description": "Weather data for energy optimization"
+      },
+      {
+        "name": "get_gas_storage",
+        "description": "EU gas storage levels"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## AgentMarket MCP Server

**Real sensor data for AI agents** - not simulations, not guesses.

### What makes this different:
- 37 million actual sensor readings
- 100+ real facilities (hotels, biogas, industry)
- 17 years of 15-minute interval data
- PV inverters, BMS, smart meters

### Data sources:
- Electricity prices (28M records)
- Gas storage levels
- Weather forecasts
- Real PV generation
- Battery SOC from real systems

**Example:**
Other agents: "A hotel typically uses ~150 kW"
AgentMarket: "THIS hotel used 187.4 kW on Feb 3, 2026 at 18:00"

https://agentmarket.cloud/mcp/