### PR TITLE
chore(deploy): bump production image tag to 1.5.0

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.4.1  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.5.0  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary
- Updates the production image tag in `deploy/Pulumi.gcpProd.yaml` from `1.4.1` to `1.5.0`

## Test plan
- [ ] Verify the Pulumi deployment picks up the new image tag
- [ ] Confirm the v1.5.0 container image exists in the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)