### PR TITLE
fix(schema): upgrade server.json dialect to JSON Schema 2020-12

### DIFF
--- a/docs/reference/server-json/draft/server.schema.json
+++ b/docs/reference/server-json/draft/server.schema.json
@@ -2,7 +2,7 @@
   "$comment": "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
   "$id": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/docs/reference/server-json/draft/server.schema.json",
   "$ref": "#/definitions/ServerDetail",
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "definitions": {
     "Argument": {
       "anyOf": [

--- a/tools/extract-server-schema/main.go
+++ b/tools/extract-server-schema/main.go
@@ -96,7 +96,7 @@ func main() {
 	schemaID := "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/docs/reference/server-json/draft/server.schema.json"
 	jsonSchema := map[string]interface{}{
 		"$comment":    "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
-		"$schema":     "http://json-schema.org/draft-07/schema#",
+		"$schema":     "https://json-schema.org/draft/2020-12/schema",
 		"$id":         schemaID,
 		"title":       "server.json defining a Model Context Protocol (MCP) server",
 		"$ref":        "#/definitions/ServerDetail",


### PR DESCRIPTION
## Summary

The generated `server.schema.json` still advertised JSON Schema draft-07 while OpenAPI already sets `jsonSchemaDialect` to 2020-12. This updates the extractor and regenerates the draft artifact to match.

## Approach

- Emit `https://json-schema.org/draft/2020-12/schema` from `tools/extract-server-schema`
- Regenerate `docs/reference/server-json/draft/server.schema.json`

## Test plan

- [x] `make generate-schema`
- [x] `make check-schema`

Fixes #842
