### PR TITLE
Add 4fetch to Community Projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -29,6 +29,7 @@ Browse the official MCP Registry in your browser!
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
+- [4fetch](https://4fetch.com) - Fetch any URL as clean Markdown via MCP (remote server at api.4fetch.com).
 
 ## Adding Your Project
 


### PR DESCRIPTION
Adds [4fetch](https://4fetch.com) to the Community Projects list. 4fetch provides a remote MCP server that fetches any URL and returns clean Markdown with metadata (no API key required for base tier).

Made with [Cursor](https://cursor.com)