### PR TITLE
Add @dltik/mcp-server — TikTok/Douyin downloader

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,40 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.walidb212/dltik-mcp-server",
+    "description": "Download TikTok and Douyin videos as MP4, MP3, or photos ZIP — anonymously, without watermark. Supports single downloads, audio extraction, and batch mode (Business plan).",
+    "repository": {
+      "url": "https://github.com/walidb212/dltik.git",
+      "source": "github"
+    },
+    "version": "1.0.1",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "@dltik/mcp-server",
+        "version": "1.0.1",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "name": "DLTIK_API_KEY",
+            "description": "Optional API key for Pro/Business tier (higher rate limits and batch downloads). Get yours at https://dltik.app/pro",
+            "isRequired": false,
+            "isSecret": true
+          },
+          {
+            "name": "DLTIK_LOCALE",
+            "description": "Language for tool descriptions and error messages. Supported: en, fr, es, pt-br, ar, de. Defaults to en.",
+            "isRequired": false,
+            "isSecret": false
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Server: `io.github.walidb212/dltik-mcp-server`

**npm package:** [`@dltik/mcp-server`](https://www.npmjs.com/package/@dltik/mcp-server) v1.0.1

### What it does

Anonymous TikTok & Douyin video downloader via [dltik.app](https://dltik.app) API.

**3 tools:**
- `tiktok_metadata` — title, author, duration, available formats
- `tiktok_download` — single download as MP4, MP3, photos ZIP, or MP4 without watermark
- `tiktok_batch` — batch download (Business API key required)

### Usage

```json
{
  "mcpServers": {
    "dltik": {
      "command": "npx",
      "args": ["-y", "@dltik/mcp-server"],
      "env": {
        "DLTIK_API_KEY": "optional_pro_or_business_key",
        "DLTIK_LOCALE": "en"
      }
    }
  }
}
```

### Checklist

- [x] `mcpName` field in `package.json` matches server name `io.github.walidb212/dltik-mcp-server`
- [x] Public npm package with `publishConfig.access: "public"`
- [x] stdio transport
- [x] No required env vars for basic usage (anonymous free tier: 10 downloads/day)
- [x] i18n support: `DLTIK_LOCALE` env var (en/fr/es/pt-br/ar/de)
- [x] MIT license