### PR TITLE
deploy: update prod to v1.7.9

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.8  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.7.9  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
Promotes [v1.7.9](https://github.com/modelcontextprotocol/registry/releases/tag/v1.7.9) to production. Includes the OCI validator fail-closed fix from #1281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)