### PR TITLE
Add CodeHealth MCP server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -155,5 +155,26 @@
         }
       }
     ]
+  },
+  {
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.icohangar-ops/codehealth-mcp",
+    "description": "AI-powered codebase health analysis - detects dead code, circular dependencies, coupling issues, and architectural drift. 6 MCP tools for Claude Desktop, Cursor, Windsurf.",
+    "repository": {
+      "url": "https://github.com/icohangar-ops/codehealth-mcp.git",
+      "source": "github"
+    },
+    "version": "1.0.0",
+    "packages": [
+      {
+        "registryType": "npm",
+        "identifier": "codehealth-mcp",
+        "version": "1.0.0",
+        "runtimeHint": "npx",
+        "transport": {
+          "type": "stdio"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Registers [CodeHealth MCP](https://github.com/icohangar-ops/codehealth-mcp) in the official MCP registry.

6 tools for codebase health analysis:
- `analyze_dead_code` — unused functions, classes, modules
- `detect_circular_deps` — DFS cycle detection
- `analyze_coupling` — fan-out metrics, cluster detection
- `detect_architectural_drift` — layer boundary violations
- `full_health_scan` — complete analysis with 0-100 score
- `explain_finding` — AI-powered explanation

Works with Claude Desktop, Cursor, Windsurf, and Slack.