### PR TITLE
docs: note PostgreSQL requirement for prebuilt Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The setup can be configured with environment variables in [docker-compose.yml](.
 <details>
 <summary>Alternative: Running a pre-built Docker image</summary>
 
-Pre-built Docker images are automatically published to GitHub Container Registry:
+Pre-built Docker images are automatically published to GitHub Container Registry. Note that the image does not bundle PostgreSQL, so you need to run your own and point the registry at it via `MCP_REGISTRY_DATABASE_URL` (see [docker-compose.yml](./docker-compose.yml) for a working example):
 
 ```bash
 # Run latest stable release


### PR DESCRIPTION
## Summary
- Clarifies in the README that the prebuilt Docker image does not bundle PostgreSQL and needs an external instance reachable via \`MCP_REGISTRY_DATABASE_URL\`
- Points readers to \`docker-compose.yml\` as a working multi-container example

Closes #723

## Test plan
- [ ] Render the README on GitHub and verify the note appears in the "Alternative: Running a pre-built Docker image" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)