### PR TITLE
chore(deps): reduce dependabot frequency from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
         patterns:
           - "go.opentelemetry.io/*"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: gomod
     directory: /deploy
     groups:
@@ -15,7 +15,7 @@ updates:
         patterns:
           - "go.opentelemetry.io/*"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     groups:
@@ -23,8 +23,8 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-        interval: "daily"
+        interval: "weekly"


### PR DESCRIPTION
## Summary
- Dependency update PRs were arriving daily across gomod (root + `/deploy`), github-actions, and docker — creating significant review noise.
- Switch all four update entries in `.github/dependabot.yml` from `interval: daily` to `interval: weekly` so they batch on a weekly cadence (Dependabot defaults to Mondays).

## Test plan
- [ ] Confirm `.github/dependabot.yml` parses correctly (Dependabot will report a config error on the repo if not)
- [ ] Observe that new dependency PRs stop appearing daily after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)