### PR TITLE
fix: client-cancelled GET /v0/servers returns 499 without error log

### DIFF
--- a/internal/api/handlers/v0/list_errors.go
+++ b/internal/api/handlers/v0/list_errors.go
@@ -1,0 +1,21 @@
+package v0
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// listServersError maps ListServers failures; client disconnects must not log as 500s.
+func listServersError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return huma.NewError(499, "Client closed request", err)
+	}
+	log.Printf("list servers failed: %v", err)
+	return huma.Error500InternalServerError("Failed to get registry list", err)
+}

--- a/internal/api/handlers/v0/list_errors.go
+++ b/internal/api/handlers/v0/list_errors.go
@@ -8,8 +8,8 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
-// listServersError maps ListServers failures; client disconnects must not log as 500s.
-func listServersError(ctx context.Context, err error) error {
+// ListServersError maps ListServers failures; client disconnects must not log as 500s.
+func ListServersError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}

--- a/internal/api/handlers/v0/list_errors_test.go
+++ b/internal/api/handlers/v0/list_errors_test.go
@@ -1,0 +1,30 @@
+package v0
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListServersError_clientCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := listServersError(ctx, errors.New("error iterating rows: context canceled"))
+	require.Error(t, err)
+	se, ok := err.(huma.StatusError)
+	require.True(t, ok)
+	assert.Equal(t, 499, se.GetStatus())
+}
+
+func TestListServersError_realFailure(t *testing.T) {
+	err := listServersError(context.Background(), errors.New("database unavailable"))
+	require.Error(t, err)
+	se, ok := err.(huma.StatusError)
+	require.True(t, ok)
+	assert.Equal(t, 500, se.GetStatus())
+}

--- a/internal/api/handlers/v0/list_errors_test.go
+++ b/internal/api/handlers/v0/list_errors_test.go
@@ -1,4 +1,4 @@
-package v0
+package v0_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
+	v0 "github.com/modelcontextprotocol/registry/internal/api/handlers/v0"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,17 +15,17 @@ func TestListServersError_clientCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := listServersError(ctx, errors.New("error iterating rows: context canceled"))
+	err := v0.ListServersError(ctx, errors.New("error iterating rows: context canceled"))
 	require.Error(t, err)
-	se, ok := err.(huma.StatusError)
-	require.True(t, ok)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
 	assert.Equal(t, 499, se.GetStatus())
 }
 
 func TestListServersError_realFailure(t *testing.T) {
-	err := listServersError(context.Background(), errors.New("database unavailable"))
+	err := v0.ListServersError(context.Background(), errors.New("database unavailable"))
 	require.Error(t, err)
-	se, ok := err.(huma.StatusError)
-	require.True(t, ok)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
 	assert.Equal(t, 500, se.GetStatus())
 }

--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -132,8 +132,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		// Get paginated results with filtering
 		servers, nextCursor, err := registry.ListServers(ctx, filter, input.Cursor, input.Limit)
 		if err != nil {
-			log.Printf("list servers failed: %v", err)
-			return nil, huma.Error500InternalServerError("Failed to get registry list")
+			return nil, listServersError(ctx, err)
 		}
 
 		// Convert []*ServerResponse to []ServerResponse

--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -132,7 +132,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		// Get paginated results with filtering
 		servers, nextCursor, err := registry.ListServers(ctx, filter, input.Cursor, input.Limit)
 		if err != nil {
-			return nil, listServersError(ctx, err)
+			return nil, ListServersError(ctx, err)
 		}
 
 		// Convert []*ServerResponse to []ServerResponse


### PR DESCRIPTION
## Summary
- Map `context.Canceled` from `ListServers` to HTTP 499 instead of 500
- Skip `list servers failed` error-level logging when the client disconnects mid-stream
- Prevents huma `superfluous response.WriteHeader` warnings on closed sockets

Closes #1323

## Test plan
- [x] `go test ./internal/api/handlers/v0/... -run ListServersError`

Made with [Cursor](https://cursor.com)