### PR TITLE
fix(handlers): return 499 on client cancel for get-server endpoints

### DIFF
--- a/internal/api/handlers/v0/list_errors.go
+++ b/internal/api/handlers/v0/list_errors.go
@@ -8,11 +8,11 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
-func clientClosedRequest(ctx context.Context, err error) (error, bool) {
+func clientClosedRequest(ctx context.Context, err error) (bool, error) {
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-		return huma.NewError(499, "Client closed request", err), true
+		return true, huma.NewError(499, "Client closed request", err)
 	}
-	return nil, false
+	return false, nil
 }
 
 // ListServersError maps ListServers failures; client disconnects must not log as 500s.
@@ -20,7 +20,7 @@ func ListServersError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
-	if cerr, ok := clientClosedRequest(ctx, err); ok {
+	if ok, cerr := clientClosedRequest(ctx, err); ok {
 		return cerr
 	}
 	log.Printf("list servers failed: %v", err)
@@ -35,7 +35,7 @@ func GetServerDetailsError(ctx context.Context, err error, serverName, version s
 	if err == nil {
 		return nil
 	}
-	if cerr, ok := clientClosedRequest(ctx, err); ok {
+	if ok, cerr := clientClosedRequest(ctx, err); ok {
 		return cerr
 	}
 	log.Printf("get server details (%q/%q) failed: %v", serverName, version, err)
@@ -47,7 +47,7 @@ func GetServerVersionsError(ctx context.Context, err error, serverName string) e
 	if err == nil {
 		return nil
 	}
-	if cerr, ok := clientClosedRequest(ctx, err); ok {
+	if ok, cerr := clientClosedRequest(ctx, err); ok {
 		return cerr
 	}
 	log.Printf("get server versions (%q) failed: %v", serverName, err)

--- a/internal/api/handlers/v0/list_errors.go
+++ b/internal/api/handlers/v0/list_errors.go
@@ -8,17 +8,48 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
+func clientClosedRequest(ctx context.Context, err error) (error, bool) {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		return huma.NewError(499, "Client closed request", err), true
+	}
+	return nil, false
+}
+
 // ListServersError maps ListServers failures; client disconnects must not log as 500s.
 func ListServersError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-		return huma.NewError(499, "Client closed request", err)
+	if cerr, ok := clientClosedRequest(ctx, err); ok {
+		return cerr
 	}
 	log.Printf("list servers failed: %v", err)
 	// Do not pass err here: huma serializes extra error args into the response
 	// body, which would leak internal (e.g. pgx) error detail to clients. Log it
 	// server-side only, like the sibling handlers in servers.go.
 	return huma.Error500InternalServerError("Failed to get registry list")
+}
+
+// GetServerDetailsError maps get-server-version failures; client disconnects must not log as 500s.
+func GetServerDetailsError(ctx context.Context, err error, serverName, version string) error {
+	if err == nil {
+		return nil
+	}
+	if cerr, ok := clientClosedRequest(ctx, err); ok {
+		return cerr
+	}
+	log.Printf("get server details (%q/%q) failed: %v", serverName, version, err)
+	return huma.Error500InternalServerError("Failed to get server details")
+}
+
+// GetServerVersionsError maps get-server-versions failures; client disconnects must not log as 500s.
+func GetServerVersionsError(ctx context.Context, err error, serverName string) error {
+	if err == nil {
+		return nil
+	}
+	if cerr, ok := clientClosedRequest(ctx, err); ok {
+		return cerr
+	}
+	log.Printf("get server versions (%q) failed: %v", serverName, err)
+	return huma.Error500InternalServerError("Failed to get server versions")
 }

--- a/internal/api/handlers/v0/list_errors_test.go
+++ b/internal/api/handlers/v0/list_errors_test.go
@@ -43,3 +43,41 @@ func TestListServersError_realFailureDoesNotLeakDetail(t *testing.T) {
 	assert.NotContains(t, string(body), "database unavailable")
 	assert.NotContains(t, string(body), "internal-host")
 }
+
+func TestGetServerDetailsError_clientCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := v0.GetServerDetailsError(ctx, errors.New("query canceled"), "io.github.acme/widget", "1.0.0")
+	require.Error(t, err)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, 499, se.GetStatus())
+}
+
+func TestGetServerDetailsError_realFailure(t *testing.T) {
+	err := v0.GetServerDetailsError(context.Background(), errors.New("database unavailable"), "io.github.acme/widget", "1.0.0")
+	require.Error(t, err)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, 500, se.GetStatus())
+}
+
+func TestGetServerVersionsError_clientCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := v0.GetServerVersionsError(ctx, errors.New("query canceled"), "io.github.acme/widget")
+	require.Error(t, err)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, 499, se.GetStatus())
+}
+
+func TestGetServerVersionsError_realFailure(t *testing.T) {
+	err := v0.GetServerVersionsError(context.Background(), errors.New("database unavailable"), "io.github.acme/widget")
+	require.Error(t, err)
+	var se huma.StatusError
+	require.True(t, errors.As(err, &se))
+	assert.Equal(t, 500, se.GetStatus())
+}

--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -3,7 +3,6 @@ package v0
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -185,8 +184,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 			if err.Error() == errRecordNotFound || errors.Is(err, database.ErrNotFound) {
 				return nil, huma.Error404NotFound("Server not found")
 			}
-			log.Printf("get server details (%q/%q) failed: %v", serverName, version, err)
-			return nil, huma.Error500InternalServerError("Failed to get server details")
+			return nil, GetServerDetailsError(ctx, err, serverName, version)
 		}
 
 		return &Response[apiv0.ServerResponse]{
@@ -215,8 +213,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 			if err.Error() == errRecordNotFound || errors.Is(err, database.ErrNotFound) {
 				return nil, huma.Error404NotFound("Server not found")
 			}
-			log.Printf("get server versions (%q) failed: %v", serverName, err)
-			return nil, huma.Error500InternalServerError("Failed to get server versions")
+			return nil, GetServerVersionsError(ctx, err, serverName)
 		}
 
 		// Convert []*ServerResponse to []ServerResponse


### PR DESCRIPTION
## Summary

- Extend the #1335 `ListServersError` pattern to the get-server-version and get-server-versions handlers
- Map client disconnects to HTTP 499 without error-level logging or a second `WriteHeader`
- Factor shared cancellation detection into `clientClosedRequest` and add unit tests for the new helpers

Fixes #1323 (handler-side scope; CDN/RPS follow-up tracked separately on the issue)

## Problem

#1335 fixed cancellation handling for `GET /v0/servers` only. rdimitrov noted that PR only partially addressed #1323. The get-server-version and get-server-versions handlers still logged benign cancellations at error level and returned 500, which can trigger huma `superfluous response.WriteHeader` warnings.

## Test plan

- [x] `go test ./internal/api/handlers/v0/... -run 'ListServersError|GetServerDetailsError|GetServerVersionsError'`
- [x] `go test -race ./internal/api/handlers/v0/... -run 'ListServersError|GetServerDetailsError|GetServerVersionsError'`
- [x] `go vet ./internal/api/handlers/v0/...`
