### PR TITLE
fix(validators): reject valueHint on named arguments

### DIFF
--- a/internal/validators/constants.go
+++ b/internal/validators/constants.go
@@ -26,6 +26,7 @@ var (
 	ErrInvalidNamedArgumentName      = errors.New("invalid named argument name format")
 	ErrArgumentValueStartsWithName   = errors.New("argument value cannot start with the argument name")
 	ErrArgumentDefaultStartsWithName = errors.New("argument default cannot start with the argument name")
+	ErrValueHintOnNamedArgument      = errors.New("valueHint is only valid for positional arguments, not named arguments")
 
 	// Server name validation errors
 	ErrMultipleSlashesInServerName = errors.New("server name cannot contain multiple slashes")

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -404,6 +404,20 @@ func validateArgument(ctx *ValidationContext, obj *model.Argument) *ValidationRe
 		// Validate value and default don't start with the name
 		valueResult := validateArgumentValueFields(ctx, obj.Name, obj.Value, obj.Default)
 		result.Merge(valueResult)
+
+		// valueHint names a positional slot for transport URL variable
+		// substitution, so it only makes sense on positional arguments. The
+		// schema allows it on named arguments (the union branches don't set
+		// additionalProperties: false), so reject it here instead.
+		if obj.ValueHint != "" {
+			issue := NewValidationIssueFromError(
+				ValidationIssueTypeSemantic,
+				ctx.Field("valueHint").String(),
+				ErrValueHintOnNamedArgument,
+				"valuehint-on-named-argument",
+			)
+			result.AddIssue(issue)
+		}
 	}
 	return result
 }

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -1301,6 +1301,19 @@ func TestValidateArgument_ValueHintOnNamedArgument(t *testing.T) {
 		assert.Error(t, result.FirstError(), "named argument carrying valueHint should be rejected")
 	})
 
+	t.Run("package_named_with_valueHint_rejected", func(t *testing.T) {
+		arg := model.Argument{
+			Type:      model.ArgumentTypeNamed,
+			Name:      "--port",
+			ValueHint: "port_number",
+		}
+		server := createValidServerWithArgument(arg)
+		server.Packages[0].RuntimeArguments = nil
+		server.Packages[0].PackageArguments = []model.Argument{arg}
+		result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+		assert.Error(t, result.FirstError(), "named package argument carrying valueHint should be rejected")
+	})
+
 	// A positional argument with a valueHint stays valid (no regression).
 	t.Run("positional_with_valueHint_valid", func(t *testing.T) {
 		arg := model.Argument{

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -1286,6 +1286,34 @@ func TestValidateArgument_InvalidNamedArgumentNames(t *testing.T) {
 	}
 }
 
+func TestValidateArgument_ValueHintOnNamedArgument(t *testing.T) {
+	// valueHint identifies a positional slot, so a named argument must not carry
+	// one. The schema misses this (the argument union branches allow extra
+	// properties), so the semantic validator is the enforcement point.
+	t.Run("named_with_valueHint_rejected", func(t *testing.T) {
+		arg := model.Argument{
+			Type:      model.ArgumentTypeNamed,
+			Name:      "--port",
+			ValueHint: "port_number",
+		}
+		server := createValidServerWithArgument(arg)
+		result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+		assert.Error(t, result.FirstError(), "named argument carrying valueHint should be rejected")
+	})
+
+	// A positional argument with a valueHint stays valid (no regression).
+	t.Run("positional_with_valueHint_valid", func(t *testing.T) {
+		arg := model.Argument{
+			InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "/etc/config.json"}},
+			Type:               model.ArgumentTypePositional,
+			ValueHint:          "config_path",
+		}
+		server := createValidServerWithArgument(arg)
+		result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+		assert.NoError(t, result.FirstError(), "positional argument with valueHint should remain valid")
+	})
+}
+
 func TestValidateArgument_InvalidValueFields(t *testing.T) {
 	invalidValueCases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Closes #662.

`valueHint` identifies a positional slot for transport URL variable substitution, so it belongs only on positional arguments. Right now nothing stops a named argument from carrying one: the model holds `ValueHint` flat on `Argument` (`pkg/model/types.go`), and `validateArgument` checks the name and value fields for named arguments but not the hint.

The JSON schema does not catch it either. `valueHint` is declared on `PositionalArgument` only, but `Argument` is an `anyOf` union and neither branch sets `additionalProperties: false`, so a named argument with a `valueHint` still validates against the `NamedArgument` branch. That leaves the semantic validator as the enforcement point.

## Change

- Add `ErrValueHintOnNamedArgument`.
- In `validateArgument`, reject a non-empty `ValueHint` on a named argument (code `valuehint-on-named-argument`), beside the existing named-argument checks.
- Tests: a named argument with a `valueHint` is rejected; a positional argument with a `valueHint` stays valid.

The check is additive and matches the schema's positional-only declaration, so existing valid data is unaffected. I kept this at the validator level rather than tightening the generated schema, which felt like the smaller change; happy to put `additionalProperties: false` on the argument branches instead if you'd rather the schema carry it.

## Test

`go test ./internal/validators/...` passes.
