### PR TITLE
Add BuyWhere MCP server (v1.0.4) to the official MCP Registry

### DIFF
--- a/servers/io.github.BuyWhere/buywhere-mcp/server.json
+++ b/servers/io.github.BuyWhere/buywhere-mcp/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.BuyWhere/buywhere-mcp",
+  "title": "BuyWhere MCP Server",
+  "description": "Open-source MCP server for AI agent commerce. Search 50M+ products across 6 markets.",
+  "version": "1.0.4",
+  "repository": {
+    "url": "https://github.com/BuyWhere/buywhere-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@buywhere/mcp-server",
+      "version": "0.3.7",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.buywhere.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Add BuyWhere MCP server (v1.0.4) to the official MCP Registry

This PR adds the BuyWhere MCP server to the official MCP Registry using the proper `io.github.BuyWhere/buywhere-mcp` namespace (matching the canonical npm package `@buywhere/mcp-server`).

### What is BuyWhere MCP?

Open-source MCP server for AI agent commerce. Search 50M+ products across 6 markets (SG, MY, TH, US, ID, AU) with hybrid FTS + vector search.

- **Repo:** https://github.com/BuyWhere/buywhere-mcp
- **npm package:** `@buywhere/mcp-server` v0.3.7
- **Documentation:** https://buywhere.ai/docs/guides/mcp
- **Live API endpoint:** `https://api.buywhere.ai/mcp` (canonical, working)

### server.json details

- **Namespace:** `io.github.BuyWhere/buywhere-mcp` (matches npm package)
- **Version:** 1.0.4 (latest, includes the [BUY-42672](https://github.com/BuyWhere/buywhere-mcp/issues/18) Authorization: Bearer auth fix)
- **Title:** "BuyWhere MCP Server"
- **Transports:**
  - `stdio` via `npx -y @buywhere/mcp-server` (npm package)
  - `streamable-http` to `https://api.buywhere.ai/mcp` (remote endpoint)

### Validation

```bash
$ /tmp/mcp-publisher validate /tmp/buywhere-mcp-server.json
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

### Notes

- This PR uses the **correct** namespace (`buywhere-mcp`), not the legacy `buywhere-api` namespace from PR #1356
- The existing PR #1356 is using the old endpoint `mcp.buywhere.io` (deprecated, NXDOMAIN) and old namespace — closing that PR and merging this one is the recommended path
- v1.0.4 is in main of `BuyWhere/buywhere-mcp` (commit `4603226`) with the Bearer auth fix
- Once merged, this entry will be available in MCP client discovery and the official registry browser
