### PR TITLE
feat: add enigmagent-mcp — AES-256-GCM encrypted vault for AI agent credentials

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,26 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.agnuxo1/enigmagent-mcp",
+    "description": "AES-256-GCM + Argon2id encrypted local vault for AI agent credentials. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts, logs, or LLM context.",
+    "repository": {
+      "url": "https://github.com/Agnuxo1/EnigmAgent.git",
+      "source": "github"
+    },
+    "version": "1.0.1",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "enigmagent-mcp",
+        "version": "1.0.1",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Description

Adds `enigmagent-mcp` to the MCP Registry — a local AES-256-GCM + Argon2id encrypted vault that resolves `{{PLACEHOLDER}}` secrets at runtime for AI agents.

## Server Details

- **npm package**: [`enigmagent-mcp`](https://www.npmjs.com/package/enigmagent-mcp)
- **GitHub**: https://github.com/Agnuxo1/EnigmAgent
- **Install**: `npx enigmagent-mcp --mode mcp`
- **Transport**: stdio
- **Version**: 1.0.1

## What it does

Stores API keys, tokens, and passwords encrypted locally (AES-256-GCM, Argon2id KDF). AI agents reference secrets as `{{OPENAI_KEY}}` — the vault resolves them at runtime so the real values never appear in prompts, logs, or LLM context windows.

## Checklist
- [x] Server is published to npm as `enigmagent-mcp`
- [x] Repository is public on GitHub
- [x] entry follows server.json schema `2025-12-11`
- [x] Transport is `stdio`