### PR TITLE
feat: add GPU-Bridge MCP server (@gpu-bridge/mcp-server)

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -1,1 +1,75 @@
-
+[
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.domdomegg/airtable-mcp-server",
+    "description": "Read and write access to Airtable database schemas, tables, and records.",
+    "repository": {
+      "url": "https://github.com/domdomegg/airtable-mcp-server.git",
+      "source": "github"
+    },
+    "version": "1.7.2",
+    "icons": [
+      {
+        "src": "https://airtable.com/images/favicon/favicon-32x32.png",
+        "mimeType": "image/png",
+        "sizes": [
+          "32x32"
+        ]
+      }
+    ],
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "airtable-mcp-server",
+        "version": "1.7.2",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "description": "Airtable personal access token.",
+            "isRequired": true,
+            "isSecret": true,
+            "name": "AIRTABLE_API_KEY"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.gpu-bridge/mcp-server",
+    "description": "GPU-Bridge MCP Server \u2014 30 AI services via one MCP tool. LLM inference, image generation, video, speech, audio, embeddings, reranking, PDF parsing, NSFW detection & more. x402-native for autonomous agents paying with USDC on Base.",
+    "repository": {
+      "url": "https://github.com/gpu-bridge/mcp-server.git",
+      "source": "github"
+    },
+    "version": "2.1.0",
+    "icons": [
+      {
+        "src": "https://gpubridge.xyz/favicon.ico",
+        "mimeType": "image/x-icon"
+      }
+    ],
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "@gpu-bridge/mcp-server",
+        "version": "2.1.0",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "description": "GPU-Bridge API key (get one at https://gpubridge.xyz). Starts with gpub_. Optional if using x402 micropayments.",
+            "isRequired": false,
+            "isSecret": true,
+            "name": "GPUBRIDGE_API_KEY"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Add GPU-Bridge MCP Server

**Package:** `@gpu-bridge/mcp-server` v2.1.0
**npm:** https://www.npmjs.com/package/@gpu-bridge/mcp-server
**GitHub:** https://github.com/gpu-bridge/mcp-server
**Website:** https://gpubridge.io

### What is GPU-Bridge?

GPU-Bridge is a unified GPU inference API that provides 30 AI services through a single MCP tool: LLM inference, image generation, video processing, speech-to-text, TTS, embeddings, reranking, PDF parsing, NSFW detection, and more.

### Why it belongs in the MCP Registry

- **30 AI services, one tool** — developers configure once, access any AI capability
- **x402-native** — autonomous agents can pay for GPU compute with USDC on Base without a pre-funded API key
- **Production-ready** — live API at api.gpubridge.io with Stripe and x402 payment support
- **Works with Claude Desktop, Cursor, Zed** — standard MCP stdio transport via npx

### Installation

```json
{
  "mcpServers": {
    "gpu-bridge": {
      "command": "npx",
      "args": ["-y", "@gpu-bridge/mcp-server"],
      "env": { "GPUBRIDGE_API_KEY": "your-api-key" }
    }
  }
}
```

### Checklist
- [x] Package published on npm: `@gpu-bridge/mcp-server@2.1.0`
- [x] Open source MIT license
- [x] Working production API
- [x] Standard MCP stdio transport
- [x] smithery.yaml included in repo
