### PR TITLE
Add DJD Agent Score MCP server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,35 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.jacobsd32-cpu/djdagentscore",
+    "description": "Reputation scoring for AI agent wallets on Base L2. Check trust scores (0-100) across 5 dimensions before transacting with autonomous agents.",
+    "repository": {
+      "url": "https://github.com/jacobsd32-cpu/djdagentscore",
+      "source": "github"
+    },
+    "version": "1.0.0",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "djd-agent-score-mcp",
+        "version": "0.1.0",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "name": "DJD_API_KEY",
+            "description": "API key for paid endpoints (get_full_score $0.10, get_score_history $0.15, batch_score $0.50). Free endpoints work without a key.",
+            "isRequired": false,
+            "format": "string",
+            "isSecret": true
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

DJD Agent Score provides reputation scoring for AI agent wallets on Base L2. It lets AI clients check trust scores (0–100) across 5 dimensions before transacting with autonomous agents.

- **npm package**: [`djd-agent-score-mcp`](https://www.npmjs.com/package/djd-agent-score-mcp)
- **GitHub repo**: https://github.com/jacobsd32-cpu/djdagentscore

## Tools exposed

| Tool | Description | Price |
|------|-------------|-------|
| `get_score` | Quick trust score for an agent wallet | Free |
| `get_full_score` | Detailed breakdown across 5 dimensions | $0.10 |
| `get_score_history` | Historical score snapshots over time | $0.15 |
| `batch_score` | Score multiple wallets in one call | $0.50 |
| `check_health` | API health / uptime check | Free |
| `get_api_info` | Available endpoints and pricing | Free |

Paid endpoints use the [x402 payment protocol](https://www.x402.org/) — no API key required for free tools.

## Test plan

- [ ] Verify entry validates against `server.schema.json`
- [ ] Confirm `npx djd-agent-score-mcp` starts the MCP server via stdio
- [ ] Test `get_score` with a known Base wallet address

🤖 Generated with [Claude Code](https://claude.com/claude-code)