### PR TITLE
Add mycrab-mcp — instant Cloudflare tunnels for AI agents

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,26 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.isgudtek/mycrab-mcp",
+    "description": "Instant public HTTPS Cloudflare tunnels for AI agents. Free ephemeral URLs in under 60 seconds, or permanent custom subdomains via Solana micropayment (x402 autonomous flow).",
+    "repository": {
+      "url": "https://github.com/isgudtek/mycrab-mcp.git",
+      "source": "github"
+    },
+    "version": "0.1.0",
+    "packages": [
+      {
+        "registryType": "pypi",
+        "identifier": "mycrab-mcp",
+        "version": "0.1.0",
+        "runtimeHint": "uvx",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## mycrab-mcp

**PyPI:** https://pypi.org/project/mycrab-mcp/
**GitHub:** https://github.com/isgudtek/mycrab-mcp

MCP server for [mycrab.space](https://mycrab.space) — gives AI agents instant public HTTPS URLs via Cloudflare Tunnels.

- Free ephemeral tunnels in under 60 seconds
- Permanent custom subdomains via Solana micropayment (x402)
- 4 tools: `check_domain`, `setup_free_tunnel`, `buy_domain_sol`, `get_skill_docs`

Install: `uvx mycrab-mcp`

Added as `io.github.isgudtek/mycrab-mcp` with PyPI package type, sorted alphabetically in seed.json.