### PR TITLE
fix(ui): prefer human-readable server title in registry cards

### DIFF
--- a/internal/api/handlers/v0/ui_index.html
+++ b/internal/api/handlers/v0/ui_index.html
@@ -279,6 +279,7 @@
             recentServers.forEach(item => {
                 const server = item.server;
                 const meta = item._meta?.['io.modelcontextprotocol.registry/official'];
+                const identity = getServerCardIdentity(server);
 
                 const card = document.createElement('div');
                 card.className = 'bg-blue-50 border border-blue-200 rounded-lg overflow-hidden hover:border-blue-400 hover:shadow-md transition-all flex flex-col';
@@ -288,7 +289,10 @@
                 header.onclick = () => toggleDetails(card, item);
                 header.innerHTML = `
                     <div class="flex items-start justify-between gap-3 mb-2">
-                        <h3 class="font-semibold text-gray-900 text-base flex-1 min-w-0 break-all">${escapeHtml(server.name)}</h3>
+                        <div class="flex-1 min-w-0">
+                            <h3 class="font-semibold text-gray-900 text-base ${identity.titleWrapClass}">${escapeHtml(identity.displayTitle)}</h3>
+                            ${identity.technicalName ? `<p class="text-xs text-gray-500 leading-tight mt-0.5 break-all">${escapeHtml(identity.technicalName)}</p>` : ''}
+                        </div>
                         <span class="text-xs text-gray-500 font-medium whitespace-nowrap">v${escapeHtml(server.version)}</span>
                     </div>
                     <p class="text-sm text-gray-600 leading-relaxed line-clamp-2 mb-2 break-words">${escapeHtml(server.description || '')}</p>
@@ -300,6 +304,16 @@
                 card.appendChild(header);
                 container.appendChild(card);
             });
+        }
+
+        function getServerCardIdentity(server) {
+            const hasDistinctTitle = Boolean(server.title && server.title !== server.name);
+
+            return {
+                displayTitle: hasDistinctTitle ? server.title : server.name,
+                technicalName: hasDistinctTitle ? server.name : null,
+                titleWrapClass: hasDistinctTitle ? 'break-words' : 'break-all'
+            };
         }
 
         // Fetch servers
@@ -344,6 +358,7 @@
             servers.forEach(item => {
                 const server = item.server;
                 const meta = item._meta?.['io.modelcontextprotocol.registry/official'];
+                const identity = getServerCardIdentity(server);
 
                 const card = document.createElement('div');
                 card.className = 'bg-white border border-gray-200 rounded-lg overflow-hidden hover:border-blue-300 hover:shadow-md transition-all flex flex-col';
@@ -353,7 +368,10 @@
                 header.onclick = () => toggleDetails(card, item);
                 header.innerHTML = `
                     <div class="flex items-start justify-between gap-3 mb-2">
-                        <h3 class="font-semibold text-gray-900 text-base flex-1 min-w-0">${escapeHtml(server.name)}</h3>
+                        <div class="flex-1 min-w-0">
+                            <h3 class="font-semibold text-gray-900 text-base ${identity.titleWrapClass}">${escapeHtml(identity.displayTitle)}</h3>
+                            ${identity.technicalName ? `<p class="text-xs text-gray-500 leading-tight mt-0.5 break-all">${escapeHtml(identity.technicalName)}</p>` : ''}
+                        </div>
                         <span class="text-xs text-gray-500 font-medium whitespace-nowrap">v${escapeHtml(server.version)}</span>
                     </div>
                     <p class="text-sm text-gray-600 leading-relaxed line-clamp-2 mb-2">${escapeHtml(server.description || '')}</p>


### PR DESCRIPTION
## Summary

- prefer the optional `server.title` as the primary heading in Registry cards
- keep `server.name` visible as a smaller secondary identity when the values differ
- preserve the existing `server.name` heading when `title` is absent or identical
- apply the same compact layout to normal results and Recently Updated cards

## Why

The Registry schema defines `title` as a human-readable display name, but collapsed cards currently headline only the reverse-DNS `name`. That makes browsing harder for users who do not recognize programmatic MCP identifiers.

Generic example:

```text
Before
io.example/weather-server

After
Weather Planner
io.example/weather-server
```

The technical identity remains visible for namespace verification. All user-provided values continue to pass through the existing `escapeHtml(...)` helper, and long values use the existing Tailwind wrapping utilities.

## Scope

This is presentation-only and backward-compatible. It does not change schemas, API responses, search behavior, publishing, authentication, or protocol behavior.

The API `search` parameter currently matches only `server_name`; title and description search are not included here. Icon rendering is also intentionally out of scope and is already tracked by #784.

## Testing

- `git diff --check`
- real-browser Playwright smoke coverage with controlled fixtures:
  - title different from name
  - no title
  - title equal to name, without duplicate identity text
  - very long title and technical name, with no card overflow
  - Recently Updated card
  - normal result cards
  - expanded details still open and display the title

Local `make check` was unavailable because this Windows environment does not have Go, Make, Docker, or a WSL distribution installed. The upstream PR CI is configured to run lint, schema validation, build, vulnerability scanning, and all tests.
