### PR TITLE
feat: add GateTest — 91-module code quality MCP server

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -1,159 +1,188 @@
-[
-  {
-    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-    "name": "io.github.domdomegg/airtable-mcp-server",
-    "description": "Read and write access to Airtable database schemas, tables, and records.",
-    "repository": {
-      "url": "https://github.com/domdomegg/airtable-mcp-server.git",
-      "source": "github"
+﻿[
+    {
+        "$schema":  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name":  "io.github.domdomegg/airtable-mcp-server",
+        "description":  "Read and write access to Airtable database schemas, tables, and records.",
+        "repository":  {
+                           "url":  "https://github.com/domdomegg/airtable-mcp-server.git",
+                           "source":  "github"
+                       },
+        "version":  "1.7.2",
+        "icons":  [
+                      {
+                          "src":  "https://airtable.com/images/favicon/favicon-32x32.png",
+                          "mimeType":  "image/png",
+                          "sizes":  [
+                                        "32x32"
+                                    ]
+                      }
+                  ],
+        "packages":  [
+                         {
+                             "registryType":  "npm",
+                             "identifier":  "airtable-mcp-server",
+                             "version":  "1.7.2",
+                             "runtimeHint":  "npx",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           },
+                             "environmentVariables":  [
+                                                          {
+                                                              "description":  "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
+                                                              "isRequired":  true,
+                                                              "isSecret":  true,
+                                                              "name":  "AIRTABLE_API_KEY"
+                                                          }
+                                                      ]
+                         },
+                         {
+                             "registryType":  "oci",
+                             "identifier":  "docker.io/domdomegg/airtable-mcp-server:1.7.2",
+                             "runtimeHint":  "docker",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           },
+                             "environmentVariables":  [
+                                                          {
+                                                              "description":  "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
+                                                              "isRequired":  true,
+                                                              "isSecret":  true,
+                                                              "name":  "AIRTABLE_API_KEY"
+                                                          }
+                                                      ]
+                         },
+                         {
+                             "registryType":  "mcpb",
+                             "identifier":  "https://github.com/domdomegg/airtable-mcp-server/releases/download/v1.7.2/airtable-mcp-server.mcpb",
+                             "fileSha256":  "8220de07a08ebe908f04da139ea03dbfe29758141347e945da60535fb7bcca20",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           }
+                         }
+                     ]
     },
-    "version": "1.7.2",
-    "icons": [
-      {
-        "src": "https://airtable.com/images/favicon/favicon-32x32.png",
-        "mimeType": "image/png",
-        "sizes": [
-          "32x32"
-        ]
-      }
-    ],
-    "packages": [
-      {
-        "registryType": "npm",
-        "identifier": "airtable-mcp-server",
-        "version": "1.7.2",
-        "runtimeHint": "npx",
-        "transport": {
-          "type": "stdio"
-        },
-        "environmentVariables": [
-          {
-            "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-            "isRequired": true,
-            "isSecret": true,
-            "name": "AIRTABLE_API_KEY"
-          }
-        ]
-      },
-      {
-        "registryType": "oci",
-        "identifier": "docker.io/domdomegg/airtable-mcp-server:1.7.2",
-        "runtimeHint": "docker",
-        "transport": {
-          "type": "stdio"
-        },
-        "environmentVariables": [
-          {
-            "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-            "isRequired": true,
-            "isSecret": true,
-            "name": "AIRTABLE_API_KEY"
-          }
-        ]
-      },
-      {
-        "registryType": "mcpb",
-        "identifier": "https://github.com/domdomegg/airtable-mcp-server/releases/download/v1.7.2/airtable-mcp-server.mcpb",
-        "fileSha256": "8220de07a08ebe908f04da139ea03dbfe29758141347e945da60535fb7bcca20",
-        "transport": {
-          "type": "stdio"
-        }
-      }
-    ]
-  },
-  {
-    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-    "name": "io.github.domdomegg/airtable-mcp-server",
-    "description": "Read and write access to Airtable database schemas, tables, and records.",
-    "repository": {
-      "url": "https://github.com/domdomegg/airtable-mcp-server.git",
-      "source": "github"
+    {
+        "$schema":  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name":  "io.github.domdomegg/airtable-mcp-server",
+        "description":  "Read and write access to Airtable database schemas, tables, and records.",
+        "repository":  {
+                           "url":  "https://github.com/domdomegg/airtable-mcp-server.git",
+                           "source":  "github"
+                       },
+        "version":  "1.7.3",
+        "packages":  [
+                         {
+                             "registryType":  "npm",
+                             "identifier":  "airtable-mcp-server",
+                             "version":  "1.7.3",
+                             "runtimeHint":  "npx",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           },
+                             "environmentVariables":  [
+                                                          {
+                                                              "description":  "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
+                                                              "isRequired":  true,
+                                                              "isSecret":  true,
+                                                              "name":  "AIRTABLE_API_KEY"
+                                                          }
+                                                      ]
+                         },
+                         {
+                             "registryType":  "oci",
+                             "identifier":  "docker.io/domdomegg/airtable-mcp-server:1.7.3",
+                             "runtimeHint":  "docker",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           },
+                             "environmentVariables":  [
+                                                          {
+                                                              "description":  "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
+                                                              "isRequired":  true,
+                                                              "isSecret":  true,
+                                                              "name":  "AIRTABLE_API_KEY"
+                                                          }
+                                                      ]
+                         },
+                         {
+                             "registryType":  "mcpb",
+                             "identifier":  "https://github.com/domdomegg/airtable-mcp-server/releases/download/v1.7.3/airtable-mcp-server.mcpb",
+                             "fileSha256":  "0f28a9129cfebd262dfb77854c872355d21401bb3e056575b3027081f5d570ca",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           }
+                         }
+                     ]
     },
-    "version": "1.7.3",
-    "packages": [
-      {
-        "registryType": "npm",
-        "identifier": "airtable-mcp-server",
-        "version": "1.7.3",
-        "runtimeHint": "npx",
-        "transport": {
-          "type": "stdio"
-        },
-        "environmentVariables": [
-          {
-            "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-            "isRequired": true,
-            "isSecret": true,
-            "name": "AIRTABLE_API_KEY"
-          }
-        ]
-      },
-      {
-        "registryType": "oci",
-        "identifier": "docker.io/domdomegg/airtable-mcp-server:1.7.3",
-        "runtimeHint": "docker",
-        "transport": {
-          "type": "stdio"
-        },
-        "environmentVariables": [
-          {
-            "description": "Airtable personal access token (e.g., pat123.abc123). Create at https://airtable.com/create/tokens/new with scopes: schema.bases:read, data.records:read, and optionally schema.bases:write and data.records:write.",
-            "isRequired": true,
-            "isSecret": true,
-            "name": "AIRTABLE_API_KEY"
-          }
-        ]
-      },
-      {
-        "registryType": "mcpb",
-        "identifier": "https://github.com/domdomegg/airtable-mcp-server/releases/download/v1.7.3/airtable-mcp-server.mcpb",
-        "fileSha256": "0f28a9129cfebd262dfb77854c872355d21401bb3e056575b3027081f5d570ca",
-        "transport": {
-          "type": "stdio"
-        }
-      }
-    ]
-  },
-  {
-    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-    "name": "io.github.domdomegg/time-mcp-nuget",
-    "description": "Get the current UTC time in RFC 3339 format.",
-    "repository": {
-      "url": "https://github.com/domdomegg/time-mcp-nuget.git",
-      "source": "github"
+    {
+        "$schema":  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name":  "io.github.domdomegg/time-mcp-nuget",
+        "description":  "Get the current UTC time in RFC 3339 format.",
+        "repository":  {
+                           "url":  "https://github.com/domdomegg/time-mcp-nuget.git",
+                           "source":  "github"
+                       },
+        "version":  "1.0.8",
+        "packages":  [
+                         {
+                             "registryType":  "nuget",
+                             "identifier":  "TimeMcpServer",
+                             "version":  "1.0.8",
+                             "runtimeHint":  "dnx",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           }
+                         }
+                     ]
     },
-    "version": "1.0.8",
-    "packages": [
-      {
-        "registryType": "nuget",
-        "identifier": "TimeMcpServer",
-        "version": "1.0.8",
-        "runtimeHint": "dnx",
-        "transport": {
-          "type": "stdio"
-        }
-      }
-    ]
-  },
-  {
-    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-    "name": "io.github.domdomegg/time-mcp-pypi",
-    "description": "Get the current UTC time in RFC 3339 format.",
-    "repository": {
-      "url": "https://github.com/domdomegg/time-mcp-pypi.git",
-      "source": "github"
+    {
+        "$schema":  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name":  "io.github.domdomegg/time-mcp-pypi",
+        "description":  "Get the current UTC time in RFC 3339 format.",
+        "repository":  {
+                           "url":  "https://github.com/domdomegg/time-mcp-pypi.git",
+                           "source":  "github"
+                       },
+        "version":  "1.0.6",
+        "packages":  [
+                         {
+                             "registryType":  "pypi",
+                             "identifier":  "time-mcp-pypi",
+                             "version":  "1.0.6",
+                             "runtimeHint":  "python",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           }
+                         }
+                     ]
     },
-    "version": "1.0.6",
-    "packages": [
-      {
-        "registryType": "pypi",
-        "identifier": "time-mcp-pypi",
-        "version": "1.0.6",
-        "runtimeHint": "python",
-        "transport": {
-          "type": "stdio"
-        }
-      }
-    ]
-  }
+    {
+        "$schema":  "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+        "name":  "io.github.ccantynz-alt/gatetest",
+        "description":  "91-module code quality gate for AI-assisted code review. Scan local repos for security vulnerabilities, reliability bugs, money-float errors, import cycles, PII leaks, and 80+ more patterns. Auto-fix with Claude. Nuclear-tier per-finding diagnosis. Replaces SonarQube, Snyk, ESLint, Lighthouse, and 10+ other tools in one unified gate.",
+        "repository":  {
+                           "url":  "https://github.com/crclabs-hq/gatetest.git",
+                           "source":  "github"
+                       },
+        "version":  "1.0.0",
+        "packages":  [
+                         {
+                             "registryType":  "npm",
+                             "identifier":  "@gatetest/mcp-server",
+                             "version":  "1.0.0",
+                             "runtimeHint":  "npx",
+                             "transport":  {
+                                               "type":  "stdio"
+                                           },
+                             "environmentVariables":  [
+                                                          {
+                                                              "name":  "ANTHROPIC_API_KEY",
+                                                              "description":  "Claude API key. Enables fix_issue (AI-driven auto-fix) and explain_finding (Nuclear-tier per-finding diagnosis). Optional — scanning tools work without it.",
+                                                              "isRequired":  false,
+                                                              "isSecret":  true
+                                                          }
+                                                      ]
+                         }
+                     ]
+    }
 ]


### PR DESCRIPTION
## Summary

Adds **GateTest** to the registry — an MCP server that exposes a 91-module static-analysis engine directly to Claude Code and any MCP-compatible AI.

**npm package:** [`@gatetest/mcp-server@1.0.0`](https://www.npmjs.com/package/@gatetest/mcp-server)  
**Homepage:** https://gatetest.ai  
**Repository:** https://github.com/crclabs-hq/gatetest

### Install

```bash
claude mcp add gatetest -- npx -y @gatetest/mcp-server
```

### Tools (9 total)

| Tool | Description |
|------|-------------|
| `scan_local` | Scan a local directory with GateTest's 91-module engine |
| `run_module` | Run a single named module (e.g. `secrets`, `tlsSecurity`) |
| `list_modules` | Enumerate all 91 modules with descriptions |
| `check_health` | Verify engine is loaded and operational |
| `fix_issue` | AI-driven auto-fix for a single finding (needs `ANTHROPIC_API_KEY`) |
| `compose_pr` | Render PR body markdown for a batch of fixes |
| `explain_finding` | Nuclear-tier per-finding Claude diagnosis (needs `ANTHROPIC_API_KEY`) |
| `audit_log` | Query local scan history from the memory store |
| `compare_repos` | Pattern summary across scan history |

### What GateTest covers

91 modules across security (secrets, TLS bypass, SSRF, SQL injection, cookie security), reliability (race conditions, resource leaks, retry hygiene, async iteration bugs), code quality (import cycles, dead code, money-float, datetime bugs), infrastructure (Terraform, Kubernetes, Dockerfile, CI security), and AI safety (prompt injection, bundled API keys, deprecated models).

### Notes

- Transport: `stdio`  
- `ANTHROPIC_API_KEY` is optional — all scan/list/health tools work without it; fix and diagnosis tools require it  
- The `mcpName` field (`io.github.ccantynz-alt/gatetest`) is set in `package.json` for ownership verification  