### PR TITLE
Add Windsor.ai MCP

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,23 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "ai.windsor/windsor-mcp",
+    "title": "Windsor.ai MCP",
+    "description": "Query and analyze marketing, sales, and business data from 325+ platforms via Windsor.ai.",
+    "repository": {
+      "url": "https://github.com/windsor-ai/windsor_mcp.git",
+      "source": "github"
+    },
+    "version": "0.1.0",
+    "websiteUrl": "https://windsor.ai",
+    "remotes": [
+      {
+        "type": "sse",
+        "url": "https://mcp.windsor.ai/sse"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
  Add Windsor.ai MCP server to the seed data as a remote SSE server.

  ## Motivation and Context
  Windsor MCP enables LLMs to query and analyze marketing, sales, and business data from 325+ platforms integrated into Windsor.ai. It is a hosted remote
   MCP server (SSE transport at `https://mcp.windsor.ai/sse`), not a locally-installed package.

  - Repository: https://github.com/windsor-ai/windsor_mcp
  - Website: https://windsor.ai
  - License: MIT

  ## How Has This Been Tested?
  - Validated seed.json is valid JSON
  - Entry follows the existing `server.schema.json` schema
  - Windsor MCP SSE endpoint is a live production service

  ## Breaking Changes
  None. Additive change to seed data only.

  ## Types of changes
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Checklist
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [ ] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [ ] I have added or updated documentation as needed

  ## Additional context
  This is the first remote (non-package) server entry in the seed data. Windsor MCP is currently in beta. Version set to 0.1.0 as no explicit version is
  published upstream.