### PR TITLE
Add Avalanche Documentation MCP server

### DIFF
--- a/data/avalanche-server.json
+++ b/data/avalanche-server.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.avax/avalanche-docs",
+  "title": "Avalanche Documentation",
+  "description": "Search and retrieve Avalanche blockchain documentation, integrations, and academy content. Provides access to 1300+ pages of documentation for building on the Avalanche network.",
+  "repository": {
+    "url": "https://github.com/ava-labs/avalanche-docs",
+    "source": "github"
+  },
+  "websiteUrl": "https://build.avax.network",
+  "version": "1.0.0",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/Airpote/avalanche-mcp-vscode/main/images/icon.png",
+      "mimeType": "image/png",
+      "sizes": ["128x128"]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://build.avax.network/api/mcp"
+    }
+  ],
+  "tools": [
+    {
+      "name": "avalanche_docs_search",
+      "description": "Search Avalanche documentation by query with optional source filter (docs, academy, integrations, blog)"
+    },
+    {
+      "name": "avalanche_docs_fetch",
+      "description": "Get a specific documentation page by URL path"
+    },
+    {
+      "name": "avalanche_docs_list_sections",
+      "description": "List all documentation sections with page counts"
+    }
+  ]
+}

--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,32 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.avax/avalanche-docs",
+    "title": "Avalanche Documentation",
+    "description": "Search and retrieve Avalanche blockchain documentation, integrations, and academy content. Access 1300+ pages of documentation for building on the Avalanche network.",
+    "repository": {
+      "url": "https://github.com/ava-labs/avalanche-docs",
+      "source": "github"
+    },
+    "websiteUrl": "https://build.avax.network",
+    "version": "1.0.0",
+    "icons": [
+      {
+        "src": "https://raw.githubusercontent.com/Airpote/avalanche-mcp-vscode/main/images/icon.png",
+        "mimeType": "image/png",
+        "sizes": [
+          "128x128"
+        ]
+      }
+    ],
+    "remotes": [
+      {
+        "type": "streamable-http",
+        "url": "https://build.avax.network/api/mcp"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Adds the official Avalanche MCP server to the registry seed data.

## Avalanche MCP Server Details

- **Name**: `io.avax/avalanche-docs`
- **Endpoint**: `https://build.avax.network/api/mcp`
- **Transport**: Streamable HTTP
- **Documentation**: https://build.avax.network/docs/tooling/ai-llm

### Available Tools

| Tool | Purpose |
|------|---------|
| `avalanche_docs_search` | Search docs by query with optional source filter |
| `avalanche_docs_fetch` | Get a specific page by URL path |
| `avalanche_docs_list_sections` | List all sections with page counts |

### Features

- Access to 1300+ pages of Avalanche blockchain documentation
- Covers documentation, academy courses, integrations, and blog content
- JSON-RPC 2.0 compatible
- Rate limited to 60 requests/minute
- No authentication required

### Configuration Example

```json
{
  "mcpServers": {
    "avalanche-docs": {
      "transport": {
        "type": "http",
        "url": "https://build.avax.network/api/mcp"
      }
    }
  }
}
```

This MCP server is officially provided by Ava Labs for the Avalanche blockchain ecosystem.