### PR TITLE
Add pmll-memory-mcp entry to server.json registry . Told Jonathan why Claude used deprecated pr registry how to 

### DIFF
--- a/data/io.github.drQedwards/pmll-memory-mcp.json
+++ b/data/io.github.drQedwards/pmll-memory-mcp.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.drQedwards/pmll-memory-mcp",
+  "title": "PMLL Memory MCP",
+  "version": "0.1.0",
+  "description": "Short-term KV context memory and Q-promise deduplication for Claude agent tasks via peek().",
+  "repository": {
+    "url": "https://github.com/drQedwards/PPM",
+    "source": "github",
+    "id": "1008142203",
+    "subfolder": "mcp"
+  },
+  "websiteUrl": "https://github.com/drQedwards/PPM/tree/main/mcp",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "pmll-memory-mcp",
+      "version": "0.1.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PMLL_SILO_SIZE",
+          "description": "Number of KV slots in the PMLL memory silo per session. Defaults to 256.",
+          "isRequired": false,
+          "default": "256"
+        },
+        {
+          "name": "PMLL_SESSION_TTL",
+          "description": "Time-to-live in seconds for memory sessions. Defaults to 3600.",
+          "isRequired": false,
+          "default": "3600"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new model context protocol configuration file for the `pmll-memory-mcp` package. The file provides metadata and configuration for short-term key-value context memory and Q-promise deduplication for Claude agent tasks.

New model context protocol configuration:

* Added `data/io.github.drQedwards/pmll-memory-mcp.json` defining schema, metadata, repository info, website URL, and PyPI package details for `pmll-memory-mcp`.
* Included environment variable definitions for session memory size (`PMLL_SILO_SIZE`) and session TTL (`PMLL_SESSION_TTL`) with descriptions and default values.
<!-- Provide a brief summary of your changes -->
Adds a new server.json registry entry for PMLL Memory MCP
(`pmll-memory-mcp`), a GPU-resident salience-based working memory
server for stateless LLM agents. Installable via `uvx pmll-memory-mcp`.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Stateless LLMs like Claude suffer from "context rot" — attention
degradation over long sessions causes hallucinations as early context
deprioritizes toward noise. Existing memory tools (mem0, zep, etc.)
address this with CPU-side KV stores retrieved by keyword or
approximate embedding search.

PMLL Memory MCP takes a different approach: GPU-resident working
memory backed by a persistent CUDA kernel with biological-style
salience decay (ψ-EMA reinforcement, `decay_rate=0.97`). Only
high-salience, semantically-relevant memories are injected into the
context window — preventing context rot by ensuring memory works for
the model, not against it.

Built on the PPM (Python Package Manager) project which includes:
- `cuda_pmll.cu` — VRAM-resident salience pool with lock-free atomics
- `Q_promise_lib` — C/Cython deduplication via Q-promise memory chains
- `PMLL.c` — Ouroboros SAT-solver logic loop for conflict resolution
- `Transformer.cu` — GPU cosine similarity for semantic retrieval
- SHA-256 + Ed25519 cryptographic integrity per memory entry

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- `server.json` validated against the official schema at
  `docs/reference/server-json/draft/server.schema.json`
- Entry tested in `drQedwards/registry` fork ([PR #1, merged](https://github.com/drQedwards/registry/pull/1)) prior
  to upstream submission
- PMLL memory logic tested via `Promises.c` standalone binary
  (`make test` in `Q_promise_lib/`)
- CUDA kernels compiled and verified against `sm_70` architecture:
  ```
  nvcc -O3 -arch=sm_70 cuda_pmll.cu -o pmll_sim
  ```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is an additive entry only — one new file:
```
data/io.github.drQedwards/pmll-memory-mcp.json
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

| Field | Value |
|---|---|
| Source repository | https://github.com/drQedwards/PPM |
| MCP server subfolder | `mcp/` |
| PyPI package | `pmll-memory-mcp 0.1.0` |
| Runtime | `uvx pmll-memory-mcp` (stdio transport) |

**Key design properties:**

- **VRAM-resident storage** — ~μs retrieval vs ~ms for CPU/DB solutions
- **Salience decay to zero** — prevents runaway memory accumulation,
  making the system safe for long-horizon agentic development
- **Persistent CUDA kernel** (`PMLL-breath-resolver`) — always-warm,
  no cold-start retrieval penalty
- **Cryptographic provenance** — SHA-256 per entry + Ed25519 signing

**Configurable via environment variables:**

| Variable | Default | Description |
|---|---|---|
| `PMLL_SILO_SIZE` | `256` | KV slots per session |
| `PMLL_SESSION_TTL` | `3600` | Session TTL in seconds |
This pull request introduces a new metadata file for the `pmll-memory-mcp` package, providing structured information for integration and deployment. The file describes the package's purpose, repository details, PyPI package configuration, and environment variables.

New package metadata definition:

* Added `data/io.github.drQedwards/pmll-memory-mcp.json` to define the `pmll-memory-mcp` package, including schema, name, version, description, repository info, website URL, and PyPI registry details.
* Specified environment variables `PMLL_SILO_SIZE` and `PMLL_SESSION_TTL` with descriptions and default values for session memory configuration.
This pull request introduces a new metadata file for the `pmll-memory-mcp` package, describing its configuration, repository information, and environment variables. The file provides essential details for integration and deployment of the package.

New package metadata definition:

* Added `data/io.github.drQedwards/pmll-memory-mcp.json` to define schema, name, version, description, repository, website, and PyPI package details for the `pmll-memory-mcp` package.
* Included configuration for environment variables `PMLL_SILO_SIZE` and `PMLL_SESSION_TTL` with descriptions and default values to support session memory management.