### PR TITLE
feat: add Alternative Asset Literacy MCP server

### DIFF
--- a/servers/io.github.untitledfinancial/alternative-asset-literacy/server.json
+++ b/servers/io.github.untitledfinancial/alternative-asset-literacy/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.untitledfinancial/alternative-asset-literacy",
+  "title": "Alternative Asset Literacy",
+  "description": "Research-backed financial education platform covering alternative assets, DeFi, behavioral economics, art investing, ESG & climate finance, and gender lens investing. 13 tools: glossary lookup/search/browse across 351 terms, module discovery, user profile routing, platform overview, institutional research papers (43 papers from IMF, BIS, World Bank, Federal Reserve), geographic intelligence by investment topic, HNW submarket data by city, investor audience profiling, audience matching, and advisor client gift bundle generation. Built for high-net-worth women investors, female entrepreneurs, ESG investors, DeFi investors, and the wealth management advisors who serve them. Educational content only — not financial advice.",
+  "repository": {
+    "url": "https://github.com/untitledfinancial/alternative-asset-literacy-mcp",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "1.0.0"
+  },
+  "remotes": [
+    {
+      "transport_type": "http",
+      "url": "https://alternativeassetliteracy.com/mcp"
+    }
+  ]
+}

--- a/servers/io.github.untitledfinancial/dpx/server.json
+++ b/servers/io.github.untitledfinancial/dpx/server.json
@@ -1,44 +1,44 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.untitledfinancial/dpx",
-  "title": "DPX — Institutional Cross-Border Settlement",
-  "description": "DPX cross-border settlement rail — institutional USD/EUR settlement at ~30bps via Base mainnet. 11 tools: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, on-chain settlement. ESG-linked fees, MiCA/FCA/Basel III-aligned.",
-  "repository": {
-    "url": "https://github.com/untitledfinancial/dpx-mcp",
-    "source": "github"
-  },
-  "version_detail": {
-    "version": "2.1.0"
-  },
-  "remotes": [
-    {
-      "transport_type": "http",
-      "url": "https://mcp.untitledfinancial.com/mcp"
-    }
-  ],
-  "packages": [
-    {
-      "registry_name": "npm",
-      "name": "@untitledfinancial/dpx-mcp",
-      "version": "2.1.0",
-      "package_arguments": [],
-      "environment_variables": [
-        {
-          "name": "STABILITY_ORACLE_URL",
-          "description": "Override the Stability Oracle URL",
-          "required": false
-        },
-        {
-          "name": "SETTLEMENT_AGENT_URL",
-          "description": "Override the Settlement Agent URL",
-          "required": false
-        },
-        {
-          "name": "SANDBOX_MODE",
-          "description": "Set to false for live on-chain settlement (default: true)",
-          "required": false
-        }
-      ]
-    }
-  ]
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "io.github.untitledfinancial/dpx",
+    "title": "DPX — Institutional Cross-Border Settlement",
+    "description": "DPX cross-border settlement rail — institutional settlement at ~30bps via Base mainnet, any currency pair. 11 tools covering the full lifecycle: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, and on-chain settlement execution. ESG-linked fees, on-chain verifiable receipts, MiCA/FCA/Basel III-aligned.",
+    "repository": {
+          "url": "https://github.com/untitledfinancial/dpx-mcp",
+          "source": "github"
+    },
+    "version_detail": {
+          "version": "2.2.0"
+    },
+    "remotes": [
+          {
+                  "transport_type": "http",
+                  "url": "https://mcp.untitledfinancial.com/mcp"
+          }
+    ],
+    "packages": [
+          {
+                  "registry_name": "npm",
+                  "name": "@untitledfinancial/dpx-mcp",
+                  "version": "2.2.0",
+                  "package_arguments": [],
+                  "environment_variables": [
+                            {
+                                        "name": "STABILITY_ORACLE_URL",
+                                        "description": "Override the Stability Oracle URL (default: https://stability.untitledfinancial.com)",
+                                        "required": false
+                            },
+                            {
+                                        "name": "SETTLEMENT_AGENT_URL",
+                                        "description": "Override the Settlement Agent URL (default: https://agent.untitledfinancial.com)",
+                                        "required": false
+                            },
+                            {
+                                        "name": "SANDBOX_MODE",
+                                        "description": "Set to false for live on-chain settlement (default: true)",
+                                        "required": false
+                            }
+                  ]
+          }
+    ]
 }

--- a/servers/io.github.untitledfinancial/dpx/server.json
+++ b/servers/io.github.untitledfinancial/dpx/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.untitledfinancial/dpx",
+  "title": "DPX — Institutional Cross-Border Settlement",
+  "description": "DPX cross-border settlement rail — institutional USD/EUR settlement at ~30bps via Base mainnet. 11 tools: quote, ESG scoring, oracle status, fee verification, competitor benchmarking, on-chain settlement. ESG-linked fees, MiCA/FCA/Basel III-aligned.",
+  "repository": {
+    "url": "https://github.com/untitledfinancial/dpx-mcp",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "2.1.0"
+  },
+  "remotes": [
+    {
+      "transport_type": "http",
+      "url": "https://mcp.untitledfinancial.com/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registry_name": "npm",
+      "name": "@untitledfinancial/dpx-mcp",
+      "version": "2.1.0",
+      "package_arguments": [],
+      "environment_variables": [
+        {
+          "name": "STABILITY_ORACLE_URL",
+          "description": "Override the Stability Oracle URL",
+          "required": false
+        },
+        {
+          "name": "SETTLEMENT_AGENT_URL",
+          "description": "Override the Settlement Agent URL",
+          "required": false
+        },
+        {
+          "name": "SANDBOX_MODE",
+          "description": "Set to false for live on-chain settlement (default: true)",
+          "required": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the Alternative Asset Literacy MCP server to the registry.

- **Server:** `io.github.untitledfinancial/alternative-asset-literacy`
- **Transport:** HTTP remote at `https://alternativeassetliteracy.com/mcp`
- **Repository:** https://github.com/untitledfinancial/alternative-asset-literacy-mcp
- **Tools (13):** glossary lookup, glossary search, glossary browse, modules find, users route, platform overview, research papers, geo by module, geo by location, HNW submarkets, audience profile, audience match, advisor gift bundle

**Platform description:** Research-backed iOS financial education app covering alternative assets, DeFi, behavioral economics, ESG & climate finance, art investing, and gender lens investing. 351 glossary terms, 43 institutional research papers (IMF, BIS, World Bank, Federal Reserve). Built for HNW women investors, female entrepreneurs, ESG practitioners, and the wealth management advisors who serve them. Educational content only — not financial advice.

**Free entry point:** Investing Primer module (no account required) — server is public, no authentication needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)