### PR TITLE
feat: add IA-QA MCP server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -136,6 +136,25 @@
     ]
   },
   {
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jcjamet/ia-qa",
+  "title": "IA-QA",
+  "description": "130+ real AI testing primitives: LLM evaluation, prompt testing, RAG pipeline QA, multimodal checks, and CI/CD-ready scoring — all callable via MCP. No signup, BYOK.",
+  "repository": {
+    "url": "https://github.com/JcJamet/ia_qa",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://ia-qa.com/mcp"
+      }
+    }
+  ]
+},
+  {
     "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     "name": "io.github.domdomegg/time-mcp-pypi",
     "description": "Get the current UTC time in RFC 3339 format.",


### PR DESCRIPTION
Summary


Add IA-QA MCP server to the registry
Motivation and Context


IA-QA (ia-qa.com) is a public MCP server exposing 130+ AI testing 
primitives: LLM evaluation, prompt testing, RAG pipeline QA, 
multimodal checks, and CI/CD-ready scoring. No signup required, BYOK.
How Has This Been Tested?


The endpoint https://ia-qa.com/mcp is live and returns a valid MCP 
manifest with all tool definitions. Tested with Claude Desktop and 
direct JSON-RPC calls.
Breaking Changes


None.
Types of changes


- [x] New feature (non-breaking change which adds functionality)
Checklist


- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
Additional context


HTTP server using streamable-http transport. Public endpoint, 
rate-limited to 60 req/min per IP.