### PR TITLE
docs: add PulseFeed MCP Drift Watch to community projects

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -36,6 +36,7 @@ Self-hostable servers that implement the MCP Registry API specification.
 - [mcp-registry-cli](https://pypi.org/project/mcp-registry-cli/) - CLI tool to navigate the MCP registry servers
 - [OtherVibes/mcp-publish-action](https://github.com/OtherVibes/mcp-publish-action) - GitHub Action for publishing MCP servers to the official registry
 - [polygraph](https://polygraph.so) - Independent behavioral security grades (A–F) for MCP servers from an open, reproducible harness, published as an adoption-ranked index with per-server reports
+- [PulseFeed MCP Drift Watch](https://pulsefeed.dev/mcp/drift) - Daily external diff of the whole registry population, recording what changed in a server *after* it was listed: package ownership transferred, install script added in a later version, repository removed, package unpublished, a removed name republished by someone else. Free JSON/RSS feed filterable to your own packages, a README badge, and webhook alerts; series runs from 2026-07-30 and each day's manifest is timestamped into Bitcoin.
 
 ## Adding Your Project
 


### PR DESCRIPTION
One line in `docs/community-projects.md` under **Other**, following the format in *Adding Your Project*.

**What it is.** A daily external diff of the whole registry population — 25,122 entries as of today — recording what changed in a server *after* it was listed rather than whether it is safe right now: package ownership transferred, an install script added in a later version, repository link removed, package unpublished, a removed name republished by someone else.

**Why the distinction matters.** A rug pull is clean at review time by construction: the package collects installs for weeks, then ships the patch. Detecting that needs yesterday's snapshot to exist, which is why the series starts on 2026-07-30 and cannot be reconstructed after the fact. The registry's own moderation policy notes it relies on downstream consumers for this kind of check.

**Free, no key, no account:** JSON and RSS feeds filterable to your own package list, a README badge, and webhook alerts. Every day's manifest of dataset digests is timestamped into Bitcoin via OpenTimestamps, so the series can be shown to have existed on a given date by anyone, without trusting us.

Placed next to `polygraph` as the nearest precedent for an independent security project in this list. All links in the entry were checked before opening this PR. Nothing else in the file is touched.