### PR TITLE
docs(authentication): note OpenSSL 3.x requirement for Ed25519

### DIFF
--- a/docs/modelcontextprotocol-io/authentication.mdx
+++ b/docs/modelcontextprotocol-io/authentication.mdx
@@ -59,6 +59,10 @@ DNS authentication is a domain-based authentication method that relies on a DNS 
 
 To perform DNS authentication using the `mcp-publisher` CLI tool, run the following commands in your server project directory to generate a TXT record based on a public/private key pair:
 
+<Note>
+  The Ed25519 codepath requires **OpenSSL 3.0 or later**. macOS ships with LibreSSL by default (the system `openssl` binary), which does not implement Ed25519 in `genpkey` and fails with `Algorithm Ed25519 not found`. On macOS, install OpenSSL 3 (`brew install openssl@3`) and invoke it explicitly — for example, replace `openssl` with `/opt/homebrew/opt/openssl@3/bin/openssl` (Apple Silicon) or `/usr/local/opt/openssl@3/bin/openssl` (Intel) in the commands below. The ECDSA P-384 codepath works on LibreSSL.
+</Note>
+
 <CodeGroup>
 
 ```bash Ed25519
@@ -184,6 +188,10 @@ mcp-publisher login dns azure-key-vault --domain="${MY_DOMAIN}" --vault "${MY_KE
 HTTP authentication is a domain-based authentication method that relies on a `/.well-known/mcp-registry-auth` file hosted on your domain. For example, `https://example.com/.well-known/mcp-registry-auth`.
 
 To perform HTTP authentication using the `mcp-publisher` CLI tool, run the following commands in your server project directory to generate an `mcp-registry-auth` file based on a public/private key pair:
+
+<Note>
+  As with DNS authentication, the Ed25519 codepath requires **OpenSSL 3.0 or later**. macOS's system LibreSSL does not support Ed25519 in `genpkey`. See the note in the [DNS Authentication](#dns-authentication) section for the macOS workaround.
+</Note>
 
 <CodeGroup>
 


### PR DESCRIPTION
## Summary

The DNS and HTTP authentication guides currently run `openssl genpkey -algorithm Ed25519 -out key.pem` without caveat. macOS ships LibreSSL as the system `openssl` binary, and LibreSSL doesn't implement Ed25519 in `genpkey` — so the very first command in the Ed25519 codepath errors out with:

```
Algorithm Ed25519 not found
```

A first-time integrator on macOS hits this immediately, with no path to a fix from the docs alone. Cost me ~5 minutes earlier today before I figured out I needed `brew install openssl@3` and an explicit binary path.

This PR adds a `<Note>` callout to the **DNS Authentication** section right above the Ed25519 codepath, and a shorter cross-reference Note in the **HTTP Authentication** section since the same `openssl genpkey -algorithm Ed25519` commands appear there. The ECDSA P-384 codepath works on LibreSSL, so it's untouched.

## Test plan

- [x] Verified locally that `/opt/homebrew/opt/openssl@3/bin/openssl genpkey -algorithm Ed25519 -out key.pem` works on macOS Darwin 25.4.0
- [x] Verified the system `/usr/bin/openssl genpkey -algorithm Ed25519 -out key.pem` fails with `Algorithm Ed25519 not found` on the same machine (LibreSSL 3.3.6)
- [x] Verified the published `ai.ravenmcp/raven-mcp` flow end-to-end with the OpenSSL 3 binary
- [ ] Markdown rendering of the `<Note>` callouts — relying on the existing `<Note>` pattern in this file (line 6) to validate the syntax
