### PR TITLE
refactor: extract readBody helper to remove duplicate io.ReadAll calls

### DIFF
--- a/internal/api/handlers/v0/auth/common.go
+++ b/internal/api/handlers/v0/auth/common.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"regexp"
@@ -19,6 +20,11 @@ import (
 	"github.com/modelcontextprotocol/registry/internal/auth"
 	"github.com/modelcontextprotocol/registry/internal/config"
 )
+
+func readBody(r io.Reader) string {
+	b, _ := io.ReadAll(r)
+	return string(b)
+}
 
 // ErrSignatureMismatch is returned by VerifySignature when the signature is structurally
 // valid but does not verify against the public key. Distinguishing this from structural

--- a/internal/api/handlers/v0/auth/github_at.go
+++ b/internal/api/handlers/v0/auth/github_at.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -123,8 +122,7 @@ func (h *GitHubHandler) getGitHubUser(ctx context.Context, token string) (*GitHu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, readBody(resp.Body))
 	}
 
 	var user GitHubUserOrOrg
@@ -152,8 +150,7 @@ func (h *GitHubHandler) getGitHubUserOrgs(ctx context.Context, username string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("GitHub API error (status %d): %s", resp.StatusCode, readBody(resp.Body))
 	}
 
 	var orgs []GitHubUserOrOrg

--- a/internal/api/handlers/v0/auth/github_oidc.go
+++ b/internal/api/handlers/v0/auth/github_oidc.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math/big"
 	"net/http"
 	"strings"
@@ -149,8 +148,7 @@ func (v *GitHubOIDCValidator) fetchJWKS(ctx context.Context) (*JWKS, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("JWKS endpoint returned status %d: %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("JWKS endpoint returned status %d: %s", resp.StatusCode, readBody(resp.Body))
 	}
 
 	var jwks JWKS

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -198,7 +198,6 @@ func (db *PostgreSQL) ListServers(
 		whereConditions = append(whereConditions, cursorCondition)
 		args = append(args, cursorArgs...)
 	}
-	_ = argIndex // Silence unused variable warning
 
 	// Build the WHERE clause
 	whereClause := ""


### PR DESCRIPTION
The same pattern for reading an error response body appeared in three places across the auth handlers:

- `internal/api/handlers/v0/auth/github_at.go` (twice)
- `internal/api/handlers/v0/auth/github_oidc.go` (once)

A shared `readBody` helper function added to `common.go` now handles this in one place. 
The `io` import is removed from both files since it is no longer used directly there.