### PR TITLE
docs: add cargo and crates.io to schema examples

### DIFF
--- a/internal/validators/schemas/2025-12-11.json
+++ b/internal/validators/schemas/2025-12-11.json
@@ -239,6 +239,7 @@
           "examples": [
             "https://registry.npmjs.org",
             "https://pypi.org",
+            "https://crates.io",
             "https://docker.io",
             "https://api.nuget.org/v3/index.json",
             "https://github.com",
@@ -252,6 +253,7 @@
           "examples": [
             "npm",
             "pypi",
+            "cargo",
             "oci",
             "nuget",
             "mcpb"


### PR DESCRIPTION
The cargo registry type has been live since v1.8.0 (#1207).
This PR only updates the schema examples so they match reality.

- Add "cargo" to registryType.examples
- Add "https://crates.io" to registryBaseUrl.examples

No behaviour change.

Note: versioned schemas are synced from modelcontextprotocol/static.
A follow-up there keeps this durable across schema sync.