### PR TITLE
fix(auth): reject gitlab.io domains in DNS/HTTP token exchange

### DIFF
--- a/internal/api/handlers/v0/auth/common.go
+++ b/internal/api/handlers/v0/auth/common.go
@@ -95,6 +95,12 @@ func ValidateDomainAndTimestamp(domain, timestamp string) (*time.Time, error) {
 				"use GitHub authentication for io.github.* namespaces")
 	}
 
+	if isGitLabPagesDomain(domain) {
+		return nil, fmt.Errorf(
+			"gitlab.io domains cannot be used with DNS/HTTP authentication; " +
+				"the proof only demonstrates write access to a single Pages repository")
+	}
+
 	ts, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
 		return nil, fmt.Errorf("invalid timestamp format: %w", err)
@@ -398,6 +404,17 @@ func ReverseString(domain string) string {
 func isGitHubPagesDomain(domain string) bool {
 	d := strings.ToLower(domain)
 	return d == "github.io" || strings.HasSuffix(d, ".github.io")
+}
+
+// isGitLabPagesDomain reports whether domain is gitlab.io or a subdomain of it.
+// GitLab Pages serves <group>.gitlab.io from the <group>/<group>.gitlab.io
+// repository, so the HTTP/DNS proof only demonstrates push access to that one
+// repository — routinely held by ordinary Developers, a far weaker bar than
+// group ownership. Users of io.gitlab.* namespaces should prove ownership of
+// their apex domain instead.
+func isGitLabPagesDomain(domain string) bool {
+	d := strings.ToLower(domain)
+	return d == "gitlab.io" || strings.HasSuffix(d, ".gitlab.io")
 }
 
 func IsValidDomain(domain string) bool {

--- a/internal/api/handlers/v0/auth/common_test.go
+++ b/internal/api/handlers/v0/auth/common_test.go
@@ -65,6 +65,18 @@ func TestValidateDomainAndTimestampRejectsGitHubPages(t *testing.T) {
 		{"github.io.evil-example.com", false},
 		{"example.com", false},
 		{"my-org.github.io.example.com", false},
+
+		// GitLab Pages domains must not mint io.gitlab.* namespaces via DNS/HTTP:
+		// <group>.gitlab.io is served from a repository ordinary Developers can
+		// write to, the same weaker bar #1506 closed for GitHub Pages.
+		{"my-group.gitlab.io", true},
+		{"my-group.GitLab.IO", true},
+		{"gitlab.io", true},
+		{"sub.my-group.gitlab.io", true},
+
+		// Lookalikes stay allowed
+		{"gitlab.io.evil-example.com", false},
+		{"my-group.gitlab.io.example.com", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.domain, func(t *testing.T) {


### PR DESCRIPTION
## What

Extends the shared-hosting rejection added in #1506 from `github.io` to `gitlab.io` (and subdomains) in `ValidateDomainAndTimestamp`, which guards both DNS and HTTP token exchange.

## Why

GitLab Pages serves `<group>.gitlab.io` from the `<group>/<group>.gitlab.io` repository, and that repository can be written to by group members holding the **Developer** role — a far weaker bar than group ownership. The DNS/HTTP proof therefore demonstrates control of one Pages repository, yet it minted publish permissions for the entire `io.gitlab.<group>/*` namespace.

This is the same weaker-bar takeover #1506 closed for GitHub Pages; GitLab Pages is the identical mechanic (per-group Pages repository) and was notably absent from that fix.

## Change

- New `isGitLabPagesDomain` check alongside `isGitHubPagesDomain`, with a distinct error message pointing GitLab users at apex-domain proof.
- Test-table rows covering `my-group.gitlab.io` (including mixed case and subdomains), plus lookalikes (`gitlab.io.evil-example.com`, `my-group.gitlab.io.example.com`) that must remain allowed.

Scope note: first-come-claimable hosts without an org-repository model (netlify.app, vercel.app, pages.dev) raise a different trust question and are deliberately left out of this PR.