### PR TITLE
docs: remove stale preview lifecycle messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ The MCP registry provides MCP clients with a list of MCP servers, like an app st
 
 ## Development Status
 
-**2025-10-24 update**: The Registry API has entered an **API freeze (v0.1)** 🎉. For the next month or more, the API will remain stable with no breaking changes, allowing integrators to confidently implement support. This freeze applies to v0.1 while development continues on v0. We'll use this period to validate the API in real-world integrations and gather feedback to shape v1 for general availability. Thank you to everyone for your contributions and patience—your involvement has been key to getting us here!
-
-**2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
+The MCP Registry is generally available and ships stable, versioned releases (including current releases through `v1.5.0`). The API and documentation linked here reflect the current stable service rather than the earlier preview and API-freeze milestones. We'd still love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
 Current key maintainers:
 - **Adam Jones** (Anthropic) [@domdomegg](https://github.com/domdomegg)  

--- a/docs/modelcontextprotocol-io/quickstart.mdx
+++ b/docs/modelcontextprotocol-io/quickstart.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Quickstart: Publish a Server"
 ---
 
 <Note>
-  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+  The MCP Registry is generally available and published as stable, versioned releases. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
 </Note>
 
 This tutorial will show you how to publish an MCP server written in TypeScript to the MCP Registry using the official `mcp-publisher` CLI tool.

--- a/docs/modelcontextprotocol-io/versioning.mdx
+++ b/docs/modelcontextprotocol-io/versioning.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Versioning
 ---
 
 <Note>
-  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
+  The MCP Registry is generally available and published as stable, versioned releases. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
 </Note>
 
 MCP servers **MUST** define a version string in `server.json`. For example:


### PR DESCRIPTION
## Problem
The registry README and publishing docs still describe the MCP Registry as a preview service and reference the older v0.1 API-freeze milestone. That messaging is stale now that the project is publishing stable releases through v1.5.0.

## Why now
Recent repo activity already reflects the current stable release posture, so the older preview/API-freeze wording is now misleading for contributors and publishers reading the entry-point docs.

## Verification
- `git diff --check`
- `grep -n "preview\|API freeze\|API-freeze\|generally available" README.md docs/modelcontextprotocol-io/quickstart.mdx docs/modelcontextprotocol-io/versioning.mdx`

## Uncertainty
I limited this PR to the README plus the two publish/versioning docs called out in local verification. There may be other historical preview references elsewhere in the repo that should be cleaned up separately rather than broadening this change.
