### PR TITLE
feat(publisher): store token files in unified .mcpregistry/ directory

### DIFF
--- a/cmd/publisher/auth/github-at.go
+++ b/cmd/publisher/auth/github-at.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 )
 
 const (
-	gitHubTokenFilePath   = ".mcpregistry_github_token"   // #nosec:G101
-	registryTokenFilePath = ".mcpregistry_registry_token" // #nosec:G101
+	tokenDir              = ".mcpregistry"
+	gitHubTokenFileName   = "github_token"   // #nosec:G101
+	registryTokenFileName = "registry_token" // #nosec:G101
 	// GitHub OAuth URLs
 	GitHubDeviceCodeURL  = "https://github.com/login/device/code"        // #nosec:G101
 	GitHubAccessTokenURL = "https://github.com/login/oauth/access_token" // #nosec:G101
@@ -117,7 +119,7 @@ func (g *GitHubATProvider) NeedsLogin() bool {
 	}
 
 	// Check if GitHub token exists
-	_, statErr := os.Stat(gitHubTokenFilePath)
+	_, statErr := os.Stat(gitHubTokenFilePath())
 	if os.IsNotExist(statErr) {
 		return true
 	}
@@ -305,14 +307,61 @@ func (g *GitHubATProvider) pollForToken(ctx context.Context, deviceCode string) 
 	return "", fmt.Errorf("device code authorization timed out")
 }
 
+// ensureTokenDir creates the .mcpregistry directory with a .gitignore if it does not exist.
+func ensureTokenDir() error {
+	if err := os.MkdirAll(tokenDir, 0700); err != nil {
+		return fmt.Errorf("failed to create token directory: %w", err)
+	}
+
+	gitignorePath := filepath.Join(tokenDir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		if err := os.WriteFile(gitignorePath, []byte("*\n"), 0600); err != nil {
+			return fmt.Errorf("failed to create .gitignore: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func gitHubTokenFilePath() string {
+	return filepath.Join(tokenDir, gitHubTokenFileName)
+}
+
+func registryTokenFilePath() string {
+	return filepath.Join(tokenDir, registryTokenFileName)
+}
+
+// migrateOldTokenFiles moves tokens from old flat paths to the new directory.
+func migrateOldTokenFiles() {
+	oldPaths := map[string]string{
+		".mcpregistry_github_token":   gitHubTokenFileName,
+		".mcpregistry_registry_token": registryTokenFileName,
+	}
+	for oldPath, newName := range oldPaths {
+		if _, err := os.Stat(oldPath); err == nil {
+			newPath := filepath.Join(tokenDir, newName)
+			if _, err := os.Stat(newPath); os.IsNotExist(err) {
+				_ = os.Rename(oldPath, newPath)
+			} else {
+				_ = os.Remove(oldPath)
+			}
+		}
+	}
+}
+
 // saveToken saves the GitHub access token to a local file
 func saveToken(token string) error {
-	return os.WriteFile(gitHubTokenFilePath, []byte(token), 0600)
+	if err := ensureTokenDir(); err != nil {
+		return err
+	}
+	migrateOldTokenFiles()
+	return os.WriteFile(gitHubTokenFilePath(), []byte(token), 0600)
 }
 
 // readToken reads the GitHub access token from a local file
 func readToken() (string, error) {
-	tokenData, err := os.ReadFile(gitHubTokenFilePath)
+	migrateOldTokenFiles()
+	tokenData, err := os.ReadFile(gitHubTokenFilePath())
 	if err != nil {
 		return "", err
 	}
@@ -420,12 +469,15 @@ func saveRegistryToken(token string, expiresAt int64) error {
 		return fmt.Errorf("failed to marshal token: %w", err)
 	}
 
-	return os.WriteFile(registryTokenFilePath, data, 0600)
+	if err := ensureTokenDir(); err != nil {
+		return err
+	}
+	return os.WriteFile(registryTokenFilePath(), data, 0600)
 }
 
 // readRegistryToken reads the registry JWT token from a local file
 func readRegistryToken() (string, error) {
-	data, err := os.ReadFile(registryTokenFilePath)
+	data, err := os.ReadFile(registryTokenFilePath())
 	if err != nil {
 		return "", err
 	}
@@ -439,7 +491,7 @@ func readRegistryToken() (string, error) {
 	// Check if token has expired
 	if time.Now().Unix() >= storedToken.ExpiresAt {
 		// Token has expired, remove the file
-		os.Remove(registryTokenFilePath)
+		os.Remove(registryTokenFilePath())
 		return "", fmt.Errorf("registry token has expired")
 	}
 

--- a/cmd/publisher/commands/logout.go
+++ b/cmd/publisher/commands/logout.go
@@ -25,17 +25,10 @@ func LogoutCommand() error {
 		return fmt.Errorf("failed to remove token: %w", err)
 	}
 
-	// Also clean up legacy token files if they exist
-	legacyFiles := []string{
-		".mcpregistry_github_token",
-		".mcpregistry_registry_token",
-	}
-
-	for _, file := range legacyFiles {
-		path := filepath.Join(homeDir, file)
-		if _, err := os.Stat(path); err == nil {
-			os.Remove(path) // Ignore errors for legacy files
-		}
+	// Clean up .mcpregistry directory (new location) and legacy flat files
+	_ = os.RemoveAll(".mcpregistry")
+	for _, file := range []string{".mcpregistry_github_token", ".mcpregistry_registry_token"} {
+		_ = os.Remove(file)
 	}
 
 	_, _ = fmt.Fprintln(os.Stdout, "✓ Successfully logged out")


### PR DESCRIPTION
## Summary

Move GitHub and registry token files from flat `.mcpregistry_*` paths in the project root into a `.mcpregistry/` directory with an auto-generated `.gitignore`, so users no longer need to manually update their `.gitignore`.

Closes #663

## Changes

- `cmd/publisher/auth/github-at.go`:
  - Token files now stored under `.mcpregistry/` directory (`github_token`, `registry_token`)
  - Added `ensureTokenDir()` — creates `.mcpregistry/` with a `.gitignore` containing `*`
  - Added `migrateOldTokenFiles()` — automatically moves old flat files to the new directory on first read/write
  - Updated all file path references to use the new directory structure
- `cmd/publisher/commands/logout.go`:
  - Logout now cleans up both `.mcpregistry/` directory and legacy flat files

## Backward compatibility

Existing users with old `.mcpregistry_github_token` / `.mcpregistry_registry_token` files will have them automatically migrated to `.mcpregistry/github_token` / `.mcpregistry/registry_token` on next token read or write. No manual action required.

## Test plan

- [x] `go build ./cmd/publisher/...` compiles without errors
- [x] `go test ./cmd/publisher/commands/...` passes all existing tests
- [ ] Manual: `mcp-publisher login github` creates `.mcpregistry/github_token` and `.mcpregistry/.gitignore`
- [ ] Manual: old flat token files are migrated on next operation
- [ ] Manual: `mcp-publisher logout` removes `.mcpregistry/` directory and any legacy files

## AI Disclosure

AI assistance (Claude) was used for issue research. The implementation was written and reviewed by the author.