### PR TITLE
deploy: update prod to v1.7.4

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.3  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.4  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary

Promotes [v1.7.4](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.4) (#1225) to production: registry pod memory request `256Mi → 512Mi`, limit `512Mi → 1Gi`.

## Why

#1221 doubled pgxpool `MaxConns` 30→60 per pod without bumping the registry pod memory limit. pgxpool keeps per-connection state in the Go process (prepared statement cache, scratch buffers, row iteration state) so peak per-pod memory shifted from ~330 MB to ~450 MB against the 512 MiB limit. Pod `tx49f` was OOMKilled at 17:01 UTC on 2026-04-29.

## Validation so far

- Staging deployed cleanly via `deploy-staging.yml` after #1225 merged
- Both staging pods running with `req=512Mi limit=1Gi` ✓
- Rolling update was clean — no failed health checks during the transition
- Both pods spread across nodes (q716 + 7exo)

## Deployment

**Zero downtime** — Deployment template change only, rolling update with `maxSurge: 1, maxUnavailable: 0`. No PG involvement (no `max_connections` change, no shared_preload_libraries change).

## Test plan

- [x] v1.7.4 release built and pushed (`ghcr.io/modelcontextprotocol/registry:1.7.4`)
- [x] Staging deployed cleanly with new limits
- [ ] Prod Pulumi run applies cleanly; rolling update completes
- [ ] Prod pods come up with `req=512Mi limit=1Gi`
- [ ] After 24h: no OOMKills on either pod, peak memory stays under ~600 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)