### PR TITLE
fix(ui): encode publisher-controlled URLs for href attribute context

### DIFF
--- a/internal/api/handlers/v0/ui_index.html
+++ b/internal/api/handlers/v0/ui_index.html
@@ -423,13 +423,13 @@
                 ${server.repository?.url ? `
                     <div>
                         <span class="font-medium">Repository:</span>
-                        <a href="${escapeHtml(server.repository.url)}" target="_blank" class="text-blue-600 hover:underline break-all" onclick="event.stopPropagation()">${escapeHtml(server.repository.url)}</a>
+                        <a href="${escapeAttr(server.repository.url)}" target="_blank" class="text-blue-600 hover:underline break-all" onclick="event.stopPropagation()">${escapeHtml(server.repository.url)}</a>
                     </div>
                 ` : ''}
                 ${server.websiteUrl ? `
                     <div>
                         <span class="font-medium">Website:</span>
-                        <a href="${escapeHtml(server.websiteUrl)}" target="_blank" class="text-blue-600 hover:underline break-all" onclick="event.stopPropagation()">${escapeHtml(server.websiteUrl)}</a>
+                        <a href="${escapeAttr(server.websiteUrl)}" target="_blank" class="text-blue-600 hover:underline break-all" onclick="event.stopPropagation()">${escapeHtml(server.websiteUrl)}</a>
                     </div>
                 ` : ''}
                 <div>
@@ -491,10 +491,24 @@
         });
 
         // Utility functions
+        // Safe for element-text contexts only: encodes `&`, `<`, `>`. Does NOT
+        // encode `"` or `'`, so it is unsafe inside attribute values — use
+        // escapeAttr there.
         function escapeHtml(text) {
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        // Safe for HTML attribute values per OWASP attribute-encoding rule.
+        function escapeAttr(text) {
+            if (text == null) return '';
+            return String(text)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
         }
 
         function formatDate(dateStr) {


### PR DESCRIPTION
The catalogue page interpolates publisher-supplied URL fields
(`server.repository.url`, `server.websiteUrl`) inside `href="..."`
attributes via `innerHTML`, escaping them with a `textContent`→`innerHTML`
helper. Per the HTML5 fragment-serialisation algorithm, that round-trip
encodes only `&`, `<`, `>`, and U+00A0 inside text nodes — it does not
encode `"` or `'`. The helper is therefore safe in element-text
contexts (where it is used for `name`, `version`, `description`, etc.)
but unsafe inside an attribute value.

Add an attribute-safe `escapeAttr` helper that follows the OWASP
attribute-encoding rule (also encodes `"` and `'`) and use it for the
two `href` interpolations. Element-text usages keep the existing
`escapeHtml` and remain unchanged. A short comment on each helper
documents the contexts they cover so future fields are wired up
correctly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
