### PR TITLE
fix(publisher): accept UTF-8 BOM in server.json

### DIFF
--- a/cmd/publisher/commands/publish.go
+++ b/cmd/publisher/commands/publish.go
@@ -28,6 +28,7 @@ func PublishCommand(args []string) error {
 		}
 		return fmt.Errorf("failed to read server.json: %w", err)
 	}
+	serverData = stripUTF8BOM(serverData)
 	if err := validateJSONUnicode(serverFile, serverData); err != nil {
 		return err
 	}

--- a/cmd/publisher/commands/publish_test.go
+++ b/cmd/publisher/commands/publish_test.go
@@ -81,6 +81,20 @@ func TestPublishCommand_RejectsInvalidUTF8ServerJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "UTF-8")
 }
 
+func TestPublishCommand_AcceptsUTF8BOM(t *testing.T) {
+	// Windows tools such as PowerShell's Out-File write UTF-8 with a leading
+	// byte order mark; RFC 8259 permits parsers to ignore it.
+	server := SetupMockRegistryServer(t, nil, nil)
+	SetupTestToken(t, server.URL, "test-token")
+
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	body := []byte(`{"$schema":"` + model.CurrentSchemaURL + `","name":"com.example/test","description":"A test server","version":"1.0.0"}`)
+	createRawServerJSON(t, append(bom, body...))
+
+	err := commands.PublishCommand([]string{})
+	assert.NoError(t, err)
+}
+
 func TestPublishCommand_RejectsUnpairedSurrogateEscape(t *testing.T) {
 	createRawServerJSON(t, []byte(`{"$schema":"","name":"com.example/test","description":"bad \udc94","version":"1.0.0"}`))
 

--- a/cmd/publisher/commands/unicode.go
+++ b/cmd/publisher/commands/unicode.go
@@ -8,6 +8,17 @@ import (
 	"unicode/utf8"
 )
 
+// utf8BOM is the UTF-8 byte order mark. Some Windows tools (e.g. PowerShell's
+// Out-File) prepend it when writing UTF-8 files. RFC 8259 permits JSON parsers
+// to ignore it, but Go's encoding/json rejects it, so it is stripped before
+// parsing.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripUTF8BOM returns data without a leading UTF-8 byte order mark.
+func stripUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
+
 func validateJSONUnicode(filename string, data []byte) error {
 	if !utf8.Valid(data) {
 		return fmt.Errorf("%s must be encoded as UTF-8", filename)

--- a/cmd/publisher/commands/validate.go
+++ b/cmd/publisher/commands/validate.go
@@ -142,6 +142,7 @@ func ValidateCommand(args []string) error {
 		}
 		return fmt.Errorf("failed to read %s: %w", serverFile, err)
 	}
+	serverData = stripUTF8BOM(serverData)
 	if err := validateJSONUnicode(serverFile, serverData); err != nil {
 		return err
 	}

--- a/cmd/publisher/commands/validate_test.go
+++ b/cmd/publisher/commands/validate_test.go
@@ -136,6 +136,20 @@ func TestValidateCommand_DeprecatedSchema(t *testing.T) {
 	assert.Contains(t, err.Error(), "Migration checklist:")
 }
 
+func TestValidateCommand_AcceptsUTF8BOM(t *testing.T) {
+	// Windows tools such as PowerShell's Out-File write UTF-8 with a leading
+	// byte order mark; RFC 8259 permits parsers to ignore it.
+	server := SetupMockRegistryServer(t, nil, nil)
+	SetupTestToken(t, server.URL, "test-token")
+
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	body := []byte(`{"$schema":"` + model.CurrentSchemaURL + `","name":"com.example/test","description":"A test server","version":"1.0.0"}`)
+	createRawServerJSON(t, append(bom, body...))
+
+	err := commands.ValidateCommand([]string{})
+	assert.NoError(t, err)
+}
+
 func TestValidateCommand_NoServerFile(t *testing.T) {
 	server := SetupMockRegistryServer(t, nil, nil)
 	SetupTestToken(t, server.URL, "test-token")


### PR DESCRIPTION
On Windows, PowerShell 5.1's `Out-File -Encoding utf8` (and several editors) write UTF-8 files with a leading byte order mark. Go's `encoding/json` does not skip the BOM, so `mcp-publisher publish` and `mcp-publisher validate` fail on such server.json files with the cryptic error `invalid character 'ï' looking for beginning of value`. RFC 8259 section 8.1 says implementations may ignore a leading BOM, and we hit this in practice publishing a server from a Windows machine.

This change strips a leading UTF-8 BOM (EF BB BF) from server.json bytes right after the file is read in both the publish and validate commands, using a small shared helper next to the existing UTF-8 validation in unicode.go. Both downstream request paths receive the cleaned bytes, so behavior is otherwise unchanged. Adds two tests that run a BOM-prefixed server.json through the full publish and validate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
