### PR TITLE
docs: state field length limits in the publishing quickstart

### DIFF
--- a/docs/modelcontextprotocol-io/quickstart.mdx
+++ b/docs/modelcontextprotocol-io/quickstart.mdx
@@ -185,6 +185,10 @@ Open the generated `server.json` file, and you should see contents like:
 }
 ```
 
+<Note>
+  Free-form text fields are validated at publish time. In the current schema, `description` and `title` are limited to 100 characters each, `name` to 200, and version strings to 255. A longer value causes `mcp-publisher publish` to fail with a schema validation error.
+</Note>
+
 Edit the contents as necessary:
 
 ```diff server.json


### PR DESCRIPTION
The server.json schema enforces length limits on free-form fields (in the 2025-12-11 schema: `description` and `title` 100 characters, `name` 200, version strings 255), but none of the user-facing docs state them; about.mdx only mentions "strict character limits" without numbers. Hitting the `description` limit is a common first-publish failure: `mcp-publisher init` generates the field, the publisher writes a sentence or two, and publish/validate fails with a schema error that has to be traced back to the length. #1184 asks for exactly this documentation.

This adds one note to the quickstart at the point where the publisher first edits `server.json`, so the limits are visible before the first publish attempt. Complements #1267, which improves the validator's error message for the same failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
