### PR TITLE
feat: add Stackbilt MCP gateway (remote hosted server)

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -161,7 +161,7 @@
     "name": "io.github.stackbilt-dev/stackbilt-mcp-gateway",
     "description": "AI-powered image generation and full-stack architecture scaffolding. Two products via one MCP connection: img-forge (5 quality tiers from SDXL Lightning to Gemini 3.1 Flash) and Stackbilder (6-mode architecture pipeline). Free tier: 25 credits, no credit card required. OAuth 2.1 with PKCE.",
     "repository": {
-      "url": "https://github.com/Stackbilt-dev/edgestack_v2.git",
+      "url": "https://github.com/Stackbilt-dev/stackbilt-mcp-gateway.git",
       "source": "github"
     },
     "version": "0.2.0",


### PR DESCRIPTION
## New Server: Stackbilt MCP Gateway

**URL:** `https://mcp.stackbilt.dev/mcp`
**Transport:** Streamable HTTP
**Auth:** OAuth 2.1 with PKCE (automatic via `/.well-known/oauth-protected-resource`)

### What it does

Two products through a single MCP connection:

- **img-forge** — AI image generation across 5 quality tiers (SDXL Lightning → Gemini 3.1 Flash). Tools: `image_generate`, `image_check_job`, `image_list_models`.
- **Stackbilder** — Full-stack architecture scaffolding via a 6-mode pipeline (Product → UX → Risk → Architect → TDD → Sprint). Tools: `flow_create`, `flow_status`, `flow_summary`, `flow_quality`, `flow_governance`, `flow_advance`, `flow_recover`.

### Free tier

25 credits on signup, no credit card required. Draft-tier image generation costs 1 credit.

### Notes

This is the first remote hosted MCP server submission to the registry. Uses `remotes` with `streamable-http` transport type per the schema spec.

Built on Cloudflare Workers. Open source gateway: https://github.com/Stackbilt-dev/stackbilt-mcp-gateway