### PR TITLE
deploy: update prod to v1.7.8

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.7  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.8  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary
- Bump `mcp-registry:imageTag` from `1.7.7` → `1.7.8` in `deploy/Pulumi.gcpProd.yaml`
- v1.7.8 ships the metrics fix that stops counting client-cancelled requests as server errors (#1255). Under scraper-driven load, clients with short timeouts close the socket while PG is still iterating; the handler converts `context.Canceled` to a 500 and the metric middleware was bumping `mcp_registry_http_errors_total` even though NGINX recorded 499 and never delivered a response. This is what's been firing the daily ~17:00 UTC `Availability dropped below 95%` alert.
- Also includes a CI-only `pulumi/actions` 6.6.1 → 7.0.0 bump (#1254). No registry runtime impact.
- Staging is on `4e14707` (the v1.7.8 commit) and `staging.registry.modelcontextprotocol.io/v0.1/version` reports it.

## Test plan
- [ ] Confirm release workflow's `ko-push` job has published `ghcr.io/modelcontextprotocol/registry:1.7.8` before merging
- [ ] Watch deploy-production roll the registry pods to `1.7.8`
- [ ] Hit `https://registry.modelcontextprotocol.io/v0.1/version` and confirm `git_commit` matches `4e147072f03aeacfe8456c7f24407e0ea65d92c0`
- [ ] Through the next ~17:00 UTC scraper burst, watch in Prometheus:
  - `mcp_registry_http_errors_total{status_code="500", path="/v0.1/servers"}` should stay flat
  - `mcp_registry_http_requests_total{status_code="499", path="/v0.1/servers"}` should grow during the burst
  - The `Availability dropped below 95%` alert should not fire on cancellation-only bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)