### PR TITLE
deploy: update prod to v1.7.1

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.0  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.1  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary

Promotes [v1.7.1](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.1) to production. Contents: the hardening + diagnostics from #1211.

What's in v1.7.1 (vs v1.7.0):
- Pulumi-managed IAM bindings for the default compute SA so fluentbit-gke and the GMP collector can ship logs/metrics (already applied to live cluster manually)
- `PodDisruptionBudget` with `minAvailable: 1` + `TopologySpreadConstraints` to keep pods spread across nodes
- `StartupProbe` (30 × 5s) covering the new DB-retry budget
- Bounded retry-with-backoff on initial DB connect in `cmd/registry/main.go`
- Memory request 128→256Mi, limit 256→512Mi
- `slog` `validate_ms` timing on the publish path so the next slow `/v0/publish` is self-diagnostic

## Test plan
- [x] v1.7.1 release workflow built and pushed image successfully (`ghcr.io/modelcontextprotocol/registry:1.7.1`)
- [x] Pulumi.gcpProd.yaml diff is the single-line image bump
- [ ] On merge, `deploy-production.yml` rolls out v1.7.1 — watch for clean rolling update (`maxSurge: 1`, `maxUnavailable: 0`) and confirm both pods reach Ready
- [ ] After rollout, confirm `Starting MCP Registry Application v1.7.1` shows up in Cloud Logging from the new pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)