### PR TITLE
Add GMGN Agent Skills to MCP Registry

### DIFF
--- a/data/io.github.GMGNAI/gmgn-skills.json
+++ b/data/io.github.GMGNAI/gmgn-skills.json
@@ -1,0 +1,31 @@
+[
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.GMGNAI/gmgn-skills",
+    "description": "With GMGN Agent Skills, you can use AI agents to query real-time trending token rankings across multiple chains, token fundamentals, social media signals, live trading activity, new tokens in Trenches, top holders, top traders, smart money positions, KOL holdings, insider wallets, bundled wallet exposure, and other professional on-chain analytics. It also supports market orders, limit orders, advanced take-profit/stop-loss strategy orders, one-command cooking orders (buy + condition orders in a single flow), and wallet management — including real-time holdings, recent P&L, and transaction history — all through natural language.",
+    "repository": {
+      "url": "https://github.com/GMGNAI/gmgn-skills.git",
+      "source": "github"
+    },
+    "version": "1.0.1",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "gmgn-cli",
+        "version": "1.0.1",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        },
+        "environmentVariables": [
+          {
+            "description": "GMGN API Key. Apply at https://gmgn.ai/ai",
+            "isRequired": true,
+            "isSecret": true,
+            "name": "GMGN_API_KEY"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
Add GMGN Agent Skills MCP server to the official registry.

## Motivation and Context
GMGN Agent Skills is an MCP server that enables AI agents to query real-time on-chain data and execute memecoin trades across Solana, BNB Chain, Ethereum, Base, Monad, and TRON via natural language.

GitHub: https://github.com/GMGNAI/gmgn-skills
Docs: https://docs.gmgn.ai

## How Has This Been Tested?
Tested with Claude Code and Cursor using gmgn-cli.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
GMGN Agent Skills supports 40+ one-click skills for on-chain memecoin trading, token & wallet analytics, smart money / KOL signal monitoring, and token launches on Pump.fun, FourMeme, and Clanker.
