### PR TITLE
fix: ignore inactive remote URL conflicts

### DIFF
--- a/internal/service/registry_service.go
+++ b/internal/service/registry_service.go
@@ -312,6 +312,9 @@ func (s *registryServiceImpl) validateNoDuplicateRemoteURLs(ctx context.Context,
 
 		// Check if any conflicting server has a different name
 		for _, conflictingServer := range conflictingServers {
+			if conflictingServer.Meta.Official != nil && conflictingServer.Meta.Official.Status != model.StatusActive {
+				continue
+			}
 			if conflictingServer.Server.Name != serverDetail.Name {
 				return fmt.Errorf("remote URL %s is already used by server %s", remote.URL, conflictingServer.Server.Name)
 			}

--- a/internal/service/registry_service_test.go
+++ b/internal/service/registry_service_test.go
@@ -51,6 +51,19 @@ func TestValidateNoDuplicateRemoteURLs(t *testing.T) {
 		_, err := service.CreateServer(ctx, server)
 		require.NoError(t, err, "failed to create server: %v", err)
 	}
+	deprecatedServer := &apiv0.ServerJSON{
+		Schema:      model.CurrentSchemaURL,
+		Name:        "com.example/deprecated-server",
+		Description: "A deprecated server",
+		Version:     "1.0.0",
+		Remotes: []model.Transport{
+			{Type: "streamable-http", URL: "https://old.example.com/mcp"},
+		},
+	}
+	_, err := service.CreateServer(ctx, deprecatedServer)
+	require.NoError(t, err)
+	_, err = service.UpdateServerStatus(ctx, deprecatedServer.Name, deprecatedServer.Version, &StatusChangeRequest{NewStatus: model.StatusDeprecated})
+	require.NoError(t, err)
 
 	tests := []struct {
 		name         string
@@ -96,6 +109,19 @@ func TestValidateNoDuplicateRemoteURLs(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "remote URL https://api.example.com/mcp is already used by server com.example/existing-server",
+		},
+		{
+			name: "duplicate remote URL on deprecated server - should pass",
+			serverDetail: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/replacement-server",
+				Description: "A replacement server",
+				Version:     "1.0.0",
+				Remotes: []model.Transport{
+					{Type: "streamable-http", URL: "https://old.example.com/mcp"},
+				},
+			},
+			expectError: false,
 		},
 		{
 			name: "updating same server with same URLs - should pass",


### PR DESCRIPTION
﻿Fixes #1193.

Remote URL uniqueness validation already excluded deleted servers at the query layer, but deprecated servers were still treated as conflicts. That blocks publishing a replacement server when the old server has intentionally been deprecated.

This change keeps the existing same-server exemption and skips inactive registry entries before reporting a remote URL conflict. The regression test creates a deprecated server that owns a remote URL, then verifies a different replacement server can reuse that URL.

## Validation

Passed:
- `gofmt -w internal\service\registry_service.go internal\service\registry_service_test.go`
- `go test ./internal/service -run '^$' -count=1`
- `git diff --check`

Blocked locally:
- `go test ./internal/service -run TestValidateNoDuplicateRemoteURLs -count=1`
- `go test ./internal/service -run 'TestUpdateServerStatus_ValidateRemoteURLsOnRestore|TestUpdateAllVersionsStatus_ValidateRemoteURLsOnRestore' -count=1`

Both targeted test commands require a local PostgreSQL test database. This Windows clean clone does not have Docker/PostgreSQL available, and the test helper failed before executing the test body with: `Failed to connect to PostgreSQL. Make sure PostgreSQL is running via: docker-compose up -d postgres`.
