### PR TITLE
fix(ci): use deploy/go.mod for deploy workflow Go version and bump root Go to 1.25.8

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'deploy/go.mod'
           cache: true
 
       - name: Setup Pulumi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'deploy/go.mod'
           cache: true
 
       - name: Setup Pulumi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/modelcontextprotocol/registry
 
-go 1.24.13
+go 1.25.8
 
 require (
 	cloud.google.com/go/kms v1.26.0


### PR DESCRIPTION
## Summary

Fixes two CI issues:

### 1. Deploy workflows broken since PR #1034 (all staging deploys failing)

The deploy-staging and deploy-production workflows install Go using the **root** `go.mod`, but then build Pulumi infrastructure code from the `deploy/` directory which has its own `go.mod`.

This started failing when PR #1034 (`build(deps): bump github.com/pulumi/pulumi/sdk/v3 from 3.220.0 to 3.225.1 in /deploy`) bumped `deploy/go.mod` from Go 1.24.11 to **Go 1.25.6** — a version newer than the root module's Go 1.24.13. Every staging deploy since that merge (Mar 6) has failed with:

```
go: go.mod requires go >= 1.25.6 (running go 1.24.13; GOTOOLCHAIN=local)
```

The last successful deploy was commit cb4807a on Mar 1, before the Go version bump.

**Fix**: point `go-version-file` in both deploy workflows at `deploy/go.mod` instead of the root `go.mod`.

### 2. `govulncheck` failing due to Go stdlib vulnerabilities

Five new Go stdlib vulnerabilities (GO-2026-4599 through GO-2026-4603) were published on Mar 5-6 affecting Go 1.24.13, fixed in Go 1.25.8. These cause `govulncheck` in the CI pipeline to fail.

**Fix**: bump root `go.mod` from Go 1.24.13 to Go 1.25.8.

## Test plan
- [ ] CI pipeline passes (govulncheck, build, lint, tests)
- [ ] Verify the deploy-staging workflow passes on the next push to main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)