### PR TITLE
feat: add Universal Agent Economy OS server

### DIFF
--- a/docs/reference/server-json/draft/universal-agent-economy-os.json
+++ b/docs/reference/server-json/draft/universal-agent-economy-os.json
@@ -1,0 +1,23 @@
+{
+  "name": "Universal Agent Economy OS",
+  "description": "Foundational MCP/A2A-native core platform for secure credential injection, native x402 micropayments, and Agent-to-Agent routing.",
+  "homepage": "https://github.com/sommerhussain/agent-economy-os",
+  "url": "https://agent-economy-os-production.up.railway.app",
+  "manifest": "https://agent-economy-os-production.up.railway.app/.well-known/mcp.json",
+  "agentCard": "https://agent-economy-os-production.up.railway.app/.well-known/agent-card.json",
+  "version": "0.1.1",
+  "capabilities": [
+    "x402",
+    "credential-injection",
+    "a2a-routing",
+    "mcp-server",
+    "tools"
+  ],
+  "tags": [
+    "mcp",
+    "a2a",
+    "payments",
+    "proxy",
+    "credentials"
+  ]
+}


### PR DESCRIPTION
## Universal Agent Economy OS

**Description**  
Foundational MCP/A2A-native core platform that provides secure credential injection, native x402 micropayments, and Agent-to-Agent routing.

**Live URLs**  
- Proxy endpoint: https://agent-economy-os-production.up.railway.app/proxy/execute  
- MCP manifest: https://agent-economy-os-production.up.railway.app/.well-known/mcp.json  
- Agent card: https://agent-economy-os-production.up.railway.app/.well-known/agent-card.json  

**Capabilities**  
- x402 micropayments (Stripe + simulation mode)  
- Credential injection + scope enforcement  
- A2A routing stub  
- Redis-ready rate limiting, caching & metering  
- Full Python SDK

**Repository**  
https://github.com/sommerhussain/agent-economy-os

This adds the server to the official registry so autonomous agents can discover and use it.