### PR TITLE
deploy: update prod to v1.6.0

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.5.0  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.6.0  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary
- Bumps production image tag from `1.5.0` to `1.6.0` in `deploy/Pulumi.gcpProd.yaml`
- Corresponds to the [v1.6.0 release](https://github.com/modelcontextprotocol/registry/releases/tag/v1.6.0)

## Test plan
- [ ] Verify Pulumi preview shows only the image tag change
- [ ] Deploy and confirm the service is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)