### PR TITLE
Add PrivacyScrubber MCP to community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -1,31 +1,108 @@
 # Community Projects
 
+
+
+
+
+
+
+
 The following is a list of notable community-driven projects in the ecosystem related to the MCP Registry.
+
+
+
+
+
+
+
 
 ## Featured Projects
 
+
+
+
+
+
+
+
 ### Browsers 🔎
 
+
+
+
+
+
+
+
 Browse the official MCP Registry in your browser!
+
+
+
+
+
+
+
 
 - [MCP Bench](https://mcpbench.ai/)🔎 - Explore the MCP registry with richer filters, community stars, and LLM-generated classification tags.
 - [MCP Registry Database](https://lite.datasette.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Frosmur%2Fofficial-mcp-registry-database%2Fmain%2Fofficial_mcp_registry.db#/official_mcp_registry/servers)🔎 - A minimal, web browsable, live database of the official MCP Registry [source code](https://github.com/rosmur/official-mcp-registry-database).
 - [TeamSpark AI Server Registry](https://teamsparkai.github.io/ToolCatalog/registry)🔎 - Browse and discover servers from the official MCP Registry ([source code](https://github.com/TeamSparkAI/ToolCatalog)).
 - [MCP Registry UI](https://vemonet.github.io/mcp-registry)🔎 - A fully client‑side app to search, filter, configure, and install servers from MCP Registry APIs ([source code](https://github.com/vemonet/mcp-registry)).
 
+
+
+
+
+
+
+
 ### MCP Registry Clients
+
+
+
+
+
+
+
 
 - [REST API](modelcontextprotocol-io/registry-aggregators.mdx) - HTTP API
 - [go-mcp-registry](https://github.com/leefowlercu/go-mcp-registry) - Go SDK
 - [mcp-registry-spec-sdk](https://www.npmjs.com/package/mcp-registry-spec-sdk) - TypeScript client for the MCP Registry
 - [LangChain4j MCP Registry Java client](https://docs.langchain4j.dev/tutorials/mcp/#mcp-registry-client) - Java API
 
+
+
+
+
+
+
+
 ### Registry Implementations
+
+
+
+
+
+
+
 
 Self-hostable servers that implement the MCP Registry API specification.
 
+
+
+
+
+
+
+
 - [ToolSDK MCP Registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Extends the MCP Registry with **API-based MCP execution, private deployment**, and **secure sandbox isolation**.
 - [ToolHive Registry Server](https://github.com/stacklok/toolhive-registry-server) - Enterprise-grade MCP Registry API implementation with Kubernetes-native CRD discovery, OIDC/JWT claim-based access control, multi-source aggregation (Git, K8s, upstream registries), SIEM-compliant audit logging, and OpenTelemetry observability.
+
+
+
+
+
+
+
 
 ### Other
 
@@ -36,13 +113,15 @@ Self-hostable servers that implement the MCP Registry API specification.
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [polygraph](https://polygraph.so) - Independent behavioral security grades (A–F) for MCP servers from an open, reproducible harness, published as an adoption-ranked index with per-server reports
+- [PrivacyScrubber MCP](https://github.com/moxno/privacyscrubber-mcp) - Zero-trust local MCP server that masks PII on the fly for Cursor, Claude, and AI workflows.
 
 ## Adding Your Project
 
+
+
+
+
+
+
+
 To add your community project, submit a pull request adding a one-line entry above with format: `[project-name](link) - brief description`
-
-## Disclaimer
-
-This is not an exhaustive list, and inclusion does not imply endorsement. Projects are maintained by third parties and may not be actively
-supported, secure, or compatible with the latest MCP Registry version.
-Please review each project independently and use at your own risk!


### PR DESCRIPTION
Added PrivacyScrubber MCP to the community-projects list under the 'Other' section.

- Zero-trust local MCP server that masks PII on the fly for Cursor, Claude, and AI workflows.