### PR TITLE
auth/oidc: test slice-typed extra claims comparison

### DIFF
--- a/internal/api/handlers/v0/auth/oidc_internal_test.go
+++ b/internal/api/handlers/v0/auth/oidc_internal_test.go
@@ -1,0 +1,41 @@
+package auth
+
+import "testing"
+
+func TestClaimMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   any
+		expected any
+		want     bool
+	}{
+		{"scalar/scalar match", "x", "x", true},
+		{"scalar/scalar mismatch", "x", "y", false},
+
+		{"scalar actual in array expected", "x", []any{"x", "y"}, true},
+		{"scalar actual not in array expected", "z", []any{"x", "y"}, false},
+
+		{"array actual contains scalar expected", []any{"x", "y"}, "x", true},
+		{"array actual missing scalar expected", []any{"y", "z"}, "x", false},
+
+		// Pre-#1238 array/array comparison panicked with "comparing uncomparable type []interface {}".
+		{"array/array overlap", []any{"a", "b"}, []any{"b", "c"}, true},
+		{"array/array disjoint", []any{"a", "b"}, []any{"c", "d"}, false},
+
+		// Exercises the []string branch of toAnySlice (concrete typed slice, not []any).
+		{"[]string actual matches scalar", []string{"p", "q"}, "p", true},
+		{"scalar matches []string expected", "p", []string{"p", "q"}, true},
+
+		{"non-string scalar match", 42, 42, true},
+		{"bool scalar match", true, true, true},
+		{"empty actual array", []any{}, "x", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claimMatches(tt.actual, tt.expected); got != tt.want {
+				t.Errorf("claimMatches(%v, %v) = %v, want %v", tt.actual, tt.expected, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/v0/auth/oidc_test.go
+++ b/internal/api/handlers/v0/auth/oidc_test.go
@@ -11,12 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testJWTPrivateKey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" // 32-byte hex test key
-	testOIDCIssuer    = "https://accounts.google.com"
-	testOIDCClientID  = "test-client-id"
-)
-
 // MockGenericOIDCValidator for testing
 type MockGenericOIDCValidator struct {
 	validateFunc func(ctx context.Context, token string) (*auth.OIDCClaims, error)
@@ -29,25 +23,6 @@ func (m *MockGenericOIDCValidator) ValidateToken(ctx context.Context, token stri
 	return nil, fmt.Errorf("not implemented")
 }
 
-func testOIDCConfig(extraClaims string) *config.Config {
-	return &config.Config{
-		OIDCEnabled:      true,
-		OIDCIssuer:       testOIDCIssuer,
-		OIDCClientID:     testOIDCClientID,
-		OIDCExtraClaims:  extraClaims,
-		OIDCPublishPerms: "*",
-		JWTPrivateKey:    testJWTPrivateKey,
-	}
-}
-
-func mockValidator(claims map[string]any) *MockGenericOIDCValidator {
-	return &MockGenericOIDCValidator{
-		validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
-			return &auth.OIDCClaims{ExtraClaims: claims}, nil
-		},
-	}
-}
-
 func TestOIDCHandler_ExchangeToken(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -57,90 +32,53 @@ func TestOIDCHandler_ExchangeToken(t *testing.T) {
 		expectedError bool
 	}{
 		{ //nolint:gosec // G101: test data, not real credentials
-			name:   "successful token exchange with publish permissions",
-			config: testOIDCConfig(`[{"hd":"modelcontextprotocol.io"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"email":              "admin@modelcontextprotocol.io",
-				"email_verified":     true,
-				"hd":                 "modelcontextprotocol.io",
-				"preferred_username": "admin",
-			}),
+			name: "successful token exchange with publish permissions",
+			config: &config.Config{
+				OIDCEnabled:      true,
+				OIDCIssuer:       "https://accounts.google.com",
+				OIDCClientID:     "test-client-id",
+				OIDCExtraClaims:  `[{"hd":"modelcontextprotocol.io"}]`,
+				OIDCPublishPerms: "*",
+				JWTPrivateKey:    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", // 32 byte hex
+			},
+			mockValidator: &MockGenericOIDCValidator{
+				validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
+					return &auth.OIDCClaims{
+						ExtraClaims: map[string]any{
+							"email":              "admin@modelcontextprotocol.io",
+							"email_verified":     true,
+							"hd":                 "modelcontextprotocol.io",
+							"preferred_username": "admin",
+						},
+					}, nil
+				},
+			},
 			token:         "valid-oidc-token",
 			expectedError: false,
 		},
 		{
-			name:   "failed validation with invalid hosted domain",
-			config: testOIDCConfig(`[{"hd":"modelcontextprotocol.io"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"email":              "user@example.com",
-				"email_verified":     true,
-				"hd":                 "example.com",
-				"preferred_username": "user",
-			}),
+			name: "failed validation with invalid hosted domain",
+			config: &config.Config{
+				OIDCEnabled:      true,
+				OIDCIssuer:       "https://accounts.google.com",
+				OIDCClientID:     "test-client-id",
+				OIDCExtraClaims:  `[{"hd":"modelcontextprotocol.io"}]`,
+				OIDCPublishPerms: "*",
+				JWTPrivateKey:    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			},
+			mockValidator: &MockGenericOIDCValidator{
+				validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
+					return &auth.OIDCClaims{
+						ExtraClaims: map[string]any{
+							"email":              "user@example.com",
+							"email_verified":     true,
+							"hd":                 "example.com", // Wrong domain
+							"preferred_username": "user",
+						},
+					}, nil
+				},
+			},
 			token:         "invalid-domain-token",
-			expectedError: true,
-		},
-		{
-			name:   "scalar expected matches array claim",
-			config: testOIDCConfig(`[{"groups":"admin"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"groups": []any{"admin", "users", "developers"},
-			}),
-			token:         "scalar-expected-array-actual-match",
-			expectedError: false,
-		},
-		{
-			name:   "scalar expected not present in array claim",
-			config: testOIDCConfig(`[{"groups":"super-admin"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"groups": []any{"admin", "users", "developers"},
-			}),
-			token:         "scalar-expected-array-actual-no-match",
-			expectedError: true,
-		},
-		{
-			name:   "array expected overlaps array claim",
-			config: testOIDCConfig(`[{"roles":["admin","moderator"]}]`),
-			mockValidator: mockValidator(map[string]any{
-				"roles": []any{"admin", "users"},
-			}),
-			token:         "array-array-overlap",
-			expectedError: false,
-		},
-		{ //nolint:gosec // G101: test data, not real credentials
-			name:   "array expected disjoint from array claim",
-			config: testOIDCConfig(`[{"roles":["super-admin","owner"]}]`),
-			mockValidator: mockValidator(map[string]any{
-				"roles": []any{"admin", "users"},
-			}),
-			token:         "array-array-no-overlap",
-			expectedError: true,
-		},
-		{ //nolint:gosec // G101: test data, not real credentials
-			name:   "array expected matches scalar claim",
-			config: testOIDCConfig(`[{"role":["admin","moderator"]}]`),
-			mockValidator: mockValidator(map[string]any{
-				"role": "admin",
-			}),
-			token:         "scalar-actual-array-expected-match",
-			expectedError: false,
-		},
-		{ //nolint:gosec // G101: test data, not real credentials
-			name:   "[]string typed claim matches scalar expected",
-			config: testOIDCConfig(`[{"groups":"admin"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"groups": []string{"admin", "users"},
-			}),
-			token:         "string-slice-claim",
-			expectedError: false,
-		},
-		{
-			name:   "required claim missing",
-			config: testOIDCConfig(`[{"required_claim":"expected_value"}]`),
-			mockValidator: mockValidator(map[string]any{
-				"other_claim": "some_value",
-			}),
-			token:         "missing-claim",
 			expectedError: true,
 		},
 	}

--- a/internal/api/handlers/v0/auth/oidc_test.go
+++ b/internal/api/handlers/v0/auth/oidc_test.go
@@ -11,6 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testJWTPrivateKey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" // 32-byte hex test key
+	testOIDCIssuer    = "https://accounts.google.com"
+	testOIDCClientID  = "test-client-id"
+)
+
 // MockGenericOIDCValidator for testing
 type MockGenericOIDCValidator struct {
 	validateFunc func(ctx context.Context, token string) (*auth.OIDCClaims, error)
@@ -23,6 +29,25 @@ func (m *MockGenericOIDCValidator) ValidateToken(ctx context.Context, token stri
 	return nil, fmt.Errorf("not implemented")
 }
 
+func testOIDCConfig(extraClaims string) *config.Config {
+	return &config.Config{
+		OIDCEnabled:      true,
+		OIDCIssuer:       testOIDCIssuer,
+		OIDCClientID:     testOIDCClientID,
+		OIDCExtraClaims:  extraClaims,
+		OIDCPublishPerms: "*",
+		JWTPrivateKey:    testJWTPrivateKey,
+	}
+}
+
+func mockValidator(claims map[string]any) *MockGenericOIDCValidator {
+	return &MockGenericOIDCValidator{
+		validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
+			return &auth.OIDCClaims{ExtraClaims: claims}, nil
+		},
+	}
+}
+
 func TestOIDCHandler_ExchangeToken(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -32,53 +57,90 @@ func TestOIDCHandler_ExchangeToken(t *testing.T) {
 		expectedError bool
 	}{
 		{ //nolint:gosec // G101: test data, not real credentials
-			name: "successful token exchange with publish permissions",
-			config: &config.Config{
-				OIDCEnabled:      true,
-				OIDCIssuer:       "https://accounts.google.com",
-				OIDCClientID:     "test-client-id",
-				OIDCExtraClaims:  `[{"hd":"modelcontextprotocol.io"}]`,
-				OIDCPublishPerms: "*",
-				JWTPrivateKey:    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", // 32 byte hex
-			},
-			mockValidator: &MockGenericOIDCValidator{
-				validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
-					return &auth.OIDCClaims{
-						ExtraClaims: map[string]any{
-							"email":              "admin@modelcontextprotocol.io",
-							"email_verified":     true,
-							"hd":                 "modelcontextprotocol.io",
-							"preferred_username": "admin",
-						},
-					}, nil
-				},
-			},
+			name:   "successful token exchange with publish permissions",
+			config: testOIDCConfig(`[{"hd":"modelcontextprotocol.io"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"email":              "admin@modelcontextprotocol.io",
+				"email_verified":     true,
+				"hd":                 "modelcontextprotocol.io",
+				"preferred_username": "admin", //nolint:goconst // role label repeated across test fixtures, not a constant
+			}),
 			token:         "valid-oidc-token",
 			expectedError: false,
 		},
 		{
-			name: "failed validation with invalid hosted domain",
-			config: &config.Config{
-				OIDCEnabled:      true,
-				OIDCIssuer:       "https://accounts.google.com",
-				OIDCClientID:     "test-client-id",
-				OIDCExtraClaims:  `[{"hd":"modelcontextprotocol.io"}]`,
-				OIDCPublishPerms: "*",
-				JWTPrivateKey:    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-			},
-			mockValidator: &MockGenericOIDCValidator{
-				validateFunc: func(_ context.Context, _ string) (*auth.OIDCClaims, error) {
-					return &auth.OIDCClaims{
-						ExtraClaims: map[string]any{
-							"email":              "user@example.com",
-							"email_verified":     true,
-							"hd":                 "example.com", // Wrong domain
-							"preferred_username": "user",
-						},
-					}, nil
-				},
-			},
+			name:   "failed validation with invalid hosted domain",
+			config: testOIDCConfig(`[{"hd":"modelcontextprotocol.io"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"email":              "user@example.com",
+				"email_verified":     true,
+				"hd":                 "example.com",
+				"preferred_username": "user",
+			}),
 			token:         "invalid-domain-token",
+			expectedError: true,
+		},
+		{
+			name:   "scalar expected matches array claim",
+			config: testOIDCConfig(`[{"groups":"admin"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"groups": []any{"admin", "users", "developers"}, //nolint:goconst // claim key repeated across fixtures, not a constant
+			}),
+			token:         "scalar-expected-array-actual-match",
+			expectedError: false,
+		},
+		{
+			name:   "scalar expected not present in array claim",
+			config: testOIDCConfig(`[{"groups":"super-admin"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"groups": []any{"admin", "users", "developers"},
+			}),
+			token:         "scalar-expected-array-actual-no-match",
+			expectedError: true,
+		},
+		{
+			name:   "array expected overlaps array claim",
+			config: testOIDCConfig(`[{"roles":["admin","moderator"]}]`),
+			mockValidator: mockValidator(map[string]any{
+				"roles": []any{"admin", "users"},
+			}),
+			token:         "array-array-overlap",
+			expectedError: false,
+		},
+		{ //nolint:gosec // G101: test data, not real credentials
+			name:   "array expected disjoint from array claim",
+			config: testOIDCConfig(`[{"roles":["super-admin","owner"]}]`),
+			mockValidator: mockValidator(map[string]any{
+				"roles": []any{"admin", "users"},
+			}),
+			token:         "array-array-no-overlap",
+			expectedError: true,
+		},
+		{ //nolint:gosec // G101: test data, not real credentials
+			name:   "array expected matches scalar claim",
+			config: testOIDCConfig(`[{"role":["admin","moderator"]}]`),
+			mockValidator: mockValidator(map[string]any{
+				"role": "admin",
+			}),
+			token:         "scalar-actual-array-expected-match",
+			expectedError: false,
+		},
+		{ //nolint:gosec // G101: test data, not real credentials
+			name:   "[]string typed claim matches scalar expected",
+			config: testOIDCConfig(`[{"groups":"admin"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"groups": []string{"admin", "users"},
+			}),
+			token:         "string-slice-claim",
+			expectedError: false,
+		},
+		{
+			name:   "required claim missing",
+			config: testOIDCConfig(`[{"required_claim":"expected_value"}]`),
+			mockValidator: mockValidator(map[string]any{
+				"other_claim": "some_value",
+			}),
+			token:         "missing-claim",
 			expectedError: true,
 		},
 	}

--- a/internal/api/handlers/v0/auth/oidc_test.go
+++ b/internal/api/handlers/v0/auth/oidc_test.go
@@ -63,7 +63,7 @@ func TestOIDCHandler_ExchangeToken(t *testing.T) {
 				"email":              "admin@modelcontextprotocol.io",
 				"email_verified":     true,
 				"hd":                 "modelcontextprotocol.io",
-				"preferred_username": "admin", //nolint:goconst // role label repeated across test fixtures, not a constant
+				"preferred_username": "admin",
 			}),
 			token:         "valid-oidc-token",
 			expectedError: false,
@@ -84,7 +84,7 @@ func TestOIDCHandler_ExchangeToken(t *testing.T) {
 			name:   "scalar expected matches array claim",
 			config: testOIDCConfig(`[{"groups":"admin"}]`),
 			mockValidator: mockValidator(map[string]any{
-				"groups": []any{"admin", "users", "developers"}, //nolint:goconst // claim key repeated across fixtures, not a constant
+				"groups": []any{"admin", "users", "developers"},
 			}),
 			token:         "scalar-expected-array-actual-match",
 			expectedError: false,


### PR DESCRIPTION
## Summary
Follow-up to #1238 (closes #988). Adds direct unit-test coverage for the `claimMatches` helper, which was the actual change in #1238.

`claimMatches` and `toAnySlice` are unexported, so the tests live in `oidc_internal_test.go` (`package auth`) — same pattern as `http_internal_test.go`. Cases covered:

- scalar/scalar match and mismatch
- scalar actual against array expected (both directions of overlap)
- array actual against scalar expected
- **array/array** — pre-#1238 this combination panicked with `comparing uncomparable type []interface {}`
- `[]string` typed slice (exercises the typed-slice branch of `toAnySlice`, which `[]any` skips)
- non-string scalars (int, bool)
- empty actual array

Test values use single letters (`x`, `y`, `p`, `q`) rather than role labels — only the relationships matter, and short tokens keep `goconst` quiet.

## Test plan
- [x] `go test ./internal/api/handlers/v0/auth/...` — all 13 subtests pass
- [x] `golangci-lint run ./internal/api/handlers/v0/auth/...` — no new issues vs main