### PR TITLE
feat: add Whaber Oracle MCP server v1.3.0

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,33 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.misaelcalvillo/whaber-oracle",
+    "description": "Ground truth operational layer for urban transfers in LatAm. Verified place nodes, carrier ANT compliance (7-doc gate), safe pickup points, and operational windows for hotel and airport transfers in Quito, Ecuador. The execution certificate layer for agentic commerce: Visa/MC resolve how the agent pays — Whaber Oracle resolves whether the physical service happened. Place Graph v3.2 · 20 zones · 478 POIs · MCP Streamable HTTP.",
+    "repository": {
+      "url": "https://github.com/MisaelCalvillo/whaber.git",
+      "source": "github"
+    },
+    "version": "1.3.0",
+    "packages": [
+      {
+        "registryType": "http",
+        "identifier": "https://oracle.whaber.ai/mcp/v1",
+        "transport": {
+          "type": "http",
+          "url": "https://oracle.whaber.ai/mcp/v1"
+        },
+        "environmentVariables": [
+          {
+            "name": "WHABER_API_KEY",
+            "description": "Bearer token for partner access. Discovery tools (query_place_safety, get_safe_pickup_point, calculate_ops_window, get_hotel_context, resolver_direccion) are open. Action tools require partner authentication. Contact cv@whaber.ai for access.",
+            "isRequired": false,
+            "isSecret": true
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds Whaber Oracle MCP server to the registry.

Whaber Oracle is a Streamable HTTP MCP server providing ground truth operational data for urban transfers in Quito, Ecuador (LatAm). It exposes 10 tools covering carrier ANT compliance verification, safe pickup points, zone safety assessment, operational window calculation, real-time flight grounding, and geocoding against a proprietary Place Graph (20 zones, 478 POIs).

**Server details:**
- Endpoint: https://oracle.whaber.ai/mcp/v1
- Transport: Streamable HTTP (JSON-RPC 2.0)
- Version: 1.3.0
- Auth: Bearer token (optional — 5 discovery tools are open, 5 action tools require partner access)

**Tested:** MCP initialize handshake verified, tools/list returns 10 tools, discovery tools callable without auth.
