### PR TITLE
feat(search): match server descriptions as well as names

### DIFF
--- a/docs/reference/api/CHANGELOG.md
+++ b/docs/reference/api/CHANGELOG.md
@@ -27,6 +27,15 @@ New fields added to `_meta["io.modelcontextprotocol.registry/official"]` (Regist
 - `statusChangedAt` - Timestamp when the server status was last changed
 - `statusMessage` - Optional message explaining status change (e.g., deprecation reason, migration guidance)
 
+#### Search matches the description
+
+`GET /v0/servers?search=` now matches a server's `description` as well as its name; a term found in
+either field returns the server. Previously only the name was matched, so a server whose name is a
+product name rather than a category name could not be found by its own subject.
+
+This widens what an existing query returns — a search that matched nothing but names before may now
+return additional servers.
+
 #### Server Filtering Enhancements
 
 New `include_deleted` query parameter added to multiple endpoints:

--- a/docs/reference/api/official-registry-api.md
+++ b/docs/reference/api/official-registry-api.md
@@ -38,7 +38,7 @@ The official registry enforces additional [package validation requirements](../s
 The official registry extends the `GET /v0.1/servers` endpoint with additional query parameters for improved discovery and synchronization:
 
 - `updated_since` - Filter servers updated after RFC3339 timestamp (e.g., `2025-08-07T13:15:04.280Z`)
-- `search` - Case-insensitive substring search on server names (e.g., `filesystem`)
+- `search` - Case-insensitive substring search on server names and descriptions (e.g., `filesystem`)
     - This is intentionally simple. For more advanced searching and filtering, use a subregistry.
 - `version` - Filter by version (currently supports `latest` for latest versions only)
 - `include_deleted` - Include deleted servers in results (default: `false`, but automatically `true` when `updated_since` is provided for incremental sync)

--- a/docs/reference/api/openapi.yaml
+++ b/docs/reference/api/openapi.yaml
@@ -41,7 +41,7 @@ paths:
             type: integer
         - name: search
           in: query
-          description: Search servers by name (substring match)
+          description: Search servers by name or description (substring match)
           required: false
           schema:
             type: string

--- a/internal/api/handlers/v0/servers.go
+++ b/internal/api/handlers/v0/servers.go
@@ -58,7 +58,7 @@ type ListServersInput struct {
 	Cursor         string       `query:"cursor" doc:"Pagination cursor" required:"false" example:"server-cursor-123"`
 	Limit          int          `query:"limit" doc:"Number of items per page" default:"30" minimum:"1" maximum:"100" example:"50"`
 	UpdatedSince   string       `query:"updated_since" doc:"Filter servers updated since timestamp (RFC3339 datetime)" required:"false" example:"2025-08-07T13:15:04.280Z"`
-	Search         string       `query:"search" doc:"Search servers by name (substring match)" required:"false" example:"filesystem"`
+	Search         string       `query:"search" doc:"Search servers by name or description (substring match)" required:"false" example:"filesystem"`
 	Version        string       `query:"version" doc:"Filter by version ('latest' for latest version, or an exact version like '1.2.3')" required:"false" example:"latest"`
 	IncludeDeleted OptionalBool `query:"include_deleted" doc:"Include deleted servers in results (default: false, but always true when updated_since is provided)" required:"false"`
 }
@@ -107,7 +107,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 
 		// Handle search parameter
 		if input.Search != "" {
-			filter.SubstringName = &input.Search
+			filter.Search = &input.Search
 		}
 
 		// Handle version parameter

--- a/internal/api/handlers/v0/servers_test.go
+++ b/internal/api/handlers/v0/servers_test.go
@@ -41,6 +41,16 @@ func TestListServersEndpoint(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Its subject appears only in the description, never in a name — the case
+	// that returned nothing before search covered the description.
+	_, err = registryService.CreateServer(ctx, &apiv0.ServerJSON{
+		Schema:      model.CurrentSchemaURL,
+		Name:        "com.example/server-gamma",
+		Description: "Weather forecasts for pilots",
+		Version:     "1.0.0",
+	})
+	require.NoError(t, err)
+
 	// Create API
 	mux := http.NewServeMux()
 	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
@@ -57,7 +67,7 @@ func TestListServersEndpoint(t *testing.T) {
 			name:           "list all servers",
 			queryParams:    "",
 			expectedStatus: http.StatusOK,
-			expectedCount:  2,
+			expectedCount:  3,
 		},
 		{
 			name:           "list with limit",
@@ -66,8 +76,14 @@ func TestListServersEndpoint(t *testing.T) {
 			expectedCount:  1,
 		},
 		{
-			name:           "search servers",
+			name:           "search servers by name",
 			queryParams:    "?search=alpha",
+			expectedStatus: http.StatusOK,
+			expectedCount:  1,
+		},
+		{
+			name:           "search servers by description",
+			queryParams:    "?search=weather",
 			expectedStatus: http.StatusOK,
 			expectedCount:  1,
 		},
@@ -75,7 +91,7 @@ func TestListServersEndpoint(t *testing.T) {
 			name:           "filter latest only",
 			queryParams:    "?version=latest",
 			expectedStatus: http.StatusOK,
-			expectedCount:  2,
+			expectedCount:  3,
 		},
 		{
 			name:           "invalid limit",

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -25,7 +25,7 @@ type ServerFilter struct {
 	Name           *string    // for finding versions of same server
 	RemoteURL      *string    // for duplicate URL detection
 	UpdatedSince   *time.Time // for incremental sync filtering
-	SubstringName  *string    // for substring search on name
+	Search         *string    // for substring search on name or description
 	Version        *string    // for exact version matching
 	IsLatest       *bool      // for filtering latest versions only
 	IncludeDeleted *bool      // for including deleted packages in results (default: exclude)

--- a/internal/database/migrations/015_add_search_trgm_indexes.sql
+++ b/internal/database/migrations/015_add_search_trgm_indexes.sql
@@ -1,0 +1,24 @@
+-- Trigram indexes for the ?search= filter.
+--
+-- The filter matches with ILIKE '%term%' against server_name and, as of #1453,
+-- against the description inside the JSON value. A leading wildcard cannot use a
+-- btree index, so every search has been a sequential scan over the table — that
+-- was already true for the name alone; adding the description to the same scan
+-- does not change how many rows are visited, but it is a good moment to make
+-- both sides indexable. See also #1252 on list latency.
+--
+-- pg_trgm is already enabled by 001_initial_schema.sql, but no trigram index was
+-- ever created against it. GIN + gin_trgm_ops is what makes an unanchored ILIKE
+-- indexable. It applies to search terms of three characters or more; shorter
+-- ones still fall back to a scan, which is the pre-existing behaviour.
+--
+-- Built non-concurrently on purpose: the migration framework wraps each migration
+-- in its own transaction, which forbids CREATE INDEX CONCURRENTLY, and the table
+-- is small — the note in postgres.go measured production at ~21K rows on
+-- 2026-04-28 — so the exclusive lock is momentary.
+
+CREATE INDEX IF NOT EXISTS idx_servers_server_name_trgm
+    ON servers USING GIN (server_name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_servers_description_trgm
+    ON servers USING GIN ((value ->> 'description') gin_trgm_ops);

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -117,13 +117,23 @@ func buildFilterConditions(filter *ServerFilter, argIndex int) ([]string, []any,
 		args = append(args, *filter.UpdatedSince)
 		argIndex++
 	}
-	if filter.SubstringName != nil {
+	if filter.Search != nil {
+		// Matches the name OR the description. A server is looked for by what it
+		// does at least as often as by what it is called, and a name is a brand:
+		// `io.github.<owner>/<product>` is what the publishing docs steer authors
+		// toward, so a server named after its product rather than its category was
+		// unfindable by its own subject. See #1453.
+		//
 		// Escape LIKE metacharacters so that user input cannot expand into
 		// wildcard matches (e.g. `?search=_` matching every single-char name,
 		// `?search=%` matching everything). Order matters: backslashes must be
 		// escaped first so subsequent escape backslashes are not double-escaped.
-		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(*filter.SubstringName)
-		conditions = append(conditions, fmt.Sprintf("server_name ILIKE $%d ESCAPE '\\'", argIndex))
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(*filter.Search)
+		// One placeholder used twice: both columns take the same pattern, so the
+		// argument list — and therefore every caller's arg index — is unchanged.
+		conditions = append(conditions, fmt.Sprintf(
+			"(server_name ILIKE $%[1]d ESCAPE '\\' OR value ->> 'description' ILIKE $%[1]d ESCAPE '\\')",
+			argIndex))
 		args = append(args, "%"+escaped+"%")
 		argIndex++
 	}

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -330,9 +330,9 @@ func TestPostgreSQL_ListServers(t *testing.T) {
 			expectedNames: []string{"com.example/server-b"},
 		},
 		{
-			name: "filter by substring name",
+			name: "filter by search term matching the name",
 			filter: &database.ServerFilter{
-				SubstringName: stringPtr("server-"),
+				Search: stringPtr("server-"),
 			},
 			limit:         10,
 			expectedCount: 3,
@@ -402,6 +402,99 @@ func TestPostgreSQL_ListServers(t *testing.T) {
 			if tt.limit < len(testServers) && len(results) == tt.limit {
 				assert.NotEmpty(t, nextCursor, "Should return next cursor when results are limited")
 			}
+		})
+	}
+}
+
+func TestPostgreSQL_ListServersSearch(t *testing.T) {
+	db := database.NewTestDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Names and descriptions are deliberately crossed: "weather" is in one
+	// server's name and in another's description, so a search for it can only
+	// return both if the two fields are really OR'd. The third carries LIKE
+	// metacharacters in its description, which is where the escaping is proved.
+	testServers := []struct {
+		name        string
+		description string
+	}{
+		{"com.example/alpha-tool", "Weather forecasts for pilots"},
+		{"com.example/weather-cli", "Unrelated subject entirely"},
+		{"com.example/gamma", "Reports 100% of coverage_report runs"},
+	}
+	for _, ts := range testServers {
+		serverJSON := &apiv0.ServerJSON{
+			Name:        ts.name,
+			Description: ts.description,
+			Version:     testVersion100,
+			Remotes:     []model.Transport{{Type: "http", URL: "https://api.example.com/mcp"}},
+		}
+		officialMeta := &apiv0.RegistryExtensions{
+			Status:          model.StatusActive,
+			StatusChangedAt: now,
+			PublishedAt:     now,
+			UpdatedAt:       now,
+			IsLatest:        true,
+		}
+		_, err := db.CreateServer(ctx, nil, serverJSON, officialMeta)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name          string
+		search        string
+		expectedNames []string
+	}{
+		{
+			name:          "matches the name",
+			search:        "alpha",
+			expectedNames: []string{"com.example/alpha-tool"},
+		},
+		{
+			name:          "matches the description — the point of #1453",
+			search:        "forecasts",
+			expectedNames: []string{"com.example/alpha-tool"},
+		},
+		{
+			name:          "matches either field, not both",
+			search:        "weather",
+			expectedNames: []string{"com.example/alpha-tool", "com.example/weather-cli"},
+		},
+		{
+			name:          "is case-insensitive on the description too",
+			search:        "WEATHER",
+			expectedNames: []string{"com.example/alpha-tool", "com.example/weather-cli"},
+		},
+		{
+			// Without escaping this would match every row through both columns.
+			name:          "treats % as a literal, not a wildcard",
+			search:        "100%",
+			expectedNames: []string{"com.example/gamma"},
+		},
+		{
+			// Likewise `_`, which would otherwise match any single character.
+			name:          "treats _ as a literal, not a single-character wildcard",
+			search:        "coverage_report",
+			expectedNames: []string{"com.example/gamma"},
+		},
+		{
+			name:          "returns nothing when neither field matches",
+			search:        "nonexistent",
+			expectedNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, _, err := db.ListServers(ctx, nil, &database.ServerFilter{Search: &tt.search}, "", 10)
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(results))
+			for _, r := range results {
+				names = append(names, r.Server.Name)
+			}
+			assert.ElementsMatch(t, tt.expectedNames, names)
 		})
 	}
 }
@@ -922,10 +1015,10 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 
 		// Test multiple filters combined
 		filter := &database.ServerFilter{
-			SubstringName: stringPtr("complex"),
-			UpdatedSince:  timePtr(testTime.Add(-30 * time.Minute)),
-			IsLatest:      boolPtr(true),
-			Version:       stringPtr("1.0.0"),
+			Search:       stringPtr("complex"),
+			UpdatedSince: timePtr(testTime.Add(-30 * time.Minute)),
+			IsLatest:     boolPtr(true),
+			Version:      stringPtr("1.0.0"),
 		}
 
 		results, _, err := db.ListServers(ctx, nil, filter, "", 10)
@@ -1229,7 +1322,7 @@ func TestPostgreSQL_PerformanceScenarios(t *testing.T) {
 		cursor := ""
 		for {
 			rs, next, err := db.ListServers(ctx, nil,
-				&database.ServerFilter{SubstringName: stringPtr("cursor-test-")},
+				&database.ServerFilter{Search: stringPtr("cursor-test-")},
 				cursor, 2)
 			require.NoError(t, err)
 			paged = append(paged, rs...)
@@ -1705,7 +1798,7 @@ func TestPostgreSQL_IncludeDeletedFilter(t *testing.T) {
 
 	t.Run("excludes deleted by default (nil IncludeDeleted)", func(t *testing.T) {
 		filter := &database.ServerFilter{
-			SubstringName: stringPtr("deleted-filter"),
+			Search: stringPtr("deleted-filter"),
 		}
 
 		results, _, err := db.ListServers(ctx, nil, filter, "", 10)
@@ -1730,7 +1823,7 @@ func TestPostgreSQL_IncludeDeletedFilter(t *testing.T) {
 
 	t.Run("excludes deleted when IncludeDeleted is false", func(t *testing.T) {
 		filter := &database.ServerFilter{
-			SubstringName:  stringPtr("deleted-filter"),
+			Search:         stringPtr("deleted-filter"),
 			IncludeDeleted: boolPtr(false),
 		}
 
@@ -1748,7 +1841,7 @@ func TestPostgreSQL_IncludeDeletedFilter(t *testing.T) {
 
 	t.Run("includes deleted when IncludeDeleted is true", func(t *testing.T) {
 		filter := &database.ServerFilter{
-			SubstringName:  stringPtr("deleted-filter"),
+			Search:         stringPtr("deleted-filter"),
 			IncludeDeleted: boolPtr(true),
 		}
 
@@ -1772,7 +1865,7 @@ func TestPostgreSQL_IncludeDeletedFilter(t *testing.T) {
 	t.Run("combined filters with include deleted", func(t *testing.T) {
 		// Test that IncludeDeleted works correctly with other filters
 		filter := &database.ServerFilter{
-			SubstringName:  stringPtr("deleted-filter"),
+			Search:         stringPtr("deleted-filter"),
 			Version:        stringPtr("1.0.0"),
 			IsLatest:       boolPtr(true),
 			IncludeDeleted: boolPtr(true),


### PR DESCRIPTION
Closes #1453.

`?search=` matched `server_name` only, so a server was findable by what it is *called* but not by
what it *does*. That splits the ecosystem along a line nobody chose: `io.github.<owner>/<product>`
is what the publishing docs steer authors toward, and a product name is a brand, not a category — so
servers named after the thing they integrate with are findable, and servers with a real product name
are not. It is also invisible to the publisher: the entry is `active` and `isLatest`, everything
reports success, and the obvious query simply never returns it.

## What changed

`ServerFilter.SubstringName` becomes `ServerFilter.Search`, and the condition it builds now covers
both columns:

```sql
(server_name ILIKE $1 ESCAPE '\' OR value ->> 'description' ILIKE $1 ESCAPE '\')
```

- **One placeholder, used twice.** Both columns take the same pattern, so the argument list — and
  with it every caller's `argIndex` — is unchanged.
- **The existing LIKE-metacharacter escaping is untouched and now protects both columns.** Without it
  `?search=%` would match every row through either field.
- **The field is renamed rather than duplicated.** It exists solely to serve `?search=`, and calling
  it `SubstringName` while it also searches the description would be worse than the diff.

## Performance

Adding a second `ILIKE '%term%'` to an existing scan does not change how many rows are visited: a
leading wildcard could never use a btree index, so `?search=` has always been a sequential scan over
`servers`. This makes each row's check slightly more expensive.

Migration `015` therefore adds the two GIN trigram indexes that make both sides indexable.
`pg_trgm` has been enabled since `001_initial_schema.sql` but no trigram index was ever created
against it. Details and the trade-offs are in the migration's own comment: the indexes apply to
search terms of three characters or more (shorter ones fall back to the scan, which is today's
behaviour either way), and the index is built non-concurrently because the migration framework wraps
each migration in a transaction and the table is small — the note in `postgres.go` measured
production at ~21K rows on 2026-04-28.

**What I could not verify:** I have no access to production data, so I have not measured this at
your row count and distribution. If it is useful, the check is:

```sql
EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM servers
WHERE (server_name ILIKE '%gmail%' ESCAPE '\' OR value ->> 'description' ILIKE '%gmail%' ESCAPE '\');
```

before and after `015`. **Happy to split the migration into its own PR** if you would rather land the
behaviour change and the index separately — say the word and I will rebase.

## Tests

- `TestPostgreSQL_ListServersSearch` covers the cases that can only pass if the fields are really
  OR'd: a term in the name only, a term in the description only, a term that appears in one server's
  name and another's description (both come back), and case-insensitivity on the description path.
- Two of them cover the LIKE escaping, which had **no test before** — `%` and `_` must stay literal,
  and without escaping the `%` case would return every row.
- `TestListServersEndpoint` gains a server whose subject appears only in its description, plus a
  `?search=` case for it, so the behaviour is asserted through the HTTP layer too.

## How this was verified

The full pipeline (lint, build, schema validation, `make test-all` against a real PostgreSQL) was run
on a fork before opening this: green.

Green on its own would not say much — `go test` without `-v` names no tests, so a test that asserts
nothing looks identical. So the same suite was run a second time with the production change reverted
(name-only match) and the tests left in place. It failed in exactly the intended places:

| test | with the change | reverted |
|---|---|---|
| `matches the name` | pass | pass |
| `matches the description` | pass | **fail** |
| `matches either field` | pass | **fail** |
| case-insensitive on the description | pass | **fail** |
| `%` / `_` stay literal | pass | **fail** (the metacharacters live in a description) |
| `returns nothing when neither matches` | pass | pass |
| API: `?search=` by description | pass | **fail** |
| API: `?search=` by name | pass | pass |

Everything that depends on the description failed, everything that does not still passed.

## Docs

`openapi.yaml`, `official-registry-api.md` and the API changelog are updated. The changelog entry
notes that this **widens** what an existing query returns, since that is the one thing a consumer
might notice.

## Disclosure

I am one of the affected publishers — `io.github.csitte/mailwarden` is the Gmail server in the
data point I left on #1453, whose description begins with the word it cannot be found by. The change
is general and was requested independently before I ran into it; I mention it so the motivation is
on the record rather than inferred.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P25Wghw8NSghMJzxw93DxU
