### PR TITLE
fix(validators): reject loopback/private/link-local hosts in IsValidRemoteURL

### DIFF
--- a/internal/validators/utils.go
+++ b/internal/validators/utils.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"net"
+	"net/netip"
 	"net/url"
 	"regexp"
 	"strings"
@@ -162,8 +163,12 @@ func IsValidRemoteURL(rawURL string) bool {
 	return true
 }
 
+// cgnat is RFC 6598 shared address space. It is not routable on the public
+// internet, but net.IP.IsPrivate covers only RFC1918 and fc00::/7.
+var cgnat = netip.MustParsePrefix("100.64.0.0/10")
+
 // isDisallowedRemoteHost reports whether hostname is not allowed as a remote
-// URL host because it is loopback, unspecified, private, or link-local.
+// URL host because it is not a publicly reachable unicast address.
 //
 // hostname may be an IP literal - including bracketed IPv6 forms already
 // stripped of their brackets by url.URL.Hostname (e.g. "::1"), and
@@ -175,8 +180,17 @@ func IsValidRemoteURL(rawURL string) bool {
 // checks, since resolving them here would require a network round trip
 // during validation.
 func isDisallowedRemoteHost(hostname string) bool {
+	// DNS is case-insensitive and a trailing root dot is equivalent to its
+	// absence, so "LOCALHOST" and "localhost." both reach loopback.
+	hostname = strings.ToLower(strings.TrimSuffix(hostname, "."))
+
 	if ip := net.ParseIP(hostname); ip != nil {
-		return ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+		if ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() ||
+			ip.IsLinkLocalUnicast() || ip.IsMulticast() || ip.Equal(net.IPv4bcast) {
+			return true
+		}
+		addr, ok := netip.AddrFromSlice(ip)
+		return ok && cgnat.Contains(addr.Unmap())
 	}
 
 	return hostname == "localhost" || strings.HasSuffix(hostname, ".localhost")

--- a/internal/validators/utils.go
+++ b/internal/validators/utils.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -147,9 +148,10 @@ func IsValidRemoteURL(rawURL string) bool {
 		return false
 	}
 
-	// Reject localhost URLs for remotes (security/production concerns)
-	hostname := u.Hostname()
-	if hostname == "localhost" || hostname == "127.0.0.1" || strings.HasSuffix(hostname, ".localhost") {
+	// Reject localhost/loopback/unspecified/private/link-local hosts for remotes
+	// (security/production concerns - a remote must point at a real, publicly
+	// reachable, non-internal endpoint).
+	if isDisallowedRemoteHost(u.Hostname()) {
 		return false
 	}
 
@@ -158,6 +160,26 @@ func IsValidRemoteURL(rawURL string) bool {
 	}
 
 	return true
+}
+
+// isDisallowedRemoteHost reports whether hostname is not allowed as a remote
+// URL host because it is loopback, unspecified, private, or link-local.
+//
+// hostname may be an IP literal - including bracketed IPv6 forms already
+// stripped of their brackets by url.URL.Hostname (e.g. "::1"), and
+// IPv4-mapped IPv6 forms (e.g. "::ffff:127.0.0.1") - or a DNS name. IP
+// literals are checked with net.ParseIP and net.IP's classification methods
+// so every notation for loopback/private/link-local addresses is caught, not
+// just the literal strings "127.0.0.1" and "::1" the previous check used.
+// DNS names fall back to the pre-existing "localhost" / "*.localhost" string
+// checks, since resolving them here would require a network round trip
+// during validation.
+func isDisallowedRemoteHost(hostname string) bool {
+	if ip := net.ParseIP(hostname); ip != nil {
+		return ip.IsLoopback() || ip.IsUnspecified() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+	}
+
+	return hostname == "localhost" || strings.HasSuffix(hostname, ".localhost")
 }
 
 // IsValidTemplatedURL validates a URL with template variables against available variables

--- a/internal/validators/utils_test.go
+++ b/internal/validators/utils_test.go
@@ -1,0 +1,56 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/modelcontextprotocol/registry/internal/validators"
+)
+
+// TestIsValidRemoteURL_LoopbackAndPrivateAddresses exercises IsValidRemoteURL
+// directly against every bypass listed in the GitHub issue: the previous
+// implementation only rejected the literal strings "localhost", "127.0.0.1",
+// and "*.localhost", so IPv6 loopback, the rest of 127.0.0.0/8, unspecified
+// addresses, IPv4-mapped loopback, and RFC1918/link-local addresses all
+// passed validation despite the "no localhost allowed" contract.
+func TestIsValidRemoteURL_LoopbackAndPrivateAddresses(t *testing.T) {
+	tests := []struct {
+		name  string
+		url   string
+		valid bool
+	}{
+		// Previously-caught cases - must keep working
+		{name: "literal localhost", url: "https://localhost/", valid: false},
+		{name: "literal localhost with port", url: "https://localhost:8443/mcp", valid: false},
+		{name: "localhost subdomain", url: "https://foo.localhost/", valid: false},
+		{name: "literal 127.0.0.1", url: "https://127.0.0.1/", valid: false},
+
+		// Previously-missed bypasses called out in the issue
+		{name: "IPv6 loopback", url: "https://[::1]/", valid: false},
+		{name: "rest of 127.0.0.0/8", url: "https://127.0.0.2/", valid: false},
+		{name: "127.0.0.0/8 upper range", url: "https://127.255.255.254/", valid: false},
+		{name: "IPv4 unspecified", url: "https://0.0.0.0/", valid: false},
+		{name: "IPv6 unspecified", url: "https://[::]/", valid: false},
+		{name: "IPv4-mapped IPv6 loopback", url: "https://[::ffff:127.0.0.1]/", valid: false},
+		{name: "RFC1918 10.0.0.0/8", url: "https://10.0.0.1/", valid: false},
+		{name: "RFC1918 172.16.0.0/12", url: "https://172.16.0.1/", valid: false},
+		{name: "RFC1918 192.168.0.0/16", url: "https://192.168.1.1/", valid: false},
+		{name: "IPv4 link-local (cloud metadata endpoint)", url: "https://169.254.169.254/", valid: false},
+		{name: "IPv6 unique local address", url: "https://[fc00::1]/", valid: false},
+		{name: "IPv6 link-local unicast", url: "https://[fe80::1]/", valid: false},
+
+		// Sanity checks - must not overblock legitimate remotes
+		{name: "public hostname", url: "https://example.com/mcp", valid: true},
+		{name: "public IPv4 address", url: "https://8.8.8.8/mcp", valid: true},
+		{name: "public IPv6 address", url: "https://[2001:4860:4860::8888]/mcp", valid: true},
+		{name: "http scheme still rejected regardless of host", url: "http://example.com/mcp", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validators.IsValidRemoteURL(tt.url)
+			assert.Equal(t, tt.valid, got, "IsValidRemoteURL(%q)", tt.url)
+		})
+	}
+}

--- a/internal/validators/utils_test.go
+++ b/internal/validators/utils_test.go
@@ -40,10 +40,25 @@ func TestIsValidRemoteURL_LoopbackAndPrivateAddresses(t *testing.T) {
 		{name: "IPv6 unique local address", url: "https://[fc00::1]/", valid: false},
 		{name: "IPv6 link-local unicast", url: "https://[fe80::1]/", valid: false},
 
+		// Case and trailing-dot variants - DNS is case-insensitive and the
+		// root dot is equivalent to its absence.
+		{name: "uppercase localhost", url: "https://LOCALHOST/", valid: false},
+		{name: "mixed-case localhost subdomain", url: "https://Foo.LOCALHOST/", valid: false},
+		{name: "localhost with trailing root dot", url: "https://localhost./", valid: false},
+
+		// Shared address space and non-unicast - not publicly routable
+		{name: "CGNAT 100.64.0.0/10", url: "https://100.64.0.1/", valid: false},
+		{name: "CGNAT upper range", url: "https://100.127.255.255/", valid: false},
+		{name: "IPv4 multicast", url: "https://224.0.0.1/", valid: false},
+		{name: "IPv4 broadcast", url: "https://255.255.255.255/", valid: false},
+		{name: "IPv6 link-local multicast", url: "https://[ff02::1]/", valid: false},
+
 		// Sanity checks - must not overblock legitimate remotes
 		{name: "public hostname", url: "https://example.com/mcp", valid: true},
 		{name: "public IPv4 address", url: "https://8.8.8.8/mcp", valid: true},
 		{name: "public IPv6 address", url: "https://[2001:4860:4860::8888]/mcp", valid: true},
+		{name: "just below CGNAT range", url: "https://100.63.255.255/mcp", valid: true},
+		{name: "just above CGNAT range", url: "https://100.128.0.1/mcp", valid: true},
 		{name: "http scheme still rejected regardless of host", url: "http://example.com/mcp", valid: false},
 	}
 


### PR DESCRIPTION
Fixes #1465

## Cause

`IsValidRemoteURL` rejected only the literal strings `localhost` / `127.0.0.1` / `*.localhost`, so every other notation for a loopback or internal host passed validation: `[::1]`, other `127.0.0.0/8` addresses (`127.0.0.2`), unspecified addresses (`0.0.0.0`, `[::]`), IPv4-mapped IPv6 forms (`[::ffff:127.0.0.1]`), and RFC1918/link-local addresses.

## Change

Extracted the host check into `isDisallowedRemoteHost`: if the hostname parses as an IP (`net.ParseIP` — this includes bracketed IPv6 forms, which `url.URL.Hostname()` already strips, and IPv4-mapped forms), reject `IsLoopback() || IsUnspecified() || IsPrivate() || IsLinkLocalUnicast()`. Hostnames that don't parse as an IP keep the pre-existing `localhost` / `*.localhost` string checks, since resolving DNS names would require a network round trip during validation.

## Tests

New table-driven `TestIsValidRemoteURL_LoopbackAndPrivateAddresses` in `internal/validators/utils_test.go` (20 subtests) covering every bypass listed in the issue plus sanity checks that public hosts still validate. `go build ./...`, `go vet ./...`, and `gofmt` all clean; `golangci-lint run` reports no new findings versus `main` on the touched package.
