### PR TITLE
fix(publisher): record repository.id at init so renames stay resolvable

### DIFF
--- a/cmd/publisher/commands/init.go
+++ b/cmd/publisher/commands/init.go
@@ -68,7 +68,14 @@ func InitCommand() error {
 		packageType, packageIdentifier, version, envVars,
 	)
 	if server.Repository != nil {
-		server.Repository.ID = detectRepoID(repoSource, repoURL)
+		id, err := detectRepoID(repoSource, repoURL)
+		if err != nil {
+			// An empty `id` on a GitHub source is indistinguishable from a
+			// non-GitHub entry once serialized, so report the gap while there
+			// is still someone around to read it.
+			_, _ = fmt.Fprintf(os.Stderr, "warning: could not resolve repository.id (%v); publishing without it\n", err)
+		}
+		server.Repository.ID = id
 	}
 
 	// Write to file
@@ -289,13 +296,17 @@ func parseGitHubOwnerRepo(repoURL string) (owner, repo string, ok bool) {
 // network, rate limited, or pointed at a private repo leaves the field empty
 // instead of failing the command. `GITHUB_TOKEN` is used when present, mostly
 // so a rate-limited developer still gets the ID.
-func detectRepoID(repoSource, repoURL string) string {
+//
+// The returned error is why a GitHub lookup came back without an ID, for the
+// caller to warn about; a non-GitHub source has nothing to resolve, so it
+// returns an empty ID and no error.
+func detectRepoID(repoSource, repoURL string) (string, error) {
 	if repoSource != MethodGitHub {
-		return ""
+		return "", nil
 	}
 	owner, repo, ok := parseGitHubOwnerRepo(repoURL)
 	if !ok {
-		return ""
+		return "", fmt.Errorf("%q is not a github.com repository URL", repoURL)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -305,7 +316,7 @@ func detectRepoID(repoSource, repoURL string) string {
 		fmt.Sprintf("%s/repos/%s/%s", githubAPIBaseURL, owner, repo), nil,
 	)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
@@ -314,20 +325,23 @@ func detectRepoID(repoSource, repoURL string) string {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return ""
+		return "", fmt.Errorf("GET /repos/%s/%s returned %s", owner, repo, resp.Status)
 	}
 
 	var body struct {
 		ID int64 `json:"id"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil || body.ID == 0 {
-		return ""
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
 	}
-	return strconv.FormatInt(body.ID, 10)
+	if body.ID == 0 {
+		return "", errors.New("response carried no repository id")
+	}
+	return strconv.FormatInt(body.ID, 10), nil
 }
 
 func detectDescription() string {

--- a/cmd/publisher/commands/init.go
+++ b/cmd/publisher/commands/init.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -64,6 +67,9 @@ func InitCommand() error {
 		model.CurrentSchemaURL, name, description, version, repoURL, repoSource, subfolder,
 		packageType, packageIdentifier, version, envVars,
 	)
+	if server.Repository != nil {
+		server.Repository.ID = detectRepoID(repoSource, repoURL)
+	}
 
 	// Write to file
 	jsonData, err := json.MarshalIndent(server, "", "  ")
@@ -245,6 +251,83 @@ func buildGitHubServerName(repoURL, subfolder string) string {
 	}
 
 	return fmt.Sprintf("io.github.%s/%s", owner, repo)
+}
+
+// githubAPIBaseURL is a variable so the tests can point it at a stub server.
+var githubAPIBaseURL = "https://api.github.com"
+
+// parseGitHubOwnerRepo pulls owner/repo out of a github.com web URL, which is
+// the only shape `detectRepoURL` produces for GitHub (it rewrites the SSH form
+// and strips `.git`). Anything else — a different host, a bare path, a URL with
+// extra segments — returns ok=false rather than a guess.
+func parseGitHubOwnerRepo(repoURL string) (owner, repo string, ok bool) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", "", false
+	}
+	if strings.TrimPrefix(strings.ToLower(u.Hostname()), "www.") != "github.com" {
+		return "", "", false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), true
+}
+
+// detectRepoID resolves the forge's own identifier for the repository, which
+// `repository.id` exists to carry.
+//
+// A URL is not a stable pointer: renaming or transferring a GitHub repo leaves
+// the registered `repository.url` resolving only through GitHub's redirect,
+// which the REST API follows but GraphQL does not, so the source link rots for
+// consumers. The numeric ID does not move (#1484). Recording it at init time
+// costs one request and makes the entry re-resolvable later even if the URL has
+// gone stale.
+//
+// Deliberately best effort: `init` is otherwise fully offline, so being off the
+// network, rate limited, or pointed at a private repo leaves the field empty
+// instead of failing the command. `GITHUB_TOKEN` is used when present, mostly
+// so a rate-limited developer still gets the ID.
+func detectRepoID(repoSource, repoURL string) string {
+	if repoSource != MethodGitHub {
+		return ""
+	}
+	owner, repo, ok := parseGitHubOwnerRepo(repoURL)
+	if !ok {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		fmt.Sprintf("%s/repos/%s/%s", githubAPIBaseURL, owner, repo), nil,
+	)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var body struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil || body.ID == 0 {
+		return ""
+	}
+	return strconv.FormatInt(body.ID, 10)
 }
 
 func detectDescription() string {

--- a/cmd/publisher/commands/init_internal_test.go
+++ b/cmd/publisher/commands/init_internal_test.go
@@ -3,9 +3,11 @@ package commands
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseGitHubOwnerRepo(t *testing.T) {
@@ -53,25 +55,46 @@ func TestDetectRepoID(t *testing.T) {
 		githubAPIBaseURL = srv.URL
 		defer func() { githubAPIBaseURL = originalBaseURL }()
 
-		assert.Equal(t, "123456789", detectRepoID(MethodGitHub, "https://github.com/acme/weather"))
+		id, err := detectRepoID(MethodGitHub, "https://github.com/acme/weather")
+		require.NoError(t, err)
+		assert.Equal(t, "123456789", id)
 		assert.Equal(t, "/repos/acme/weather", gotPath)
 	})
 
 	t.Run("stays empty rather than failing init when the lookup does not work", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer srv.Close()
-		t.Setenv("GITHUB_TOKEN", "")
+		// A failed lookup leaves the field empty, but it reports why, so init can
+		// say so on stderr instead of silently producing a GitHub entry that
+		// serializes exactly like a non-GitHub one.
+		for _, status := range []int{http.StatusNotFound, http.StatusForbidden} {
+			t.Run(http.StatusText(status), func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(status)
+				}))
+				defer srv.Close()
+				t.Setenv("GITHUB_TOKEN", "")
 
-		originalBaseURL := githubAPIBaseURL
-		githubAPIBaseURL = srv.URL
-		defer func() { githubAPIBaseURL = originalBaseURL }()
+				originalBaseURL := githubAPIBaseURL
+				githubAPIBaseURL = srv.URL
+				defer func() { githubAPIBaseURL = originalBaseURL }()
 
-		// 404 / private / rate limited.
-		assert.Empty(t, detectRepoID(MethodGitHub, "https://github.com/acme/weather"))
-		// Non-GitHub sources are never looked up, so no request is made at all.
-		assert.Empty(t, detectRepoID("gitlab", "https://gitlab.com/acme/weather"))
-		assert.Empty(t, detectRepoID(MethodGitHub, ""))
+				// 404 is private or missing, 403 is rate limited.
+				id, err := detectRepoID(MethodGitHub, "https://github.com/acme/weather")
+				assert.Empty(t, id)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), strconv.Itoa(status))
+			})
+		}
+
+		// Non-GitHub sources are never looked up, so no request is made at all —
+		// and the empty ID is correct there, so there is nothing to report.
+		id, err := detectRepoID("gitlab", "https://gitlab.com/acme/weather")
+		assert.Empty(t, id)
+		assert.NoError(t, err)
+
+		// A GitHub source we cannot even build a request for is still a GitHub
+		// entry that ended up without its ID.
+		id, err = detectRepoID(MethodGitHub, "")
+		assert.Empty(t, id)
+		assert.Error(t, err)
 	})
 }

--- a/cmd/publisher/commands/init_internal_test.go
+++ b/cmd/publisher/commands/init_internal_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGitHubOwnerRepo(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		owner   string
+		repo    string
+		ok      bool
+	}{
+		{name: "plain https URL", repoURL: "https://github.com/acme/weather", owner: "acme", repo: "weather", ok: true},
+		{name: "www host", repoURL: "https://www.github.com/acme/weather", owner: "acme", repo: "weather", ok: true},
+		{name: "trailing slash", repoURL: "https://github.com/acme/weather/", owner: "acme", repo: "weather", ok: true},
+		{name: "dot-git suffix", repoURL: "https://github.com/acme/weather.git", owner: "acme", repo: "weather", ok: true},
+		{name: "gitlab is not github", repoURL: "https://gitlab.com/acme/weather"},
+		// A lookalike host must not be treated as GitHub — the ID we would fetch
+		// would belong to whatever that host decided to return.
+		{name: "lookalike host", repoURL: "https://github.com.evil.example/acme/weather"},
+		{name: "deep path is not a repo root", repoURL: "https://github.com/acme/weather/tree/main/src"},
+		{name: "owner only", repoURL: "https://github.com/acme"},
+		{name: "empty", repoURL: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, ok := parseGitHubOwnerRepo(tt.repoURL)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.owner, owner)
+			assert.Equal(t, tt.repo, repo)
+		})
+	}
+}
+
+func TestDetectRepoID(t *testing.T) {
+	t.Run("records the numeric id GitHub reports", func(t *testing.T) {
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_, _ = w.Write([]byte(`{"id": 123456789, "full_name": "acme/weather"}`))
+		}))
+		defer srv.Close()
+		t.Setenv("GITHUB_TOKEN", "")
+
+		originalBaseURL := githubAPIBaseURL
+		githubAPIBaseURL = srv.URL
+		defer func() { githubAPIBaseURL = originalBaseURL }()
+
+		assert.Equal(t, "123456789", detectRepoID(MethodGitHub, "https://github.com/acme/weather"))
+		assert.Equal(t, "/repos/acme/weather", gotPath)
+	})
+
+	t.Run("stays empty rather than failing init when the lookup does not work", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+		t.Setenv("GITHUB_TOKEN", "")
+
+		originalBaseURL := githubAPIBaseURL
+		githubAPIBaseURL = srv.URL
+		defer func() { githubAPIBaseURL = originalBaseURL }()
+
+		// 404 / private / rate limited.
+		assert.Empty(t, detectRepoID(MethodGitHub, "https://github.com/acme/weather"))
+		// Non-GitHub sources are never looked up, so no request is made at all.
+		assert.Empty(t, detectRepoID("gitlab", "https://gitlab.com/acme/weather"))
+		assert.Empty(t, detectRepoID(MethodGitHub, ""))
+	})
+}


### PR DESCRIPTION
Towards #1484

## Background

#1484 audited the `repository.url` of the 398 highest-graded remote servers and
found 38 (9.5%) pointing at repositories that have since been renamed or
transferred. No hard 404s — GitHub's REST API follows the redirect — but GraphQL
consumers resolve them as nonexistent (`Could not resolve to a Repository`), so
the source link is broken for a real class of tooling, and it stays broken once
the redirect eventually lapses.

## The gap this closes

`pkg/model/types.go` already defines the field that solves this:

```go
ID string `json:"id,omitempty" doc:"Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks …"`
```

Nothing populates it. `mcp-publisher init` builds the repository block from
`detectRepoURL()` and writes `url` and `source` only, so in practice every entry's
sole pointer at its source is a URL — and a URL is not a stable pointer.

This PR resolves the ID at init time and writes it alongside the URL. A rename
after that point no longer loses the entry: the ID still identifies the
repository, and it also gives the "deleted and recreated" detection the schema
doc already describes something to compare against.

## Scope and deliberate limits

- **One request, at scaffolding time.** Not in the publish path, so it adds no
  latency or GitHub rate-limit exposure to publishing.
- **Best effort.** `init` is otherwise fully offline. Being off the network,
  rate limited, or pointed at a private repo leaves the field empty rather than
  failing the command. `GITHUB_TOKEN` is used when set, mostly so a rate-limited
  developer still gets an ID.
- **GitHub only.** `repository.source` also allows `gitlab`, and `detectRepoURL`
  can produce a plain `git` source. Those return empty; GitLab's equivalent
  lookup is easy to add if you want it, but I did not want to guess at the
  ID semantics for a forge the audit did not cover.
- Host matching is exact (`github.com`, optionally `www.`) so a lookalike host
  cannot get us to fetch an ID that belongs to somebody else. Covered by a test.

## What this does **not** do

Two parts of #1484 are maintainer calls, not code I should pick unilaterally, and
I have written them up on the issue rather than guessing here:

1. **Backfilling the 38 existing entries.** The registry's data is in the
   database, not this repo — `CLAUDE.md` is explicit that `data/seed.json` is
   local dev seed data and must not be used to publish. So a data fix cannot
   arrive as a PR to this repository at all; it needs an operator-run migration,
   and someone has to decide whether rewriting a publisher's `repository.url`
   without them re-publishing is acceptable.
2. **Publish-time behaviour on a redirecting URL** — reject, warn, or accept and
   record. `ValidateServerJSON` is currently pure and offline; the only network
   validation lives in `ValidatePublishRequest` behind
   `cfg.EnableRegistryValidation`, and it returns a bare `error` with no channel
   for a warning even though `ValidationIssueSeverityWarning` exists elsewhere.
   Wiring a warning through is a real design decision about the publish contract.

## Test

`cmd/publisher/commands/init_internal_test.go`:

- `TestParseGitHubOwnerRepo` — the URL shapes `detectRepoURL` actually produces
  (plain, `www.`, trailing slash, `.git`), plus the ones that must **not** be
  treated as GitHub: gitlab, a `github.com.evil.example` lookalike, a deep
  `/tree/main/...` path, an owner with no repo.
- `TestDetectRepoID` — against an `httptest` stub: records the numeric id and
  requests `/repos/{owner}/{repo}`; and stays empty on 404 / non-GitHub source /
  empty URL, so a failed lookup can never fail `init`.

```
$ go test ./cmd/publisher/...
ok      github.com/modelcontextprotocol/registry/cmd/publisher/auth      2.363s
ok      github.com/modelcontextprotocol/registry/cmd/publisher/commands  4.838s

$ go build ./...      # clean
$ gofmt -l cmd/       # clean
```

`golangci-lint` was not available in my environment, so that gate is unverified
locally.
