### PR TITLE
deploy: update prod to v1.8.0

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.7.9  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.8.0  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
Promotes production to the [`v1.8.0`](https://github.com/modelcontextprotocol/registry/releases/tag/v1.8.0) release.

- `deploy/Pulumi.gcpProd.yaml` → `imageTag: 1.8.0` (one line).
- The release build for `v1.8.0` completed successfully, so the image is present in ghcr.
- **Merging this triggers `deploy-production.yml`** (it's path-filtered to `deploy/Pulumi.gcpProd.yaml`); the PR itself doesn't deploy.

### Notable behavior changes in v1.8.0
- **Org-namespace publishing now requires org Owner** (via GitHub login / PAT). Member-level publishers lose org publish — intended tightening.
- Stricter validation may reject some previously-accepted package metadata / names (#1310, #1331, #1411).
- New: cargo (crates.io) package registry support (#1207).

### After merge
- Confirm prod `/v0/version` reports `1.8.0` before treating the rollout as done.