### PR TITLE
feat: add OpenSOSData MCP server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,34 @@
         }
       }
     ]
-  }
+  },
+  {
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.opensosdata/mcp-server",
+  "description": "Real-time US business entity search across all 53 US jurisdictions -- all 50 states, Washington DC, Puerto Rico, and US Virgin Islands. Search, verify, and check the status of any LLC, corporation, or registered entity. Ideal for KYB compliance, due diligence, and vendor verification.",
+  "repository": {
+    "url": "https://github.com/OpenSOSData/opensosdata-mcp.git",
+    "source": "github"
+  },
+  "version": "1.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@opensosdata/mcp-server",
+      "version": "1.0.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "Your OpenSOSData API key. Get one free at opensosdata.com -- includes 10 free lookups. $0.0314 per lookup after that.",
+          "isRequired": true,
+          "isSecret": true,
+          "name": "OPENSOSDATA_API_KEY"
+        }
+      ]
+    }
+  ]
+}
 ]


### PR DESCRIPTION
Adding OpenSOSData MCP server to the registry.

## Motivation and Context
OpenSOSData provides real-time US business entity search across all 
53 US jurisdictions - all 50 states, Washington DC, Puerto Rico, and 
US Virgin Islands. Data is fetched live from official Secretary of State 
portals at query time, not from a stale database. This fills a gap in 
the registry - no business entity search MCP server currently exists.

Use cases: KYB compliance, due diligence, vendor verification, legal 
research, and any workflow requiring confirmation of business registration 
status.

## How Has This Been Tested?
Tested end-to-end in Claude.ai (web), Claude Desktop, and Claude Code. 
The remote MCP server at https://mcp.opensosdata.com/mcp is live in 
production and has processed real user lookups. The npm package 
@opensosdata/mcp-server v1.0.1 is published and working. Two external 
users have signed up and used the service since launch.

## Breaking Changes
None. This is a new server addition.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- Remote MCP endpoint: https://mcp.opensosdata.com/mcp
- Documentation: https://opensosdata.com/mcp
- GitHub: https://github.com/OpenSOSData/opensosdata-mcp
- npm: @opensosdata/mcp-server
- Transport: Streamable HTTP
- Auth: Bearer token (API key from opensosdata.com)
- 6 tools, all readOnlyHint: true