### PR TITLE
Match mcp-name marker exactly in PyPI/NuGet ownership checks

### DIFF
--- a/internal/validators/registries/mcpname.go
+++ b/internal/validators/registries/mcpname.go
@@ -1,0 +1,44 @@
+package registries
+
+import "strings"
+
+// validServerNameByte reports whether b can appear in an MCP server name
+// (namespace/name) per the registry's server name grammar:
+// [a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]/[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9].
+func validServerNameByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
+		return true
+	case b == '.', b == '-', b == '_', b == '/':
+		return true
+	default:
+		return false
+	}
+}
+
+// ReadmeDeclaresMCPName reports whether content contains an
+// "mcp-name: <serverName>" ownership marker that matches serverName in full.
+//
+// The matched name must end at a non-name character or the end of content, so a
+// README declaring a longer name that merely has serverName as a prefix — e.g.
+// "mcp-name: io.github.alice/foo-evil" for the server "io.github.alice/foo" — is
+// not accepted. This mirrors the exact match npm performs against the package's
+// mcpName field and the documented contract that the "$SERVER_NAME portion MUST
+// match" the server name from server.json.
+func ReadmeDeclaresMCPName(content, serverName string) bool {
+	const prefix = "mcp-name: "
+	for offset := 0; ; {
+		idx := strings.Index(content[offset:], prefix)
+		if idx < 0 {
+			return false
+		}
+		nameStart := offset + idx + len(prefix)
+		if strings.HasPrefix(content[nameStart:], serverName) {
+			nameEnd := nameStart + len(serverName)
+			if nameEnd == len(content) || !validServerNameByte(content[nameEnd]) {
+				return true
+			}
+		}
+		offset = nameStart
+	}
+}

--- a/internal/validators/registries/mcpname_test.go
+++ b/internal/validators/registries/mcpname_test.go
@@ -1,0 +1,84 @@
+package registries_test
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/registry/internal/validators/registries"
+)
+
+func TestReadmeDeclaresMCPName(t *testing.T) {
+	const server = "io.github.alice/foo"
+
+	cases := []struct {
+		name    string
+		content string
+		server  string
+		want    bool
+	}{
+		{
+			name:    "html comment marker as documented",
+			content: "# My package\n\n<!-- mcp-name: io.github.alice/foo -->\n",
+			server:  server,
+			want:    true,
+		},
+		{
+			name:    "bare line followed by newline",
+			content: "mcp-name: io.github.alice/foo\nmore docs",
+			server:  server,
+			want:    true,
+		},
+		{
+			name:    "marker at end of content",
+			content: "see mcp-name: io.github.alice/foo",
+			server:  server,
+			want:    true,
+		},
+		{
+			name:    "no marker",
+			content: "this readme has no ownership marker",
+			server:  server,
+			want:    false,
+		},
+		{
+			name:    "server name present without marker prefix",
+			content: "install io.github.alice/foo from pip",
+			server:  server,
+			want:    false,
+		},
+		{
+			// The core fix: a longer name that has the server name as a prefix
+			// must not satisfy ownership for the shorter name.
+			name:    "hyphen-suffixed longer name is rejected",
+			content: "<!-- mcp-name: io.github.alice/foo-evil -->",
+			server:  server,
+			want:    false,
+		},
+		{
+			name:    "dot-suffixed longer name is rejected",
+			content: "mcp-name: io.github.alice/foo.bar\n",
+			server:  server,
+			want:    false,
+		},
+		{
+			name:    "exact match for a name that itself ends in a suffix",
+			content: "<!-- mcp-name: io.github.alice/foo-evil -->",
+			server:  "io.github.alice/foo-evil",
+			want:    true,
+		},
+		{
+			// A prefix-only occurrence followed by a genuine match still passes.
+			name:    "second occurrence is an exact match",
+			content: "mcp-name: io.github.alice/foobar then mcp-name: io.github.alice/foo ",
+			server:  server,
+			want:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := registries.ReadmeDeclaresMCPName(tc.content, tc.server); got != tc.want {
+				t.Errorf("ReadmeDeclaresMCPName(%q, %q) = %v, want %v", tc.content, tc.server, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/validators/registries/nuget.go
+++ b/internal/validators/registries/nuget.go
@@ -238,8 +238,7 @@ func validateReadme(ctx context.Context, serverName, lowerID, lowerVersion strin
 		readmeContent := string(readmeBytes)
 
 		// Check for mcp-name: format (more specific)
-		mcpNamePattern := "mcp-name: " + serverName
-		if strings.Contains(readmeContent, mcpNamePattern) {
+		if ReadmeDeclaresMCPName(readmeContent, serverName) {
 			return ValidReadme, nil // Found as mcp-name: format
 		}
 

--- a/internal/validators/registries/pypi.go
+++ b/internal/validators/registries/pypi.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/registry/pkg/model"
@@ -86,8 +85,7 @@ func ValidatePyPI(ctx context.Context, pkg model.Package, serverName string) err
 	description := pypiResp.Info.Description
 
 	// Check for mcp-name: format (more specific)
-	mcpNamePattern := "mcp-name: " + serverName
-	if strings.Contains(description, mcpNamePattern) {
+	if ReadmeDeclaresMCPName(description, serverName) {
 		return nil // Found as mcp-name: format
 	}
 


### PR DESCRIPTION
PyPI and NuGet ownership validation check for the `mcp-name: <serverName>` marker with a plain substring match:

```go
mcpNamePattern := "mcp-name: " + serverName
if strings.Contains(description, mcpNamePattern) { ... }
```

Because nothing anchors the end of `serverName`, a README that declares a **longer** name which merely has the server name as a prefix also passes. For example, validating `io.github.alice/foo` succeeds against a README containing:

```
<!-- mcp-name: io.github.alice/foo-evil -->
```

That contradicts the documented contract — "the `$SERVER_NAME` portion **MUST** match the server name" in `docs/modelcontextprotocol-io/package-types.mdx` — and is inconsistent with npm, which compares the `mcpName` field with `==`.

This adds a shared `readmeDeclaresMCPName` helper that finds `mcp-name: <serverName>` and requires the matched name to end at a non-name character (per the server-name grammar `[a-zA-Z0-9._/-]`) or at end of content. Both the documented HTML-comment form (`<!-- mcp-name: name -->`) and a bare `mcp-name: name` line still pass; prefix-only matches no longer do. PyPI and NuGet both use it.

Added `mcpname_test.go` with table-driven cases (documented formats, end-of-content, hyphen/dot-suffixed longer names, and a second-occurrence exact match). The existing `registries` package tests still pass.