### PR TITLE
Add ControlKeel to MCP Registry community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -27,6 +27,7 @@ Browse the official MCP Registry in your browser!
 - [MCP Server for MCP Registry](https://github.com/formulahendry/mcp-server-mcp-registry) - MCP Server to discover and search for available MCP servers in the registry
 - [mcp-insights](https://github.com/joelverhagen/mcp-insights/) - Analytics and insights for the MCP Registry
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
+- [ControlKeel](https://github.com/aryaminus/controlkeel) - Governance control plane for MCP workflows with policy validation, findings tracking, and proof-oriented review gates
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
 


### PR DESCRIPTION
## Summary
- add ControlKeel to `docs/community-projects.md` as a governance-focused MCP ecosystem project

## Why
ControlKeel provides policy validation, findings tracking, and review/proof workflows around MCP usage, which can help registry users discover governance tooling.