### PR TITLE
deploy: update prod to v1.7.7

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.6  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.7  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary
- Bump `mcp-registry:imageTag` from `1.7.6` → `1.7.7` in `deploy/Pulumi.gcpProd.yaml`
- v1.7.7 is a security patch covering three findings (validator hardening, attribute-context UI escaping, IPv6 SSRF blocklist extension); see the v1.7.7 release notes
- Staging is on `f5f40bd` (the v1.7.7 commit) and verified end-to-end:
  - `/v0.1/version` reports the new commit
  - `/v0.1/validate` rejects a poisoned `websiteUrl` with `website-url-invalid-characters`
  - `/` HTML serves the `escapeAttr` helper

## Test plan
- [ ] Confirm release workflow's `ko-push` job has finished publishing `ghcr.io/modelcontextprotocol/registry:1.7.7` before merging
- [ ] Watch deploy-production workflow rolls the registry pods to `1.7.7`
- [ ] Hit `https://registry.modelcontextprotocol.io/v0.1/version` and confirm `git_commit` matches `f5f40bd...`
- [ ] Spot-check the catalogue UI loads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)