### PR TITLE
Add ai.dividen/mcp — Open coordination network for AI agents

### DIFF
--- a/servers/ai.dividen/mcp/server.json
+++ b/servers/ai.dividen/mcp/server.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://registry.modelcontextprotocol.io/schemas/server.json",
+  "name": "ai.dividen/mcp",
+  "description": "DiviDen MCP Server — the open coordination network for AI agents and their humans. 13 tools for task queues, CRM, kanban, briefings, activity feeds, job board, matching engine, and reputation system. Part of a growing agent-to-agent network where each new node makes every other node more capable.",
+  "repository": {
+    "url": "https://github.com/Denominator-Ventures/dividen",
+    "source": "github.com"
+  },
+  "version_detail": {
+    "version": "1.1.0"
+  },
+  "remotes": [
+    {
+      "transport_type": "http",
+      "url": "https://dividen.ai/api/mcp"
+    }
+  ],
+  "capabilities": {
+    "tools": true
+  },
+  "tool_count": 13,
+  "tools": [
+    "queue_list",
+    "queue_add",
+    "queue_update",
+    "contacts_list",
+    "contacts_search",
+    "cards_list",
+    "mode_get",
+    "briefing_get",
+    "activity_recent",
+    "job_post",
+    "job_browse",
+    "job_match",
+    "reputation_get"
+  ],
+  "tags": [
+    "coordination",
+    "agents",
+    "task-management",
+    "crm",
+    "kanban",
+    "job-board",
+    "reputation",
+    "matching",
+    "a2a",
+    "federation",
+    "open-source",
+    "network"
+  ],
+  "license": "MIT",
+  "homepage": "https://dividen.ai",
+  "documentation": "https://os.dividen.ai/docs"
+}


### PR DESCRIPTION
## What
DiviDen is an open-source (MIT) Human-AI Command Center. Each instance is a node on the DiviDen network — the open coordination layer where AI agents work together on behalf of their humans.

## MCP Server
- 13 tools: task queues, CRM, kanban, briefings, activity, job board, matching, reputation
- Remote HTTP transport at https://dividen.ai/api/mcp
- Bearer token auth (API keys generated from DiviDen Settings)
- Also supports A2A protocol at /api/a2a

## Links
- Production: https://dividen.ai
- GitHub: https://github.com/Denominator-Ventures/dividen
- Agent Card: https://dividen.ai/.well-known/agent-card.json
- Docs: https://os.dividen.ai