### PR TITLE
Add BuyWhere buywhere-api MCP server

### DIFF
--- a/servers/io.github.BuyWhere/buywhere-api/server.json
+++ b/servers/io.github.BuyWhere/buywhere-api/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/schema/model-context-protocol/server.json",
+  "name": "buywhere-catalog",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "buywhere-api",
+      "version": "0.1.0",
+      "transport": {
+        "type": "http"
+      }
+    }
+  ],
+  "description": "BuyWhere product catalog MCP server — search, compare, and ingest product data across merchants via natural language. Connects to PostgreSQL with full-text search.",
+  "repository": {
+    "url": "https://github.com/BuyWhere/buywhere.git",
+    "source": "github"
+  }
+}

--- a/servers/io.github.BuyWhere/buywhere-api/server.json
+++ b/servers/io.github.BuyWhere/buywhere-api/server.json
@@ -1,19 +1,16 @@
 {
-  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/schema/model-context-protocol/server.json",
-  "name": "buywhere-catalog",
-  "packages": [
-    {
-      "registryType": "npm",
-      "identifier": "buywhere-api",
-      "version": "0.1.0",
-      "transport": {
-        "type": "http"
-      }
-    }
-  ],
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.BuyWhere/buywhere-api",
   "description": "BuyWhere product catalog MCP server — search, compare, and ingest product data across merchants via natural language. Connects to PostgreSQL with full-text search.",
   "repository": {
     "url": "https://github.com/BuyWhere/buywhere.git",
     "source": "github"
-  }
+  },
+  "version": "0.1.0",
+  "remotes": [
+    {
+      "type": "http",
+      "url": "https://api.buywhere.ai/mcp"
+    }
+  ]
 }

--- a/servers/io.github.BuyWhere/buywhere-api/server.json
+++ b/servers/io.github.BuyWhere/buywhere-api/server.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.BuyWhere/buywhere-api",
-  "description": "BuyWhere product catalog MCP server — search, compare, and ingest product data across merchants via natural language. Connects to PostgreSQL with full-text search.",
+  "description": "BuyWhere product catalog API for AI agents — search, compare, and ingest products across 6 markets.",
+  "version": "0.1.0",
   "repository": {
-    "url": "https://github.com/BuyWhere/buywhere.git",
+    "url": "https://github.com/BuyWhere/buywhere",
     "source": "github"
   },
-  "version": "0.1.0",
   "remotes": [
     {
-      "type": "http",
+      "type": "streamable-http",
       "url": "https://api.buywhere.ai/mcp"
     }
   ]


### PR DESCRIPTION
## BuyWhere MCP Server Registration

**Namespace:** io.github.BuyWhere/buywhere-api
**MCP Server Name:** buywhere-catalog
**Version:** 0.1.0
**Transport:** HTTP (JSON-RPC 2.0 over HTTP POST)
**Endpoint:** mcp.buywhere.io

### Tools
- search_products - Full-text product search across merchants
- get_product - Product details by ID
- compare_products - Cross-merchant price comparison
- get_deals - Active deals and discounts
- list_categories - Browse product categories
- find_best_price - Find lowest price for a product
- ingest_products - Bulk product ingestion

### Description
BuyWhere product catalog MCP server - search, compare, and ingest product data across merchants via natural language. Connects to PostgreSQL with full-text search.

### Repository
https://github.com/BuyWhere/buywhere

---
*This PR was created automatically by the BuyWhere fleet agent.*
Co-Authored-By: Paperclip <noreply@paperclip.ing>