### PR TITLE
fix(publisher): omit repository when URL cannot be detected

### DIFF
--- a/cmd/publisher/commands/init.go
+++ b/cmd/publisher/commands/init.go
@@ -246,7 +246,7 @@ func detectRepoURL() string {
 		}
 	}
 
-	return "https://github.com/YOUR_USERNAME/YOUR_REPO"
+	return ""
 }
 
 func detectPackageType() string {


### PR DESCRIPTION
## Summary

When `detectRepoURL()` cannot determine the repository (no git remote, no package.json repository field), return an empty string instead of a placeholder URL (`https://github.com/YOUR_USERNAME/YOUR_REPO`). This causes `createServerJSON()` to omit the `repository` field entirely, preventing schema validation failures on publish.

Fixes #613

## Problem

`mcp-publisher init` generated a `repository` object with a placeholder URL that fails the `uri` format validation on publish. 88 published servers in the official registry had this issue.

## Change

- `cmd/publisher/commands/init.go`: `detectRepoURL()` returns `""` instead of placeholder when no repo is found
- The existing guard in `createServerJSON()` (`if repoURL != "" && repoSource != ""`) already handles this correctly — it omits the repository when URL is empty

## Test plan

- [x] `go build ./cmd/publisher/...` compiles
- [x] `go test ./cmd/publisher/commands/...` passes
- [ ] Manual: `mcp-publisher init` in a directory without git remote or package.json repo — verify no `repository` field in generated server.json
- [ ] Manual: `mcp-publisher init` in a git repo — verify `repository` is populated correctly

## AI Disclosure

AI assistance (Claude) was used for issue research. The implementation was written and reviewed by the author.