### PR TITLE
Fix broken relative links in releasing docs

### DIFF
--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -27,13 +27,13 @@ Releases do not automatically deploy to production. To deploy a release:
 
 1. Update `mcp-registry:imageTag` in `deploy/Pulumi.gcpProd.yaml` to the desired version (e.g., `1.2.3` - note: no 'v' prefix)
 2. Commit and push the change to the `main` branch (either through a PR or by pushing directly to main)
-3. The [deploy-production.yml](../../../.github/workflows/deploy-production.yml) workflow will automatically trigger and deploy the specified version
+3. The [deploy-production.yml](../../.github/workflows/deploy-production.yml) workflow will automatically trigger and deploy the specified version
 
-See the [deployment documentation](../../../deploy/README.md) for more details.
+See the [deployment documentation](../../deploy/README.md) for more details.
 
 ## Staging
 
-Staging auto-deploys from `main` via [deploy-staging.yml](../../../.github/workflows/deploy-staging.yml). It always runs the latest `main` branch code.
+Staging auto-deploys from `main` via [deploy-staging.yml](../../.github/workflows/deploy-staging.yml). It always runs the latest `main` branch code.
 
 ## Rollback
 


### PR DESCRIPTION
The three deployment links in `docs/contributing/releasing.md` use `../../../`, which resolves above the repository root and 404s on GitHub. The file lives in `docs/contributing/`, so the repo root is two levels up and `../../` is correct.

This fixes the links to `deploy-production.yml`, `deploy-staging.yml`, and `deploy/README.md` (all three targets exist at the repo root). No content change.
