### PR TITLE
Fix broken reference documentation links

### DIFF
--- a/docs/contributing/add-package-registry.md
+++ b/docs/contributing/add-package-registry.md
@@ -2,9 +2,9 @@
 
 The MCP Registry project is a **metaregistry**, meaning that it hosts metadata for MCP servers but does not host the code for the servers directly.
 
-For local MCP servers, the MCP Registry has pointers in the `packages` node of the [`server.json`](../../reference/server-json/generic-server-json.md) schema that refer to packages in supported package managers.
+For local MCP servers, the MCP Registry has pointers in the `packages` node of the [`server.json`](../reference/server-json/generic-server-json.md) schema that refer to packages in supported package managers.
 
-The list of supported package managers for hosting MCP servers is defined by the `properties.packages[N].properties.registryType` string enum in the [`server.json` schema](../../reference/server-json/draft/server.schema.json). For example, this could be "npm" (for npmjs.com packages) or "pypi" (for PyPI packages).
+The list of supported package managers for hosting MCP servers is defined by the `properties.packages[N].properties.registryType` string enum in the [`server.json` schema](../reference/server-json/draft/server.schema.json). For example, this could be "npm" (for npmjs.com packages) or "pypi" (for PyPI packages).
 
 For remote MCP servers, the package registry is not relevant. The MCP client consumes the server via a URL instead of by downloading and running a package. In other words, this document only applies to local MCP servers.
 
@@ -33,15 +33,15 @@ These steps may evolve as additional validations or details are discovered and m
 1. [Create a feature request issue](https://github.com/modelcontextprotocol/registry/issues/new?template=feature_request.md) on the MCP Registry repository to begin the discussion about adding the package registry.
    - Example for NuGet: https://github.com/modelcontextprotocol/registry/issues/126
 1. Open a PR with the following changes:
-   - Update the [`server.json` schema](../../reference/server-json/draft/server.schema.json)
+   - Update the [`server.json` schema](../reference/server-json/draft/server.schema.json)
      - Add your package registry name to the `registryType` example array.
      - Add your package registry base url to the `registryBaseUrl` example array.
      - Add the single-shot CLI command name to the `runtimeHint` example value array.
-   - Update the [`openapi.yaml`](../../reference/api/openapi.yaml)
+   - Update the [`openapi.yaml`](../reference/api/openapi.yaml)
      - Add your package registry name to the `registryType` enum value array.
      - Add your package registry base url to the `registryBaseUrl` enum value array.
      - Add the single-shot CLI command name to the `runtimeHint` example value array.
-   - Add a sample, minimal `server.json` to the [`server.json` examples](../../reference/server-json/generic-server-json.md).
+   - Add a sample, minimal `server.json` to the [`server.json` examples](../reference/server-json/generic-server-json.md).
    - Implement a registry validator:
       - Create a new validator file: `internal/validators/registries/yourregistry.go`, following the pattern of existing validators. Examples:
          - **npm**: Checks for an `mcpName` field in `package.json` that matches the server name

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -19,4 +19,4 @@ Technical specifications and quick lookups for the MCP Registry.
 
 ## Quick Reference
 
-- [FAQ](./faq.md)
+- [FAQ](../modelcontextprotocol-io/faq.mdx)


### PR DESCRIPTION
Summary:
- Fix the reference index FAQ link to point at the existing docs FAQ.
- Correct package registry guide links from docs/contributing into docs/reference.

Validation:
- Focused markdown-link-check on the changed docs passed.
- Git whitespace check passed.