### PR TITLE
docs: remove Tadas as WG Lead

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The MCP registry provides MCP clients with a list of MCP servers, like an app st
 **2025-09-08 update**: The registry has launched in preview 🎉 ([announcement blog post](https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/)). While the system is now more stable, this is still a preview release and breaking changes or data resets may occur. A general availability (GA) release will follow later. We'd love your feedback in [GitHub discussions](https://github.com/modelcontextprotocol/registry/discussions/new?category=ideas) or in the [#registry-dev Discord](https://discord.com/channels/1358869848138059966/1369487942862504016) ([joining details here](https://modelcontextprotocol.io/community/communication)).
 
 Registry Working Group:
+- **Radoslav (Rado) Dimitrov** (Stacklok) [@rdimitrov](https://github.com/rdimitrov) - WG Lead
 - **Tadas Antanavicius** (PulseMCP) [@tadasant](https://github.com/tadasant)
-- **Radoslav (Rado) Dimitrov** (Stacklok) [@rdimitrov](https://github.com/rdimitrov)
 - **Bob Dickinson** (TeamSpark) [@BobDickinson](https://github.com/BobDickinson)
 - **Preeti (Pree) Dewani** (Ravenmail) [@pree-dew](https://github.com/pree-dew)
 


### PR DESCRIPTION
Per discussion with @rdimitrov, removing my listing as WG Lead of Registry so I can free up some time to work on [AI Catalog](https://github.com/Agent-Card/ai-catalog) and [Server Cards](https://github.com/modelcontextprotocol/experimental-ext-server-card).

FYI @BobDickinson @pree-dew 