### PR TITLE
docs: add polygraph to community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -35,6 +35,7 @@ Self-hostable servers that implement the MCP Registry API specification.
 - [mcp-insights](https://github.com/joelverhagen/mcp-insights/) - Analytics and insights for the MCP Registry
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
+- [polygraph](https://polygraph.so) - Independent behavioral security grades (A–F) for MCP servers from an open, reproducible harness, published as an adoption-ranked index with per-server reports
 
 ## Adding Your Project
 


### PR DESCRIPTION
Adds polygraph (https://polygraph.so) to the **Other** section of `docs/community-projects.md`, per the *Adding Your Project* instructions (one-line entry).

polygraph publishes independent behavioral security grades (A–F) for MCP servers from an open, reproducible harness (https://github.com/polygraphso/litmus) — it exercises a server's live tool surface and grades what it does (tool-output injection, undeclared egress, sensitive-data handling, adversarial-input robustness), then publishes the results as an adoption-ranked index with per-server reports. It reads the official registry to discover and version servers, and adds the independent ratings layer this project's docs note downstream aggregators can provide.

One-line entry only; no code or schema changes.