### PR TITLE
fix: add context.Canceled checks to get-details and get-versions handlers

### DIFF
--- a/internal/api/handlers/v0/registry_error.go
+++ b/internal/api/handlers/v0/registry_error.go
@@ -1,0 +1,22 @@
+package v0
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// RegistryError maps registry errors to HTTP responses; client disconnects
+// must not log as 500s.
+func RegistryError(ctx context.Context, err error, logPrefix string, userMsg string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return huma.NewError(499, "Client closed request", err)
+	}
+	log.Printf("%s failed: %v", logPrefix, err)
+	return huma.Error500InternalServerError(userMsg)
+}

--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -3,7 +3,6 @@ package v0
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -185,8 +184,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 			if err.Error() == errRecordNotFound || errors.Is(err, database.ErrNotFound) {
 				return nil, huma.Error404NotFound("Server not found")
 			}
-			log.Printf("get server details (%q/%q) failed: %v", serverName, version, err)
-			return nil, huma.Error500InternalServerError("Failed to get server details")
+			return nil, RegistryError(ctx, err, "get server details ("+serverName+"/"+version+")", "Failed to get server details")
 		}
 
 		return &Response[apiv0.ServerResponse]{
@@ -215,8 +213,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 			if err.Error() == errRecordNotFound || errors.Is(err, database.ErrNotFound) {
 				return nil, huma.Error404NotFound("Server not found")
 			}
-			log.Printf("get server versions (%q) failed: %v", serverName, err)
-			return nil, huma.Error500InternalServerError("Failed to get server versions")
+			return nil, RegistryError(ctx, err, "get server versions ("+serverName+")", "Failed to get server versions")
 		}
 
 		// Convert []*ServerResponse to []ServerResponse


### PR DESCRIPTION
## Summary

#1335 fixed the list-servers endpoint to return 499 instead of 500 when the client disconnects mid-request. But the get-server-details and get-server-versions handlers still use raw `huma.Error500InternalServerError` without checking for `context.Canceled`.

This PR applies the same cancellation check pattern to both remaining GET handlers, so all server endpoints consistently return 499 on client disconnect instead of logging a noisy 500 and triggering `superfluous response.WriteHeader` warnings.

## Changes

- `internal/api/handlers/v0/servers.go`: Added `context.Canceled` check before logging and returning 500 in get-server-details (line ~188) and get-server-versions (line ~218)
- Pattern matches `ListServersError` in `list_errors.go` (already tested)

## Why this matters

Without this fix, clients that disconnect during get-details or get-versions requests still produce:
1. Error-level log lines for benign cancellations (noise in logs/alerts)
2. `superfluous response.WriteHeader` warnings (huma tries to write to a closed socket)

The fix short-circuits before the error log and 500 response, returning 499 instead.

## Test plan

- [ ] Existing tests pass (`go test ./internal/api/handlers/v0/...`)
- [ ] Manual: `curl --max-time 0.05 http://localhost:8080/v0/servers/<name>/versions/latest` no longer logs error-level cancellation