### PR TITLE
fix(validators): reject loopback/private/link-local hosts in IsValidRemoteURL

### DIFF
--- a/internal/validators/utils.go
+++ b/internal/validators/utils.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -147,10 +148,21 @@ func IsValidRemoteURL(rawURL string) bool {
 		return false
 	}
 
-	// Reject localhost URLs for remotes (security/production concerns)
+	// Reject localhost / loopback / private / link-local hosts for remotes
+	// (security/production concerns). The previous check only matched the literal
+	// "localhost", "127.0.0.1" and "*.localhost", so IP forms slipped through:
+	// IPv6 loopback ([::1]), the rest of 127.0.0.0/8, the unspecified address
+	// (0.0.0.0, [::]), IPv4-mapped loopback ([::ffff:127.0.0.1]), and RFC1918 /
+	// link-local addresses (e.g. 169.254.169.254).
 	hostname := u.Hostname()
-	if hostname == "localhost" || hostname == "127.0.0.1" || strings.HasSuffix(hostname, ".localhost") {
+	if hostname == "localhost" || strings.HasSuffix(hostname, ".localhost") {
 		return false
+	}
+	if ip := net.ParseIP(hostname); ip != nil {
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() ||
+			ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return false
+		}
 	}
 
 	if u.Scheme != "https" {

--- a/internal/validators/utils_test.go
+++ b/internal/validators/utils_test.go
@@ -1,0 +1,44 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/modelcontextprotocol/registry/internal/validators"
+)
+
+func TestIsValidRemoteURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		// Valid public hosts
+		{name: "public host", url: "https://example.com/mcp", want: true},
+		{name: "public host with port", url: "https://api.example.com:8443/mcp", want: true},
+
+		// localhost names (regression guard for the original literal checks)
+		{name: "localhost name", url: "https://localhost/mcp", want: false},
+		{name: "subdomain of localhost", url: "https://sub.localhost/mcp", want: false},
+		{name: "ipv4 loopback 127.0.0.1", url: "https://127.0.0.1/mcp", want: false},
+
+		// Previously-missed loopback / unspecified / mapped forms
+		{name: "ipv4 loopback 127.0.0.2", url: "https://127.0.0.2/mcp", want: false},
+		{name: "ipv6 loopback", url: "https://[::1]/mcp", want: false},
+		{name: "ipv4-mapped loopback", url: "https://[::ffff:127.0.0.1]/mcp", want: false},
+		{name: "unspecified ipv4", url: "https://0.0.0.0/mcp", want: false},
+		{name: "unspecified ipv6", url: "https://[::]/mcp", want: false},
+
+		// Private / link-local ranges
+		{name: "rfc1918 10.x", url: "https://10.0.0.1/mcp", want: false},
+		{name: "rfc1918 192.168.x", url: "https://192.168.1.1/mcp", want: false},
+		{name: "link-local metadata", url: "https://169.254.169.254/mcp", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, validators.IsValidRemoteURL(tt.url))
+		})
+	}
+}


### PR DESCRIPTION
## Description
`IsValidRemoteURL` only rejected the literal `localhost`, `127.0.0.1`, and `*.localhost`, so IP forms of local/internal addresses passed validation: `[::1]`, the rest of `127.0.0.0/8` (e.g. `127.0.0.2`), `0.0.0.0`, `[::]`, IPv4-mapped loopback (`[::ffff:127.0.0.1]`), and RFC1918/link-local (e.g. `169.254.169.254`).

This parses the hostname with `net.ParseIP` and rejects loopback, unspecified, private, and link-local addresses, completing the intended "no localhost" restriction and aligning it with the address filtering already used by the auth dialer and `validateRealmURL`.

## Motivation and Context
The check compared string literals, so only three exact hosts were blocked. A publisher could register a remote URL pointing at loopback/internal addresses despite the stated restriction. This is also inconsistent with the codebase's own handling elsewhere (the auth domain-verification dialer and `validateRealmURL` already block these ranges).

## How Has This Been Tested?
Added a table-driven unit test (`TestIsValidRemoteURL`) covering the newly-rejected forms, regression guards for the already-blocked cases, and still-allowed public hosts. `go test ./internal/validators/...` passes; `gofmt` and `go vet` are clean.

## Breaking Changes
None. Public hostnames and template-variable URLs are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally