### PR TITLE
docs: remove stale build.sh reference from publisher Key Files

### DIFF
--- a/cmd/publisher/README.md
+++ b/cmd/publisher/README.md
@@ -44,4 +44,3 @@ Optional: enables `dns` and `http` methods to sign out-of-process without direct
 - **`main.go`** - CLI setup and command routing
 - **`commands/`** - Command implementations with auto-detection logic
 - **`auth/`** - Authentication provider implementations
-- **`build.sh`** - Cross-platform build script


### PR DESCRIPTION
The Key Files list in `cmd/publisher/README.md` includes a bullet for `build.sh`, but there is no `build.sh` anywhere in the repo. The publisher is built with `make publisher`, which runs `go build -o bin/mcp-publisher ./cmd/publisher` (Makefile), so there is no separate cross-platform build script.

The other three entries in the same list (`main.go`, `commands/`, `auth/`) all exist. This removes the stale bullet so the list matches the actual files in the directory.
