### PR TITLE
fix(publisher): validate JSON encoding before publishing to catch Windows codepage corruption

### DIFF
--- a/cmd/publisher/commands/publish.go
+++ b/cmd/publisher/commands/publish.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"unicode/utf8"
 
 	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 )
@@ -112,6 +113,12 @@ func publishToRegistry(registryURL string, serverData []byte, token string) (*ap
 		return nil, 0, fmt.Errorf("error serializing request: %w", err)
 	}
 
+	// Validate JSON encoding before sending to prevent publishing
+	// corrupted data on systems with non-UTF-8 codepage environments.
+	if err := validatePublishData(jsonData); err != nil {
+		return nil, 0, fmt.Errorf("publish data validation failed: %w", err)
+	}
+
 	// Ensure URL ends with the publish endpoint
 	if !strings.HasSuffix(registryURL, "/") {
 		registryURL += "/"
@@ -149,4 +156,35 @@ func publishToRegistry(registryURL string, serverData []byte, token string) (*ap
 	}
 
 	return &serverResponse, resp.StatusCode, nil
+}
+
+// validatePublishData checks that JSON data is clean before sending to the registry.
+// This catches encoding corruption that can occur on Windows systems when running
+// under Git Bash / MSYS with a non-UTF-8 ANSI codepage (e.g. zh-CN CP-936/GBK).
+//
+// The check validates:
+//  1. Data is valid UTF-8
+//  2. No JSON-escaped lone surrogates (\udc00-\udfff) appear in the data
+func validatePublishData(data []byte) error {
+	// Check for valid UTF-8 encoding
+	if !utf8.Valid(data) {
+		return fmt.Errorf("server.json contains invalid UTF-8 encoding - this may indicate system encoding corruption. Try running mcp-publisher from PowerShell or CMD instead of Git Bash")
+	}
+
+	// Check for JSON-escaped lone surrogates (e.g. \udc94, \uddff).
+	// These indicate bytes that were misinterpreted through the system codepage
+	// instead of being treated as raw UTF-8.
+	//
+	// We look for the escape prefix \udc-\udf in the marshaled JSON output.
+	// Lone surrogates (U+DC00-U+DFFF) are never valid content in server metadata
+	// and always indicate encoding corruption.
+	lower := bytes.ToLower(data)
+	if bytes.Contains(lower, []byte(`\udc`)) ||
+		bytes.Contains(lower, []byte(`\udd`)) ||
+		bytes.Contains(lower, []byte(`\ude`)) ||
+		bytes.Contains(lower, []byte(`\udf`)) {
+		return fmt.Errorf("server.json contains encoding corruption (lone surrogate characters detected) - this may be caused by non-UTF-8 system codepage. Try running mcp-publisher from PowerShell or CMD instead of Git Bash")
+	}
+
+	return nil
 }

--- a/cmd/publisher/commands/publish_internal_test.go
+++ b/cmd/publisher/commands/publish_internal_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestValidatePublishData_ValidASCII(t *testing.T) {
+	data := []byte(`{"name": "com.example/test", "description": "A simple test server", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err != nil {
+		t.Errorf("expected no error for valid ASCII JSON, got: %v", err)
+	}
+}
+
+func TestValidatePublishData_ValidUTF8(t *testing.T) {
+	// Valid UTF-8 with em-dash and accented characters
+	data := []byte(`{"name": "com.example/test", "description": "Test server — café résumé", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err != nil {
+		t.Errorf("expected no error for valid UTF-8 JSON, got: %v", err)
+	}
+}
+
+func TestValidatePublishData_ValidUnicode(t *testing.T) {
+	// Valid UTF-8 with various Unicode (Chinese, Japanese, emoji)
+	data := []byte(`{"name": "com.example/test", "description": "测试サーバー 🔧", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err != nil {
+		t.Errorf("expected no error for valid Unicode JSON, got: %v", err)
+	}
+}
+
+func TestValidatePublishData_InvalidUTF8(t *testing.T) {
+	// Invalid UTF-8 sequence: 0xFF is never valid in UTF-8
+	// Use interpreted string literal so \xff is the raw byte 0xFF
+	data := []byte("{\"name\": \"com.example/test\", \"description\": \"Test \xff server\", \"version\": \"1.0.0\"}")
+	if err := validatePublishData(data); err == nil {
+		t.Error("expected error for invalid UTF-8, got nil")
+	}
+}
+
+func TestValidatePublishData_InvalidUTF8MultiByte(t *testing.T) {
+	// Invalid UTF-8: truncated multi-byte sequence (0xE2 without continuation bytes)
+	data := []byte("{\"name\": \"test\", \"description\": \"\xe2 server\", \"version\": \"1.0.0\"}")
+	if err := validatePublishData(data); err == nil {
+		t.Error("expected error for truncated UTF-8, got nil")
+	}
+}
+
+func TestValidatePublishData_LoneSurrogateJSON(t *testing.T) {
+	// Marshaled JSON containing a lone surrogate escape (\udc94).
+	// This is the pattern observed on Windows systems with CP-936/GBK codepage.
+	data := []byte(`{"name": "com.example/test", "description": "test \udc94 server", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err == nil {
+		t.Error("expected error for lone surrogate, got nil")
+	}
+}
+
+func TestValidatePublishData_LoneSurrogateUppercase(t *testing.T) {
+	// Same but with uppercase hex: \udc94 vs \uDC94
+	data := []byte(`{"name": "com.example/test", "description": "test \uDC94 server", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err == nil {
+		t.Error("expected error for uppercase lone surrogate, got nil")
+	}
+}
+
+func TestValidatePublishData_LoneSurrogateEndRange(t *testing.T) {
+	// \uddff - another lone surrogate in the surrogate range
+	data := []byte(`{"name": "com.example/test", "description": "test \uddff server", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err == nil {
+		t.Error("expected error for lone surrogate at end of range, got nil")
+	}
+}
+
+func TestValidatePublishData_ValidEscapeNotSurrogate(t *testing.T) {
+	// \udc is 4 chars but these are not \udcXX patterns
+	// "\\udc" alone doesn't match - it's just the word "udc" in a valid escape
+	// or a string that happens to contain these characters
+	data := []byte(`{"name": "more-like-udc", "description": "valid string", "version": "1.0.0"}`)
+	if err := validatePublishData(data); err != nil {
+		t.Errorf("expected no error for valid string containing 'udc', got: %v", err)
+	}
+}

--- a/cmd/publisher/commands/validate.go
+++ b/cmd/publisher/commands/validate.go
@@ -201,6 +201,12 @@ func validateViaAPI(registryURL string, serverData []byte) (*validators.Validati
 		return nil, fmt.Errorf("error serializing request: %w", err)
 	}
 
+	// Validate JSON encoding to detect encoding corruption
+	// (e.g. on Windows with non-UTF-8 codepage in Git Bash/MSYS)
+	if err := validatePublishData(jsonData); err != nil {
+		return nil, fmt.Errorf("validation data encoding error: %w", err)
+	}
+
 	// Ensure URL ends with / and add validate endpoint
 	if !strings.HasSuffix(registryURL, "/") {
 		registryURL += "/"


### PR DESCRIPTION
## Summary

On Windows systems running under Git Bash/MSYS with a non-UTF-8 ANSI codepage (e.g. zh-CN CP-936/GBK), UTF-8 bytes in `server.json` description fields can be silently reinterpreted through the system codepage. The result is corrupted metadata in the registry containing lone surrogate characters (e.g. `\udc94`).

This adds a `validatePublishData()` function that checks both valid UTF-8 encoding and absence of JSON-escaped lone surrogates (`\udc00-\udfff`) before transmitting the publish or validate request. If corruption is detected, the command fails with a clear error message suggesting running from PowerShell or CMD instead of Git Bash.

## Changes

- **publish.go**: Added `validatePublishData()` function and call before HTTP send
- **validate.go**: Added `validatePublishData()` call in `validateViaAPI` for consistency
- **publish_internal_test.go**: 9 test cases covering valid ASCII, UTF-8 Unicode, invalid UTF-8, lone surrogate detection (lowercase, uppercase, end range), and false-positive avoidance

## Testing

- `go build ./cmd/publisher/...` passes
- `go vet ./cmd/publisher/commands/` passes  
- All 9 validation unit tests pass
- Existing publish integration tests pass

Fixes #1306