### PR TITLE
feat(ui): support serving under a subpath via MCP_REGISTRY_UI_BASE_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ MCP_REGISTRY_JWT_PRIVATE_KEY=bb2c6b424005acd5df47a9e2c87f446def86dd740c888ea3efb
 # This should be disabled in prod
 MCP_REGISTRY_ENABLE_ANONYMOUS_AUTH=false
 
+# Base path for the UI when served behind a reverse proxy under a subpath (e.g. /mcp/registry).
+# Only affects browser-side links and navigation, not API routing.
+MCP_REGISTRY_UI_BASE_PATH=
+
 # GitHub OIDC token exchange (for `mcp-publisher login github-oidc`)
 # Expected `aud` claim on incoming GitHub Actions OIDC tokens. Must equal the
 # scheme + host that publishers pass via `--registry` (e.g. `https://registry.example.com`).

--- a/internal/api/handlers/v0/ui.go
+++ b/internal/api/handlers/v0/ui.go
@@ -2,12 +2,14 @@ package v0
 
 import (
 	_ "embed"
+	"strings"
 )
 
 //go:embed ui_index.html
 var embedUI string
 
-// GetUIHTML returns the embedded HTML for the UI
-func GetUIHTML() string {
-	return embedUI
+// GetUIHTML returns the embedded HTML for the UI with the given base path
+// substituted into browser-side links and navigation.
+func GetUIHTML(basePath string) string {
+	return strings.ReplaceAll(embedUI, "{{UI_BASE_PATH}}", basePath)
 }

--- a/internal/api/handlers/v0/ui_index.html
+++ b/internal/api/handlers/v0/ui_index.html
@@ -20,7 +20,7 @@
             <div class="flex gap-6 text-sm">
                 <a href="https://github.com/modelcontextprotocol/registry" target="_blank" class="text-blue-600 hover:text-blue-700 font-medium">GitHub</a>
                 <a href="https://github.com/modelcontextprotocol/registry/tree/main/docs" target="_blank" class="text-blue-600 hover:text-blue-700 font-medium">Docs</a>
-                <a href="/docs" class="text-blue-600 hover:text-blue-700 font-medium">API Reference</a>
+                <a href="{{UI_BASE_PATH}}/docs" class="text-blue-600 hover:text-blue-700 font-medium">API Reference</a>
             </div>
         </header>
 
@@ -156,11 +156,11 @@
                 case 'staging':
                     return 'https://staging.registry.modelcontextprotocol.io';
                 case 'local':
-                    return '';
+                    return '{{UI_BASE_PATH}}';
                 case 'custom':
                     return customUrl;
                 default:
-                    return '';
+                    return '{{UI_BASE_PATH}}';
             }
         }
 
@@ -197,7 +197,8 @@
             if (!latestOnly) params.set('all', '1');
             if (currentCursor) params.set('cursor', currentCursor);
 
-            const newUrl = params.toString() ? `?${params.toString()}` : '/';
+            const base = '{{UI_BASE_PATH}}' || '/';
+            const newUrl = params.toString() ? `${base}?${params.toString()}` : base;
             history.pushState({cursor: currentCursor, search, latestOnly}, '', newUrl);
         }
 

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -121,20 +121,22 @@ func WithSkipPaths(paths ...string) MiddlewareOption {
 }
 
 // handle404 returns a helpful 404 error with suggestions for common mistakes
-func handle404(w http.ResponseWriter, r *http.Request) {
+func handle404(w http.ResponseWriter, r *http.Request, uiBasePath string) {
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusNotFound)
 
 	path := r.URL.Path
-	detail := "Endpoint not found. See /docs for the API documentation."
+	docsPath := uiBasePath + "/docs"
+	detail := fmt.Sprintf("Endpoint not found. See %s for the API documentation.", docsPath)
 
 	// Provide suggestions for common API endpoint mistakes
 	if !strings.HasPrefix(path, "/v0/") && !strings.HasPrefix(path, "/v0.1/") {
 		detail = fmt.Sprintf(
-			"Endpoint not found. Did you mean '%s' or '%s'? See /docs for the API documentation.",
+			"Endpoint not found. Did you mean '%s' or '%s'? See %s for the API documentation.",
 			"/v0.1"+path,
 			"/v0"+path,
+			docsPath,
 		)
 	}
 
@@ -236,7 +238,7 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 					"frame-ancestors 'none'; "+
 					"base-uri 'self'; "+
 					"form-action 'self'")
-			_, err := w.Write([]byte(v0.GetUIHTML()))
+			_, err := w.Write([]byte(v0.GetUIHTML(cfg.UIBasePath)))
 			if err != nil {
 				http.Error(w, "Failed to write response", http.StatusInternalServerError)
 			}
@@ -244,7 +246,7 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 		}
 
 		// Handle 404 for all non-matched routes
-		handle404(w, r)
+		handle404(w, r, cfg.UIBasePath)
 	})
 
 	return api

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,11 @@ type Config struct {
 	EnableAnonymousAuth      bool   `env:"ENABLE_ANONYMOUS_AUTH" envDefault:"false"`
 	EnableRegistryValidation bool   `env:"ENABLE_REGISTRY_VALIDATION" envDefault:"true"`
 
+	// UIBasePath is a path prefix for browser-side links when the UI is served
+	// behind a reverse proxy under a subpath (e.g. "/mcp/registry"). It does
+	// not affect API routing.
+	UIBasePath string `env:"UI_BASE_PATH" envDefault:""`
+
 	GitHubOIDCAudience string `env:"GITHUB_OIDC_AUDIENCE" envDefault:""`
 
 	// OIDC Configuration


### PR DESCRIPTION
## Motivation and Context

https://github.com/modelcontextprotocol/registry/pull/757 added a simple UI, and although I understand this was a simple example and most production downstream registries will have a custom UI, I like the idea of starting small and staying consistent with https://registry.modelcontextprotocol.io/.

In my case this is at https://api.company.com/mcp/registry behind a reverse proxy, but the UI redirects and expects to be served at the root, so the UI is broken.

This PR adds subpath handling to the browser side template but does not adjust routing itself (this is normally handled by the reverse proxy).

If this is accepted I'd add a few more adjustments as a follow-up, so that downstream registries can use the same UI but a few custom options like the title and so on.

## How Has This Been Tested?

<details>
<summary>docker compose + nginx</summary>

`Dockerfile.dev`

```dockerfile
FROM golang:1.26-alpine AS build
WORKDIR /src
COPY go.mod go.sum ./
RUN go mod download
COPY . .
RUN go build -o /registry ./cmd/registry
FROM alpine:3
COPY --from=build /registry /registry
ENTRYPOINT ["/registry"]
```

`nginx.conf`

```nginx
server {
    listen 9090;
    location /mcp/registry/ {
        proxy_pass http://registry:8080/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
    }
    location = /mcp/registry {
        return 301 /mcp/registry/;
    }
}
```
`docker-compose.dev.yml`

```yaml
services:
  registry:
    build:
      context: .
      dockerfile: Dockerfile.dev
    container_name: registry
    depends_on:
      postgres:
        condition: service_healthy
    environment:
      - MCP_REGISTRY_DATABASE_URL=postgres://mcpregistry:mcpregistry@postgres:5432/mcp-registry
      - MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false
      - MCP_REGISTRY_SEED_FROM=data/seed.json
      - MCP_REGISTRY_JWT_PRIVATE_KEY=8103179d8ef955f6d3de6d6217224a909ec4060529dfeb1d4ca5a994537658cd
      - MCP_REGISTRY_ENABLE_ANONYMOUS_AUTH=true
      - MCP_REGISTRY_UI_BASE_PATH=/mcp/registry
    volumes:
      - ./data:/data:ro
    restart: "unless-stopped"
  postgres:
    image: postgres:16-alpine
    container_name: postgres
    environment:
      POSTGRES_DB: mcp-registry
      POSTGRES_USER: mcpregistry
      POSTGRES_PASSWORD: mcpregistry
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -U mcpregistry -d mcp-registry"]
      interval: 1s
      retries: 30
    restart: "unless-stopped"
  nginx:
    image: nginx:alpine
    container_name: nginx
    depends_on:
      - registry
    ports:
      - "9090:9090"
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
    restart: "unless-stopped"
```


```bash
docker compose -f docker-compose.dev.yml up --build
```

- Browse to `http://localhost:9090/mcp/registry`
- API Reference link points to `/mcp/registry/docs`
- Servers load correctly (API calls go through `/mcp/registry/v0.1/servers`)
- Browser navigation/history stays under `/mcp/registry`

Also tested with `/my-registry` as the base path and without a path to confirm it works with arbitrary prefixes.

</details>

## Breaking Changes

Shouldn't be breaking anything, but see testing example above.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
