### PR TITLE
Add evc-team-relay-mcp - Obsidian vault MCP server (PyPI)

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,26 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.entire-vc/evc-team-relay-mcp",
+    "description": "MCP server for reading and writing Obsidian vault documents via EVC Team Relay - a self-hosted CRDT-based collaborative sync server. Supports listing, reading, writing, and searching notes with multi-agent vault access.",
+    "repository": {
+      "url": "https://github.com/entire-vc/evc-team-relay-mcp.git",
+      "source": "github"
+    },
+    "version": "1.0.0",
+    "packages": [
+      {
+        "registryType": "pypi",
+        "identifier": "evc-team-relay-mcp",
+        "version": "1.0.0",
+        "runtimeHint": "python",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Add evc-team-relay-mcp

### Server details

- **Name:** `io.github.entire-vc/evc-team-relay-mcp`
- **Registry:** PyPI - `evc-team-relay-mcp` v1.0.0
- **GitHub:** https://github.com/entire-vc/evc-team-relay-mcp
- **PyPI:** https://pypi.org/project/evc-team-relay-mcp/
- **Homepage:** https://entire.vc/team-relay/ai/

### What it does

MCP server that gives AI agents read/write access to Obsidian vault documents via EVC Team Relay - a self-hosted CRDT-based collaborative sync server.

**5 MCP tools:**
- `list_folders` - list vault folders
- `list_notes` - list notes in a folder
- `read_note` - read note content
- `write_note` - create or update notes
- `search_notes` - keyword search

### Install

```bash
uvx evc-team-relay-mcp
```
