### PR TITLE
refactor: remove redundant blank identifier for argIndex in ListServers

### DIFF
--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -198,7 +198,6 @@ func (db *PostgreSQL) ListServers(
 		whereConditions = append(whereConditions, cursorCondition)
 		args = append(args, cursorArgs...)
 	}
-	_ = argIndex // Silence unused variable warning
 
 	// Build the WHERE clause
 	whereClause := ""


### PR DESCRIPTION
The blank assignment `_ = argIndex` on line 201 of `internal/database/postgres.go` was not needed.

`argIndex` is already read by `fmt.Sprintf` two lines below when building the `LIMIT` clause of the query.