### PR TITLE
chore(deploy): promote production to 1.8.1

### DIFF
--- a/deploy/Pulumi.gcpProd.yaml
+++ b/deploy/Pulumi.gcpProd.yaml
@@ -1,7 +1,7 @@
 config:
   mcp-registry:environment: prod
   mcp-registry:provider: gcp
-  mcp-registry:imageTag: 1.8.0  # Set specific image tag for production (change this to deploy different versions)
+  mcp-registry:imageTag: 1.8.1  # Set specific image tag for production (change this to deploy different versions)
   gcp:project: mcp-registry-prod
   mcp-registry:githubClientId: Iv23liUydBbI7Z2Q9bOZ
   mcp-registry:githubClientSecret:


### PR DESCRIPTION
## Summary

Promote the production registry image from `1.8.0` to [`1.8.1`](https://github.com/modelcontextprotocol/registry/releases/tag/v1.8.1).

This release includes #1509, which adds a short ingress cache and a scoped rate-limit increase for the exact public registry-list endpoints.

## Staging verification

- release tag points to `f52dc8525a441a3abf5fedc9912152d95af5aab1`, the commit deployed to staging
- staging deployment and CI workflows completed successfully
- both registry replicas became ready with zero restarts
- rendered NGINX configuration kept the root route at 180 RPM with buffering off
- exact `/v0/servers` and `/v0.1/servers` routes rendered at 600 RPM with buffering on
- live cache probe returned `MISS`, then `HIT`
- health and unrelated routes remained uncached
- no application 5xx, serious NGINX errors, or application error logs were observed after rollout

## Release artifact

- release workflow completed successfully
- `ghcr.io/modelcontextprotocol/registry:1.8.1` is available for `linux/amd64` and `linux/arm64`

## Deployment and rollback

Merging this PR triggers the production Pulumi deployment automatically. Monitor registry pod readiness, NGINX reloads, cache behavior, origin request volume, 429/499/5xx responses, and publish requests exceeding 10 seconds.

Rollback by restoring `mcp-registry:imageTag` to `1.8.0`.
