### PR TITLE
Split HTTP error metrics into separate 4xx and 5xx counters

### DIFF
--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -77,8 +77,10 @@ func MetricTelemetryMiddleware(metrics *telemetry.Metrics, options ...Middleware
 		// Record metrics
 		metrics.Requests.Add(ctx.Context(), 1, metric.WithAttributes(attrs...))
 
-		if statusCode >= 400 {
+		if statusCode >= 500 {
 			metrics.ErrorCount.Add(ctx.Context(), 1, metric.WithAttributes(attrs...))
+		} else if statusCode >= 400 {
+			metrics.ClientErrorCount.Add(ctx.Context(), 1, metric.WithAttributes(attrs...))
 		}
 
 		metrics.RequestDuration.Record(ctx.Context(), duration, metric.WithAttributes(attrs...))


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The following PR split the metrics into separate 4xx and 5xx counters

**Details:**
- Separate mcp_registry_http_errors_total to only count 5xx server errors
- Add new mcp_registry_http_client_errors_total counter for 4xx client errors                                                                
- Previously all 4xx and 5xx were counted together under errors making it harder to distinguish real server issues from client validation errors (e.g. 422s were 93% of "errors")

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
