### PR TITLE
Add @servicialo/mcp-server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,35 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "com.servicialo/mcp-server",
+    "description": "Open protocol for AI-agent coordination of professional services. Scheduling, identity, delivery verification, and financial settlement.",
+    "repository": {
+      "url": "https://github.com/servicialo/mcp-server.git",
+      "source": "github"
+    },
+    "version": "0.7.0",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "@servicialo/mcp-server",
+        "version": "0.7.0",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        }
+      },
+      {
+        "registryType": "pypi",
+        "identifier": "servicialo",
+        "version": "0.7.0",
+        "runtimeHint": "python",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Add @servicialo/mcp-server

Servicialo is an open protocol for AI-agent coordination of professional services.

- **npm:** `@servicialo/mcp-server` (v0.7.0)
- **23 MCP tools** across 6 phases: discovery, understanding, commitment, lifecycle, delivery, settlement
- **HTTP profile** with OpenAPI 3.1 spec
- **Python SDK:** `pip install servicialo`
- **Website:** https://servicialo.com
- **Protocol spec:** https://github.com/servicialo/mcp-server/blob/main/PROTOCOL.md