### PR TITLE
Create io.github.socalstreet.prwire-mcp-server.json

### DIFF
--- a/data/io.github.socalstreet.prwire-mcp-server.json
+++ b/data/io.github.socalstreet.prwire-mcp-server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.socalstreet.prwire-mcp-server",
+  "description": "The permissionless newswire for crypto and digital assets. Get latest news, search articles, and submit press releases across 4 crypto publications.",
+  "repository": {
+    "url": "https://github.com/SoCalStreet/prwire-mcp-server.git",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "prwire-mcp-server",
+      "version": "1.0.0",
+      "runtimeHint": "node",
+      "transport": {
+        "type": "sse"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation and Context
Adding PRWire MCP server to the registry. PRWire is the permissionless newswire for crypto and digital assets.

## Tools provided
- get_latest_news — Get latest crypto news from 4 publications
- search_news — Search articles across the PRWire network  
- submit_press_release — Submit a press release for distribution

## How Has This Been Tested?
Server is live and running at https://mcp.cryptowiredaily.io/sse

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines