### PR TITLE
fix(validators): reject incomplete repository metadata

### DIFF
--- a/internal/api/handlers/v0/publish_test.go
+++ b/internal/api/handlers/v0/publish_test.go
@@ -103,6 +103,25 @@ func TestPublishEndpoint(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
+			name: "reject publish with empty repository",
+			requestBody: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "example/test-server",
+				Description: "A test server",
+				Repository:  &model.Repository{},
+				Version:     "1.0.0",
+			},
+			tokenClaims: &auth.JWTClaims{
+				AuthMethod: auth.MethodNone,
+				Permissions: []auth.Permission{
+					{Action: auth.PermissionActionPublish, ResourcePattern: "example/*"},
+				},
+			},
+			setupRegistryService: func(_ service.RegistryService) {},
+			expectedStatus:       http.StatusUnprocessableEntity,
+			expectedError:        "Failed to publish server, invalid schema: call /validate for details",
+		},
+		{
 			name:        "missing authorization header",
 			requestBody: apiv0.ServerJSON{},
 			authHeader:  "", // Empty auth header

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -119,8 +119,32 @@ func ValidateServerJSON(serverJSON *apiv0.ServerJSON, opts ValidationOptions) *V
 func validateRepository(ctx *ValidationContext, obj *model.Repository) *ValidationResult {
 	result := &ValidationResult{Valid: true, Issues: []ValidationIssue{}}
 
-	// Skip validation if repository is nil or empty (optional field)
-	if obj == nil || (obj.URL == "" && obj.Source == "") {
+	// The repository field is optional, but its required fields must be present
+	// when the repository object itself is provided.
+	if obj == nil {
+		return result
+	}
+	if obj.URL == "" {
+		issue := NewValidationIssue(
+			ValidationIssueTypeSemantic,
+			ctx.Field("url").String(),
+			"repository url is required when repository is provided",
+			ValidationIssueSeverityError,
+			"repository-url-required",
+		)
+		result.AddIssue(issue)
+	}
+	if obj.Source == "" {
+		issue := NewValidationIssue(
+			ValidationIssueTypeSemantic,
+			ctx.Field("source").String(),
+			"repository source is required when repository is provided",
+			ValidationIssueSeverityError,
+			"repository-source-required",
+		)
+		result.AddIssue(issue)
+	}
+	if !result.Valid {
 		return result
 	}
 

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -250,6 +250,16 @@ func TestValidate(t *testing.T) {
 			expectedError: validators.ErrMultipleSlashesInServerName.Error(),
 		},
 		{
+			name: "server without repository",
+			serverDetail: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/test-server",
+				Description: "A test server",
+				Version:     "1.0.0",
+			},
+			expectedError: "",
+		},
+		{
 			name: "valid server detail with all fields",
 			serverDetail: apiv0.ServerJSON{
 				Schema:      model.CurrentSchemaURL,
@@ -280,6 +290,43 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			expectedError: "",
+		},
+		{
+			name: "server with empty repository",
+			serverDetail: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/test-server",
+				Description: "A test server",
+				Repository:  &model.Repository{},
+				Version:     "1.0.0",
+			},
+			expectedError: "repository url is required when repository is provided",
+		},
+		{
+			name: "server with repository missing URL",
+			serverDetail: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/test-server",
+				Description: "A test server",
+				Repository: &model.Repository{
+					Source: "github",
+				},
+				Version: "1.0.0",
+			},
+			expectedError: "repository url is required when repository is provided",
+		},
+		{
+			name: "server with repository missing source",
+			serverDetail: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/test-server",
+				Description: "A test server",
+				Repository: &model.Repository{
+					URL: "https://github.com/owner/repo",
+				},
+				Version: "1.0.0",
+			},
+			expectedError: "repository source is required when repository is provided",
 		},
 		{
 			name: "server with invalid repository source",


### PR DESCRIPTION
Fixes #1546

## What changed

- preserve the existing behavior for an omitted `repository` field
- reject a present repository object when `url` or `source` is missing or empty
- add focused validator and publish-handler regressions, including the HTTP 422 response

## Validation

- focused repository validator cases: pass
- publish endpoint regression and success controls: pass
- full `TestPublishEndpoint` table: pass
- `go vet` for the affected packages: pass
- `git diff --check`: pass

The broader validators package was also attempted. Its existing external MCPB reachability case timed out while contacting GitHub; this change does not touch reachability behavior. `golangci-lint` was not available in the validation environment.

No public API shape is changed.