### PR TITLE
​Add agent-token-stripper server

### DIFF
--- a/servers/io.github.goldminex/agent-token-stripper.json
+++ b/servers/io.github.goldminex/agent-token-stripper.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.goldminex/agent-token-stripper",
+  "version": "1.0.0",
+  "description": "Autonomous x402 Machine-to-Machine Token Stripper API settling $0.002 USDC micro-payments on Base L2.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoldMineX/gold-mind-max"
+  },
+  "transport": {
+    "type": "http",
+    "url": "https://gold-mind-max.vercel.app/api/extract"
+  }
+}


### PR DESCRIPTION
### Summary
Adds the `agent-token-stripper` server configuration to the official MCP registry.

- **Server ID:** `io.github.goldminex/agent-token-stripper`
- **Transport Type:** HTTP
- **Endpoint:** `https://gold-mind-max.vercel.app/api/extract`
- **Capability:** Strips HTML bloat, styles, and scripts to return token-optimized plain text for LLM context windows with x402 micropayments on Base L2.

### Checklist
- [x] I have read the MCP Documentation
- [x] My code/config follows the repository style guidelines
- [x] Validated JSON schema locally
