### PR TITLE
Update quickstart.mdx to remove note HTML block

### DIFF
--- a/docs/modelcontextprotocol-io/quickstart.mdx
+++ b/docs/modelcontextprotocol-io/quickstart.mdx
@@ -3,9 +3,7 @@ title: "Quickstart: Publish an MCP Server to the MCP Registry"
 sidebarTitle: "Quickstart: Publish a Server"
 ---
 
-<Note>
-  The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
-</Note>
+> The MCP Registry is currently in preview. Breaking changes or data resets may occur before general availability. If you encounter any issues, please report them on [GitHub](https://github.com/modelcontextprotocol/registry/issues).
 
 This tutorial will show you how to publish an MCP server written in TypeScript to the MCP Registry using the official `mcp-publisher` CLI tool.
 


### PR DESCRIPTION
The HTML note block doesn't render correctly in GitHub, with links inside that block broken. Changed to a block quote to fix the link.

## Motivation and Context

README change to fix link styling

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
