### PR TITLE
feat: add DPX institutional cross-border settlement MCP server

### DIFF
--- a/servers/io.github.untitledfinancial/dpx/server.json
+++ b/servers/io.github.untitledfinancial/dpx/server.json
@@ -1,44 +1,44 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.untitledfinancial/dpx",
-  "title": "DPX — Institutional Cross-Border Settlement",
-  "description": "DPX cross-border settlement rail — institutional USD/EUR settlement at ~30bps via Base mainnet. 11 tools: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, on-chain settlement. ESG-linked fees, MiCA/FCA/Basel III-aligned.",
-  "repository": {
-    "url": "https://github.com/untitledfinancial/dpx-mcp",
-    "source": "github"
-  },
-  "version_detail": {
-    "version": "2.1.0"
-  },
-  "remotes": [
-    {
-      "transport_type": "http",
-      "url": "https://mcp.untitledfinancial.com/mcp"
-    }
-  ],
-  "packages": [
-    {
-      "registry_name": "npm",
-      "name": "@untitledfinancial/dpx-mcp",
-      "version": "2.1.0",
-      "package_arguments": [],
-      "environment_variables": [
-        {
-          "name": "STABILITY_ORACLE_URL",
-          "description": "Override the Stability Oracle URL",
-          "required": false
-        },
-        {
-          "name": "SETTLEMENT_AGENT_URL",
-          "description": "Override the Settlement Agent URL",
-          "required": false
-        },
-        {
-          "name": "SANDBOX_MODE",
-          "description": "Set to false for live on-chain settlement (default: true)",
-          "required": false
-        }
-      ]
-    }
-  ]
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.untitledfinancial/dpx",
+    "title": "DPX — Institutional Cross-Border Settlement",
+    "description": "DPX cross-border settlement rail — institutional settlement at ~30bps via Base mainnet, any currency pair. 11 tools covering the full lifecycle: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, and on-chain settlement execution. ESG-linked fees, on-chain verifiable receipts, MiCA/FCA/Basel III-aligned.",
+    "repository": {
+          "url": "https://github.com/untitledfinancial/dpx-mcp",
+          "source": "github"
+    },
+    "version_detail": {
+          "version": "2.2.0"
+    },
+    "remotes": [
+          {
+                  "transport_type": "http",
+                  "url": "https://mcp.untitledfinancial.com/mcp"
+          }
+    ],
+    "packages": [
+          {
+                  "registry_name": "npm",
+                  "name": "@untitledfinancial/dpx-mcp",
+                  "version": "2.2.0",
+                  "package_arguments": [],
+                  "environment_variables": [
+                            {
+                                        "name": "STABILITY_ORACLE_URL",
+                                        "description": "Override the Stability Oracle URL (default: https://stability.untitledfinancial.com)",
+                                        "required": false
+                            },
+                            {
+                                        "name": "SETTLEMENT_AGENT_URL",
+                                        "description": "Override the Settlement Agent URL (default: https://agent.untitledfinancial.com)",
+                                        "required": false
+                            },
+                            {
+                                        "name": "SANDBOX_MODE",
+                                        "description": "Set to false for live on-chain settlement (default: true)",
+                                        "required": false
+                            }
+                  ]
+          }
+    ]
 }

--- a/servers/io.github.untitledfinancial/dpx/server.json
+++ b/servers/io.github.untitledfinancial/dpx/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.untitledfinancial/dpx",
+  "title": "DPX — Institutional Cross-Border Settlement",
+  "description": "DPX cross-border settlement rail — institutional USD/EUR settlement at ~30bps via Base mainnet. 11 tools: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, on-chain settlement. ESG-linked fees, MiCA/FCA/Basel III-aligned.",
+  "repository": {
+    "url": "https://github.com/untitledfinancial/dpx-mcp",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "2.1.0"
+  },
+  "remotes": [
+    {
+      "transport_type": "http",
+      "url": "https://mcp.untitledfinancial.com/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@untitledfinancial/dpx-mcp",
+      "version": "2.1.0",
+      "package_arguments": [],
+      "environment_variables": [
+        {
+          "name": "STABILITY_ORACLE_URL",
+          "description": "Override the Stability Oracle URL",
+          "required": false
+        },
+        {
+          "name": "SETTLEMENT_AGENT_URL",
+          "description": "Override the Settlement Agent URL",
+          "required": false
+        },
+        {
+          "name": "SANDBOX_MODE",
+          "description": "Set to false for live on-chain settlement (default: true)",
+          "required": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds DPX to the official MCP registry — an institutional cross-border settlement rail for any currency pair, running on Base mainnet.

**Server:** `io.github.untitledfinancial/dpx`
**Remote endpoint:** https://mcp.untitledfinancial.com/mcp (HTTP transport)
**npm package:** `@untitledfinancial/dpx-mcp` v2.2.0

### 11 tools
- `get_manifest` — protocol capabilities and contract addresses
- - `get_quote` — binding fee quote with 300s TTL
- - `get_esg_score` — live ESG score for a wallet address
- - `get_reliability` — oracle stability signal
- - `get_oracle_status` — full 9-layer oracle output
- - `get_fee_schedule` — complete fee table with volume tiers
- - `verify_fees` — confirm off-chain quote matches on-chain router
- - `compare_to_competitors` — DPX vs SWIFT/Stripe/Wise/PayPal
- - `get_analytics` — live protocol health metrics
- - `settle` — execute cross-border settlement (sandbox=true by default)
- - `get_settlement_status` — look up settlement audit record
## Checklist
- [x] Remote HTTP endpoint responding at https://mcp.untitledfinancial.com/mcp
- [ ] - [x] npm package published: `@untitledfinancial/dpx-mcp`
- [ ] - [x] server.json validates against the registry schema
- [ ] - [x] Namespace matches GitHub org: github.com/untitledfinancial