### PR TITLE
docs(deploy): correct config parameter names in deploy README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -147,15 +147,20 @@ Pre-requisites:
 
 ## Configuration
 
+Configuration keys are namespaced. Set them with `pulumi config set <key> [--secret]`.
+
 | Parameter | Description | Required |
 |-----------|-------------|----------|
-| `environment` | Deployment environment (local/staging/prod) | Yes |
-| `provider` | Kubernetes provider (local/gcp) | No (default: local) |
-| `githubClientId` | GitHub OAuth Client ID | Yes |
-| `githubClientSecret` | GitHub OAuth Client Secret | Yes |
-| `imageTag` | Docker image tag for production environment | Yes (prod only) |
-| `gcpProjectId` | GCP Project ID (required when provider=gcp) | No |
-| `gcpRegion` | GCP Region (default: us-central1) | No |
+| `mcp-registry:environment` | Deployment environment (local/staging/prod) | Yes |
+| `mcp-registry:provider` | Kubernetes provider (local/gcp) | No (default: local) |
+| `mcp-registry:githubClientId` | GitHub OAuth Client ID | Yes |
+| `mcp-registry:githubClientSecret` | GitHub OAuth Client Secret | Yes (secret) |
+| `mcp-registry:jwtPrivateKey` | Ed25519 seed used to sign registry JWTs | Yes (secret) |
+| `mcp-registry:googleOauthClientSecret` | Google OAuth client secret for Grafana login | Yes (secret) |
+| `mcp-registry:imageTag` | Docker image tag for production environment | Yes (prod only) |
+| `gcp:project` | GCP Project ID | Yes when `provider=gcp` |
+| `gcp:region` | GCP Region | No (default: us-central1) |
+| `gcp:credentials` | GCP service account credentials JSON | No (secret; set in staging/prod) |
 
 ## Database Backups
 


### PR DESCRIPTION
The deploy configuration table named two parameters that **no code reads**, and omitted two that a deploy cannot succeed without.

## Wrong names

| Documented | Actual | Evidence |
|---|---|---|
| `gcpProjectId` | `gcp:project` | [provider.go:30](https://github.com/modelcontextprotocol/registry/blob/main/deploy/pkg/providers/gcp/provider.go#L30) — its error text literally says `Set gcp:project` |
| `gcpRegion` | `gcp:region` | [provider.go:36](https://github.com/modelcontextprotocol/registry/blob/main/deploy/pkg/providers/gcp/provider.go#L36), default `us-central1` |

`gcpProjectId` and `gcpRegion` appear **nowhere** in `deploy/` outside this table. All three stack files (`Pulumi.gcpProd.yaml`, `Pulumi.gcpStaging.yaml`, `Pulumi.local.yaml`) already use `gcp:project`.

## Missing required secrets

Both are `RequireSecret`, so a deploy fails outright without them — yet neither was in the table:

- `mcp-registry:jwtPrivateKey` — [registry.go:56](https://github.com/modelcontextprotocol/registry/blob/main/deploy/pkg/k8s/registry.go#L56)
- `mcp-registry:googleOauthClientSecret` — [monitoring.go:463](https://github.com/modelcontextprotocol/registry/blob/main/deploy/pkg/k8s/monitoring.go#L463)

## Also

- Documents `gcp:credentials` (read at [provider.go:42](https://github.com/modelcontextprotocol/registry/blob/main/deploy/pkg/providers/gcp/provider.go#L42), set in the staging and prod stacks)
- Marks which values are secrets
- **Adds the namespace prefixes.** The table listed bare names, which is part of why the two wrong ones survived: `gcpProjectId` reads as plausible right up until you notice the real key lives in a different config namespace altogether.

## Verification

Checked both directions:
- every key now in the table is read by code in `deploy/` (reference counts confirmed per key)
- every `conf.*("...")` key found anywhere in `deploy/` now appears in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)