### PR TITLE
Add mcp-swarm: parallel Claude agent orchestration via Docker

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,26 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.stiege/mcp-swarm",
+    "description": "Orchestrate parallel Claude agent workloads via Docker containers. Run N agents simultaneously with functional combinators (map, par, chain, reduce, pipeline), lazy monadic refs, and a natural language type system.",
+    "repository": {
+      "url": "https://github.com/stiege/swarm-mcp.git",
+      "source": "github"
+    },
+    "version": "0.1.1",
+    "packages": [
+      {
+        "registryType": "pypi",
+        "identifier": "mcp-swarm",
+        "version": "0.1.1",
+        "runtimeHint": "python",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Server details

**Name**: `io.github.stiege/mcp-swarm`
**PyPI package**: [`mcp-swarm`](https://pypi.org/project/mcp-swarm/) (v0.1.1)
**GitHub**: https://github.com/stiege/swarm-mcp
**Docs**: https://stiege.github.io/swarm-mcp

## What it does

mcp-swarm is an MCP server that gives Claude Code the ability to orchestrate N parallel agents, each running in an isolated Docker container. It provides functional combinators for composing agent work:

- **`run`** — single agent in isolation
- **`par`** — N agents in parallel
- **`map`** / **`map_reduce`** — fan-out over inputs, optional synthesis
- **`chain`** / **`pipeline`** — sequential stages with `on_fail`, `next` jumps, `max_retries`
- **`filter`** / **`retry`** / **`guard`** — type-validated loops
- **`reduce`** — synthesise multiple results into one

Outputs are lazy refs (metadata only) until `unwrap()` materialises the text — so a pipeline fanning out to 50 agents doesn't flood the MCP protocol.

The natural language type system lets you define what agents should produce as markdown prose ("The analysis must identify at least 3 risk factors"), validated by a LLM judge returning `VALID`/`PARTIAL`/`INVALID` with per-criterion feedback.

## Ownership verification

The `<!-- mcp-name: io.github.stiege/mcp-swarm -->` comment is present at the top of the [README.md](https://github.com/stiege/swarm-mcp/blob/master/README.md).

## Install

```bash
uvx mcp-swarm
```