### PR TITLE
docs: add mcp-server-audit to Community Projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -36,6 +36,7 @@ Self-hostable servers that implement the MCP Registry API specification.
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [polygraph](https://polygraph.so) - Independent behavioral security grades (A–F) for MCP servers from an open, reproducible harness, published as an adoption-ranked index with per-server reports
+- [mcp-server-audit](https://github.com/Yveshby27/mcp-server-audit) - Pre-install validation CLI for MCP servers. Runs 4 install-time checks (handshake, descriptor, capabilities, tool schemas) against any server before adding it to your client config.
 
 ## Adding Your Project
 


### PR DESCRIPTION
## Motivation and Context
Adds mcp-server-audit to the Community Projects "Other" subsection. Slots alongside polygraph as a validation/analysis tool for MCP servers users may find in the registry before they install them.

## Types of changes
- [x] Documentation update

## Additional context
mcp-server-audit is a pre-install validation CLI for MCP servers. Runs 4 install-time checks (handshake, descriptor, capabilities, tool schemas) against any MCP server before you add it to your client config, so silent install failures and spec violations surface before deployment.

- Repo: [Yveshby27/mcp-server-audit](https://github.com/Yveshby27/mcp-server-audit)
- PyPI: [mcp-server-audit](https://pypi.org/project/mcp-server-audit/)
- Install: `pip install mcp-server-audit` then run `mcp-audit`
- Background: [MCP install-time quality gap](https://habchy.dev/research/mcp-install-time-quality-gap)