### PR TITLE
deploy: update prod to v1.7.2

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.1  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.2  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary

Promotes [v1.7.2](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.2) (PR #1215) to production:

- **Row-constructor cursor pagination** — fixes the 760ms list query that was the root cause of today's pool-exhaustion alerts. Local benchmark shows /v0/servers paginated requests dropping from ~30ms (cold cache, 100K rows) to ~0.05ms.
- **Per-phase publish slog** — `publish complete` events now include validate / lock / remotes / version_checks / unmark / db_create timings so the next slow publish is self-diagnostic.
- **pg_stat_statements** — aggregate query visibility we didn't have during today's incident.

## Deployment caveat

The CNPG cluster spec change for `pg_stat_statements` triggers an in-pod postgres restart on the next prod Pulumi run. Staging took **~45–70s of registry unavailability** during the equivalent restart. The DB retry-with-backoff in v1.7.1 covers most of it, but registry pods may bounce once before they reconnect (one staging pod hit `Failed to connect after 8 attempts` then recovered on its next restart).

**Time the merge for a low-traffic UTC window** — the alert history suggests very early UTC is quietest.

## Post-merge action

Once the prod Pulumi run completes, run once on the existing cluster:

```bash
PATH=/opt/homebrew/share/google-cloud-sdk/bin:$PATH
kubectl exec -i registry-pg-1 -c postgres \
  --context gke_mcp-registry-prod_us-central1-b_mcp-registry-prod \
  -- psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
```

Verify:

```bash
kubectl exec -i registry-pg-1 -c postgres \
  --context gke_mcp-registry-prod_us-central1-b_mcp-registry-prod \
  -- psql -U postgres -d app -c "
    SELECT round(mean_exec_time::numeric, 2) AS mean_ms, calls,
           substring(query, 1, 80) AS q
    FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;"
```

## Test plan

- [x] v1.7.2 release built and pushed (`ghcr.io/modelcontextprotocol/registry:1.7.2`)
- [x] Staging deployed cleanly; `pg_stat_statements` is collecting on staging
- [ ] Prod Pulumi run applies cleanly; brief PG restart
- [ ] Run `CREATE EXTENSION` on prod
- [ ] Confirm `publish complete` events contain per-phase timings on the next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)