### PR TITLE
deploy: update prod to v1.7.0

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.6.0  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.0  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary
- Bumps production image tag from `1.6.0` to `1.7.0` in `deploy/Pulumi.gcpProd.yaml`
- Corresponds to the [v1.7.0 release](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.0)
- Notable change: includes #1201 — fixes #1081 (`isLatest` no longer stranded after soft-delete) and ships migration `014_heal_is_latest` that auto-heals affected servers (e.g. `io.github.containers/kubernetes-mcp-server`) on deploy

## Test plan
- [ ] Verify Pulumi preview shows only the image tag change
- [ ] After deploy, confirm migration 014 ran and `io.github.containers/kubernetes-mcp-server`'s `/versions/latest` returns `0.0.61` (or whichever is highest non-deleted)
- [ ] Sample a few unaffected servers and confirm `isLatest` is unchanged
- [ ] Confirm overall service health

🤖 Generated with [Claude Code](https://claude.com/claude-code)