### PR TITLE
fix(ci): bump root Go to 1.26.1 to resolve govulncheck failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
       with:
-        version: v2.4.0
+        version: v2.11.1
 
     - name: Validate schemas and examples
       run: make validate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,12 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - linters: [noctx]
+        path: _test\.go
+      - linters: [gosec]
+        path: _test\.go
+        text: "G101"
     paths:
       - third_party$
       - builtin$

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Often (but not always) ideas flow through this pipeline:
 - **Docker**
 - **Go 1.24.x**
 - **ko** - Container image builder for Go ([installation instructions](https://ko.build/install/))
-- **golangci-lint v2.4.0**
+- **golangci-lint v2.11.1**
 
 #### Running the server
 

--- a/cmd/publisher/auth/common.go
+++ b/cmd/publisher/auth/common.go
@@ -160,7 +160,7 @@ func parseRawPrivateKey(curve elliptic.Curve, privateKeyBytes []byte) (*ecdsa.Pr
 		return nil, fmt.Errorf("invalid private scalar")
 	}
 
-	x, y := curve.ScalarBaseMult(d.Bytes())
+	x, y := curve.ScalarBaseMult(d.Bytes()) //nolint:staticcheck // SA1019: migrating to crypto/ecdh is a separate effort
 	return &ecdsa.PrivateKey{
 		PublicKey: ecdsa.PublicKey{
 			Curve: curve,
@@ -192,7 +192,7 @@ func PrintEcdsaP384KeyInfo(pubKey ecdsa.PublicKey) {
 }
 
 func printEcdsaKeyInfo(k string, pubKey ecdsa.PublicKey) {
-	compressed := elliptic.MarshalCompressed(pubKey.Curve, pubKey.X, pubKey.Y)
+	compressed := elliptic.MarshalCompressed(pubKey.Curve, pubKey.X, pubKey.Y) //nolint:staticcheck // SA1019: migrating to crypto/ecdh is a separate effort
 	pubKeyString := base64.StdEncoding.EncodeToString(compressed)
 	fmt.Fprint(os.Stdout, "Expected proof record:\n")
 	fmt.Fprintf(os.Stdout, "v=MCPv1; k=%s; p=%s\n", k, pubKeyString)

--- a/cmd/publisher/auth/github-oidc.go
+++ b/cmd/publisher/auth/github-oidc.go
@@ -122,7 +122,7 @@ func (o *GitHubOIDCProvider) getOIDCTokenFromGitHub(ctx context.Context) (string
 	fullURL := requestURL + "&audience=mcp-registry"
 
 	// Create the request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil) //nolint:gosec // URL from trusted ACTIONS_ID_TOKEN_REQUEST_URL env var
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}
@@ -133,7 +133,7 @@ func (o *GitHubOIDCProvider) getOIDCTokenFromGitHub(ctx context.Context) (string
 
 	// Make the request
 	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // URL from trusted ACTIONS_ID_TOKEN_REQUEST_URL env var
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/modelcontextprotocol/registry
 
-go 1.25.8
+go 1.26.1
 
 require (
 	cloud.google.com/go/kms v1.26.0

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -764,7 +764,6 @@ func hashServerName(name string) int64 {
 		hash ^= uint64(name[i])
 		hash *= prime64
 	}
-	//nolint:gosec // Intentional conversion with masking to 63 bits
 	return int64(hash & 0x7FFFFFFFFFFFFFFF)
 }
 

--- a/internal/database/testutil.go
+++ b/internal/database/testutil.go
@@ -64,7 +64,7 @@ func NewTestDB(t *testing.T) Database {
 	defer cancel()
 
 	// Connect to postgres database
-	adminURI := "postgres://mcpregistry:mcpregistry@localhost:5432/postgres?sslmode=disable"
+	adminURI := "postgres://mcpregistry:mcpregistry@localhost:5432/postgres?sslmode=disable" //nolint:gosec // test-only credentials
 	adminConn, err := pgx.Connect(ctx, adminURI)
 	require.NoError(t, err, "Failed to connect to PostgreSQL. Make sure PostgreSQL is running via: docker-compose up -d postgres")
 	defer adminConn.Close(ctx)

--- a/internal/validators/schema.go
+++ b/internal/validators/schema.go
@@ -284,7 +284,7 @@ func ConvertJSONPointerToBracketNotation(jsonPointer string) string {
 		// Check if part is a pure number (array index)
 		if _, err := strconv.Atoi(part); err == nil {
 			// It's a numeric index - use bracket notation
-			result.WriteString(fmt.Sprintf("[%s]", part))
+			fmt.Fprintf(&result, "[%s]", part)
 			// Add dot after bracket if next part exists and is a field name (not a number)
 			if i < len(parts)-1 {
 				nextPart := parts[i+1]


### PR DESCRIPTION
## Summary
- `govulncheck` is failing in CI due to two `crypto/x509` vulnerabilities (GO-2026-4599, GO-2026-4600) that are only fixed in Go 1.26.1, not in the 1.25.x line
- The previous bump to Go 1.25.8 (in #1040) resolved 3 of the 5 vulnerabilities, but these two require Go 1.26.1
- Bumps root `go.mod` from 1.25.8 to 1.26.1
- Bumps `golangci-lint` from v2.4.0 to v2.11.1, since v2.4.0 was built with Go 1.25 and [cannot lint a Go 1.26 project](https://github.com/golangci/golangci-lint/issues/6272)
- Fixes lint issues surfaced by the updated linter:
  - Exclude `noctx` and `gosec G101` false positives from test files via `.golangci.yml`
  - Suppress `gosec G704` SSRF warnings on trusted env var URLs in `github-oidc.go`
  - Suppress `staticcheck SA1019` deprecated `crypto/ecdsa` API usage in `common.go` (migration to `crypto/ecdh` is a separate effort)
  - Remove stale `//nolint:gosec` directive in `postgres.go`
  - Use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` in `schema.go`

## Test plan
- [x] CI pipeline passes (govulncheck, build, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)