### PR TITLE
feat(validators): expose config-free validators as an importable pkg/validators library

### DIFF
--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -1,0 +1,125 @@
+// Package validators exposes the config-free subset of the registry's
+// validation logic as an importable library.
+//
+// The registry uses these validators to ensure only well-formed, publisher-owned
+// entries make it into the registry. Historically the logic lived under
+// internal/validators and could not be reused outside of running a full registry.
+// This package is a thin facade over that internal implementation, re-exporting
+// the parts that do not depend on a running registry's configuration so that
+// external tools (for example, a private sub-registry or a preflight check that
+// runs in CI before a release tag is cut) can validate a server.json locally.
+//
+// Two entry points cover the common cases:
+//
+//   - ValidateServerJSON performs schema and semantic validation of a server.json
+//     document and returns every issue it finds.
+//   - ValidatePackage checks that a package is allowed on the official registry
+//     and is owned by the publisher, by dispatching to the per-registry
+//     ownership validators (npm, PyPI, NuGet, OCI, MCPB, Cargo).
+//
+// The sentinel errors re-exported here can be matched with errors.Is, so
+// consumers can distinguish outcomes without matching on error strings.
+//
+// This is intentionally the config-free surface only. Validators that require a
+// running registry's *config.Config (ValidatePublishRequest, ValidateUpdateRequest)
+// and the authentication checks currently embedded in the API auth handlers are
+// out of scope here and remain in internal/ for now; see issue #1394 for the
+// planned follow-up phases.
+package validators
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/registry/internal/validators"
+	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/modelcontextprotocol/registry/pkg/model"
+)
+
+// Result and issue types describing the outcome of validation. These are aliases
+// of the internal types so values flow freely between this package and the
+// registry's internal call sites.
+type (
+	// ValidationResult contains the results of validation.
+	ValidationResult = validators.ValidationResult
+	// ValidationIssue represents a single validation problem.
+	ValidationIssue = validators.ValidationIssue
+	// ValidationOptions configures which types of validation to perform.
+	ValidationOptions = validators.ValidationOptions
+	// ValidationIssueType classifies a validation issue (json, schema, semantic, linter).
+	ValidationIssueType = validators.ValidationIssueType
+	// ValidationIssueSeverity is the severity of a validation issue (error, warning, info).
+	ValidationIssueSeverity = validators.ValidationIssueSeverity
+	// SchemaVersionPolicy determines how non-current schema versions are handled.
+	SchemaVersionPolicy = validators.SchemaVersionPolicy
+)
+
+// Validation issue types.
+const (
+	ValidationIssueTypeJSON     = validators.ValidationIssueTypeJSON
+	ValidationIssueTypeSchema   = validators.ValidationIssueTypeSchema
+	ValidationIssueTypeSemantic = validators.ValidationIssueTypeSemantic
+	ValidationIssueTypeLinter   = validators.ValidationIssueTypeLinter
+)
+
+// Validation issue severities.
+const (
+	ValidationIssueSeverityError   = validators.ValidationIssueSeverityError
+	ValidationIssueSeverityWarning = validators.ValidationIssueSeverityWarning
+	ValidationIssueSeverityInfo    = validators.ValidationIssueSeverityInfo
+)
+
+// Schema version policies.
+const (
+	SchemaVersionPolicyAllow = validators.SchemaVersionPolicyAllow
+	SchemaVersionPolicyWarn  = validators.SchemaVersionPolicyWarn
+	SchemaVersionPolicyError = validators.SchemaVersionPolicyError
+)
+
+// Common validation configurations for use with ValidateServerJSON.
+var (
+	// ValidationSemanticOnly performs only semantic validation (no schema checks).
+	ValidationSemanticOnly = validators.ValidationSemanticOnly
+	// ValidationSchemaVersionOnly checks schema version only (empty, non-current).
+	ValidationSchemaVersionOnly = validators.ValidationSchemaVersionOnly
+	// ValidationSchemaVersionAndSemantic checks schema version and performs semantic validation.
+	ValidationSchemaVersionAndSemantic = validators.ValidationSchemaVersionAndSemantic
+	// ValidationAll performs all validation types (schema version, full schema validation, and semantic).
+	ValidationAll = validators.ValidationAll
+)
+
+// Sentinel validation errors. Match these with errors.Is to distinguish outcomes
+// without matching on error strings.
+var (
+	ErrInvalidRepositoryURL          = validators.ErrInvalidRepositoryURL
+	ErrInvalidSubfolderPath          = validators.ErrInvalidSubfolderPath
+	ErrPackageNameHasSpaces          = validators.ErrPackageNameHasSpaces
+	ErrReservedVersionString         = validators.ErrReservedVersionString
+	ErrVersionLooksLikeRange         = validators.ErrVersionLooksLikeRange
+	ErrInvalidPackageTransportURL    = validators.ErrInvalidPackageTransportURL
+	ErrInvalidRemoteURL              = validators.ErrInvalidRemoteURL
+	ErrUnsupportedRegistryBaseURL    = validators.ErrUnsupportedRegistryBaseURL
+	ErrMismatchedRegistryTypeAndURL  = validators.ErrMismatchedRegistryTypeAndURL
+	ErrNamedArgumentNameRequired     = validators.ErrNamedArgumentNameRequired
+	ErrInvalidNamedArgumentName      = validators.ErrInvalidNamedArgumentName
+	ErrArgumentValueStartsWithName   = validators.ErrArgumentValueStartsWithName
+	ErrArgumentDefaultStartsWithName = validators.ErrArgumentDefaultStartsWithName
+	ErrMultipleSlashesInServerName   = validators.ErrMultipleSlashesInServerName
+	ErrInvalidServerNameFormat       = validators.ErrInvalidServerNameFormat
+)
+
+// ValidateServerJSON performs exhaustive validation of a server.json document and
+// returns all issues found. opts specifies which types of validation to perform;
+// see the Validation* option presets for common configurations.
+func ValidateServerJSON(serverJSON *apiv0.ServerJSON, opts ValidationOptions) *ValidationResult {
+	return validators.ValidateServerJSON(serverJSON, opts)
+}
+
+// ValidatePackage validates that the package referenced in the server
+// configuration is allowed on the official registry (based on its registry type
+// and base URL) and is owned by the publisher, by checking for a matching server
+// name in the package metadata. It dispatches to the per-registry validator for
+// the package's registry type and may perform network calls against the upstream
+// package registry.
+func ValidatePackage(ctx context.Context, pkg model.Package, serverName string) error {
+	return validators.ValidatePackage(ctx, pkg, serverName)
+}

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -1,0 +1,65 @@
+package validators_test
+
+import (
+	"errors"
+	"testing"
+
+	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/modelcontextprotocol/registry/pkg/model"
+	"github.com/modelcontextprotocol/registry/pkg/validators"
+)
+
+// TestValidateServerJSON_PublicAPI exercises the public facade end to end: a
+// well-formed server.json passes, and a malformed one is reported as invalid.
+func TestValidateServerJSON_PublicAPI(t *testing.T) {
+	valid := &apiv0.ServerJSON{
+		Schema:      model.CurrentSchemaURL,
+		Name:        "com.example/test-server",
+		Description: "A test server",
+		Repository: &model.Repository{
+			URL:    "https://github.com/owner/repo",
+			Source: "github",
+		},
+		Version: "1.0.0",
+	}
+
+	result := validators.ValidateServerJSON(valid, validators.ValidationSchemaVersionAndSemantic)
+	if result == nil {
+		t.Fatal("expected a non-nil validation result")
+	}
+	if !result.Valid {
+		t.Fatalf("expected known-good server.json to be valid, got issues: %+v", result.Issues)
+	}
+
+	// A top-level version range is rejected by semantic validation.
+	invalid := &apiv0.ServerJSON{
+		Schema:      model.CurrentSchemaURL,
+		Name:        "com.example/test-server",
+		Description: "A test server",
+		Repository: &model.Repository{
+			URL:    "https://github.com/owner/repo",
+			Source: "github",
+		},
+		Version: "^1.2.3",
+	}
+
+	result = validators.ValidateServerJSON(invalid, validators.ValidationSchemaVersionAndSemantic)
+	if result.Valid {
+		t.Fatal("expected known-bad server.json (version range) to be invalid")
+	}
+	if err := result.FirstError(); err == nil {
+		t.Fatal("expected FirstError to return an error for an invalid result")
+	}
+}
+
+// TestSentinelErrorsAreMatchable confirms the re-exported sentinel errors are the
+// same values as the internal ones, so consumers can use errors.Is instead of
+// matching on error strings.
+func TestSentinelErrorsAreMatchable(t *testing.T) {
+	if !errors.Is(validators.ErrVersionLooksLikeRange, validators.ErrVersionLooksLikeRange) {
+		t.Fatal("sentinel error should match itself via errors.Is")
+	}
+	if validators.ErrVersionLooksLikeRange.Error() == "" {
+		t.Fatal("expected re-exported sentinel to carry a message")
+	}
+}


### PR DESCRIPTION
Addresses #1394 (phase 1).

## What this does

Adds a thin `pkg/validators` facade over the existing `internal/validators` package so the config-free validation logic can be imported and used as a library, without running a full registry. This covers the two common cases from the issue:

- `ValidateServerJSON(serverJSON, opts)` for schema/semantic validation of a `server.json`, plus the `Validation*` option presets and the `ValidationResult`/`ValidationIssue` types.
- `ValidatePackage(ctx, pkg, serverName)`, the per-registry ownership dispatcher (npm / PyPI / NuGet / OCI / MCPB / Cargo) that already lives in `internal/validators/package.go`.

This lets tools such as a private sub-registry, or a preflight check that runs in CI before a release tag is cut, validate locally instead of calling a deployed `/validate` endpoint.

The re-exported sentinel errors (e.g. `ErrVersionLooksLikeRange`) are aliases of the internal values, so consumers can use `errors.Is` rather than matching on error strings.

## Scope (phase 1 only)

Per the issue and the discussion, this intentionally exposes **only the config-free surface**. It uses a thin re-export facade to keep the diff small and leave all internal call sites compiling unchanged:

- `pkg/validators/validators.go`: the facade (doc-commented package + re-exports).
- `pkg/validators/validators_test.go`: a test that imports `pkg/validators` and validates a known-good and a known-bad `server.json` through the public API.

No existing files are modified.

**Deferred to follow-up phases** (noted for reviewers, not done here):

- `ValidatePublishRequest` / `ValidateUpdateRequest` take a `*config.Config` and gate on `EnableRegistryValidation`, so they need a config-decoupling design before they can live in `pkg/`.
- The authentication checks are currently embedded in the API auth handlers (e.g. `github_oidc.go`) and would be a broader refactor, as the issue notes.

## On typed outcomes

@sronix raised a good point in the thread about library consumers wanting typed outcomes (package missing vs ownership mismatch vs transient upstream error) rather than matching on error strings. This PR takes a first step by re-exporting the sentinel errors for `errors.Is`, but the per-registry validators still largely return formatted strings. Happy to iterate on a richer typed-error surface in this PR or a follow-up if maintainers prefer that direction. I didn't want to expand the blast radius here.

## Verification

Run with Go 1.26 on darwin/arm64:

- `go build ./...`: passes
- `go vet ./...`: clean
- `gofmt -l pkg/validators/`: no diffs
- `go test ./pkg/validators/... ./internal/validators/...`: passes

The DB-backed test packages (`internal/database`, `internal/service`, etc.) were not run in my environment because they require a local PostgreSQL/Docker; this change doesn't touch them.

Happy to adjust naming, scope, or the exported surface to match maintainer preferences.
