### PR TITLE
Add com.aradia/sovereign-hardware MCP Server

### DIFF
--- a/servers/com.aradia/sovereign-hardware.json
+++ b/servers/com.aradia/sovereign-hardware.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/modelcontextprotocol/registry/main/data/server.schema.json",
+  "name": "com.aradia/sovereign-hardware",
+  "title": "Aradia Sovereign AI Infrastructure",
+  "description": "Autonomous MCP interface for querying on-premise NVIDIA DGX private AI Agent hardware specs, modeling CapEx token ROI, executing M2M procurement, and onboarding into the Aradia Partner Program.",
+  "version": "1.0.0",
+  "websiteUrl": "https://aradia.com",
+  "repository": {
+    "url": "https://github.com/ARADIA-systems",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "sse",
+      "url": "https://aradia.com/api/a2a/mcp-endpoint.php"
+    }
+  ]
+}


### PR DESCRIPTION
### Server Description
Adds the Aradia Sovereign AI Infrastructure MCP server (`com.aradia/sovereign-hardware`).

- **Domain:** https://aradia.com
- **Server Card:** https://aradia.com/.well-known/mcp/server-card.json
- **Transport:** SSE (`https://aradia.com/api/a2a/mcp-endpoint.php`)
- **Tools:** `query_hardware_specs`, `calculate_roi`, `execute_procurement_order`, `aradia_partner_onboard`