### PR TITLE
deploy: update prod to v1.7.5

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.4  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.5  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary

- Bumps prod imageTag from `1.7.4` to `1.7.5`.
- Promotes the security release tagged at v1.7.5 (#1227 merged at 1201cbd).

## Test plan

- [ ] Smoke staging at https://staging.registry.modelcontextprotocol.io — already done, all checks green
- [ ] Roll out via Pulumi
- [ ] Confirm prod health post-rollout: `curl https://registry.modelcontextprotocol.io/v0/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)