### PR TITLE
fix(validators): reject invalid argument types and empty positional arguments

### DIFF
--- a/internal/api/handlers/v0/publish_test.go
+++ b/internal/api/handlers/v0/publish_test.go
@@ -384,6 +384,41 @@ func TestPublishEndpoint(t *testing.T) {
 			expectedStatus:       http.StatusUnprocessableEntity,
 			expectedError:        "Failed to publish server, invalid schema: call /validate for details",
 		},
+		{
+			name: "invalid argument - empty type",
+			requestBody: apiv0.ServerJSON{
+				Schema:      model.CurrentSchemaURL,
+				Name:        "com.example/test-server",
+				Description: "A test server",
+				Version:     "1.0.0",
+				Packages: []model.Package{
+					{
+						RegistryType: model.RegistryTypeNPM,
+						Identifier:   "test-package",
+						Version:      "1.0.0",
+						Transport: model.Transport{
+							Type: model.TransportTypeStdio,
+						},
+						RuntimeArguments: []model.Argument{
+							{
+								InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "mcp"}},
+								Type:               "", // type present but empty string, not a missing key
+								Name:               "command",
+							},
+						},
+					},
+				},
+			},
+			tokenClaims: &auth.JWTClaims{
+				AuthMethod: auth.MethodNone,
+				Permissions: []auth.Permission{
+					{Action: auth.PermissionActionPublish, ResourcePattern: "*"},
+				},
+			},
+			setupRegistryService: func(_ service.RegistryService) {},
+			expectedStatus:       http.StatusUnprocessableEntity,
+			expectedError:        "Failed to publish server, invalid schema: call /validate for details",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/validators/constants.go
+++ b/internal/validators/constants.go
@@ -27,6 +27,10 @@ var (
 	ErrArgumentValueStartsWithName   = errors.New("argument value cannot start with the argument name")
 	ErrArgumentDefaultStartsWithName = errors.New("argument default cannot start with the argument name")
 
+	// Argument type and shape validation errors
+	ErrInvalidArgumentType             = errors.New("argument type must be 'positional' or 'named'")
+	ErrPositionalArgumentValueRequired = errors.New("positional argument must provide a value or a valueHint")
+
 	// Server name validation errors
 	ErrMultipleSlashesInServerName = errors.New("server name cannot contain multiple slashes")
 	ErrInvalidServerNameFormat     = errors.New("server name format is invalid")

--- a/internal/validators/validation_detailed_test.go
+++ b/internal/validators/validation_detailed_test.go
@@ -163,6 +163,12 @@ func TestValidateServerJSON_ContextPaths(t *testing.T) {
 						Type: model.ArgumentTypeNamed,
 						Name: "invalid name", // Error in second package's argument
 					},
+					{
+						Type: "", // Error: argument type outside the enum
+					},
+					{
+						Type: model.ArgumentTypePositional, // Error: positional without value or valueHint
+					},
 				},
 			},
 		},
@@ -180,6 +186,16 @@ func TestValidateServerJSON_ContextPaths(t *testing.T) {
 	// Should have issues at specific nested paths
 	assert.True(t, issuePaths["packages[0].version"], "Should have issue at packages[0].version")
 	assert.True(t, issuePaths["packages[1].runtimeArguments[0].name"], "Should have issue at packages[1].runtimeArguments[0].name")
+	assert.True(t, issuePaths["packages[1].runtimeArguments[1].type"], "Should have issue at packages[1].runtimeArguments[1].type")
+	assert.True(t, issuePaths["packages[1].runtimeArguments[2]"], "Should have issue at packages[1].runtimeArguments[2]")
+
+	// Pin the API-visible references for the argument checks
+	issueRefs := make(map[string]string)
+	for _, issue := range result.Issues {
+		issueRefs[issue.Path] = issue.Reference
+	}
+	assert.Equal(t, "invalid-argument-type", issueRefs["packages[1].runtimeArguments[1].type"])
+	assert.Equal(t, "positional-argument-value-or-hint-required", issueRefs["packages[1].runtimeArguments[2]"])
 }
 
 func TestValidateServerJSON_RefResolution(t *testing.T) {

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -396,7 +396,8 @@ func looksLikeVersionRange(version string) bool {
 func validateArgument(ctx *ValidationContext, obj *model.Argument) *ValidationResult {
 	result := &ValidationResult{Valid: true, Issues: []ValidationIssue{}}
 
-	if obj.Type == model.ArgumentTypeNamed {
+	switch obj.Type {
+	case model.ArgumentTypeNamed:
 		// Validate named argument name format
 		nameResult := validateNamedArgumentName(ctx.Field("name"), obj.Name)
 		result.Merge(nameResult)
@@ -404,6 +405,26 @@ func validateArgument(ctx *ValidationContext, obj *model.Argument) *ValidationRe
 		// Validate value and default don't start with the name
 		valueResult := validateArgumentValueFields(ctx, obj.Name, obj.Value, obj.Default)
 		result.Merge(valueResult)
+	case model.ArgumentTypePositional:
+		// Positional arguments need a value or a valueHint to be usable
+		if obj.Value == "" && obj.ValueHint == "" {
+			issue := NewValidationIssueFromError(
+				ValidationIssueTypeSemantic,
+				ctx.String(),
+				ErrPositionalArgumentValueRequired,
+				"positional-argument-value-or-hint-required",
+			)
+			result.AddIssue(issue)
+		}
+	default:
+		// Reject unknown argument types, including the empty string
+		issue := NewValidationIssueFromError(
+			ValidationIssueTypeSemantic,
+			ctx.Field("type").String(),
+			fmt.Errorf("%w: %q", ErrInvalidArgumentType, obj.Type),
+			"invalid-argument-type",
+		)
+		result.AddIssue(issue)
 	}
 	return result
 }

--- a/internal/validators/validators_test.go
+++ b/internal/validators/validators_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/modelcontextprotocol/registry/internal/config"
 	"github.com/modelcontextprotocol/registry/internal/validators"
@@ -1241,8 +1242,8 @@ func TestValidateArgument_ValidNamedArguments(t *testing.T) {
 
 func TestValidateArgument_ValidPositionalArguments(t *testing.T) {
 	positionalCases := []model.Argument{
-		{Type: model.ArgumentTypePositional, Name: "anything with spaces"},
-		{Type: model.ArgumentTypePositional, Name: "anything<with>brackets"},
+		{Type: model.ArgumentTypePositional, Name: "anything with spaces", ValueHint: "target_dir"},
+		{Type: model.ArgumentTypePositional, Name: "anything<with>brackets", ValueHint: "target_dir"},
 		{
 			InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "--port 8080"}},
 			Type:               model.ArgumentTypePositional,
@@ -1394,6 +1395,105 @@ func TestValidateArgument_ValidValueFields(t *testing.T) {
 			assert.NoError(t, err, "Expected valid argument %+v", tc.arg)
 		})
 	}
+}
+
+func TestValidateArgument_InvalidArgumentType(t *testing.T) {
+	invalidTypeCases := []struct {
+		name string
+		arg  model.Argument
+	}{
+		{
+			// Same shape as live entry io.github.Jordan-Horner/symbols@1.0.1
+			// (there under packageArguments): name and value are set, so only
+			// the type check can fire
+			"empty_type",
+			model.Argument{
+				InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "mcp"}},
+				Type:               "",
+				Name:               "command",
+			},
+		},
+		{"literal", model.Argument{Type: "literal"}},
+		{"flag", model.Argument{Type: "flag", Name: "--verbose"}},
+		{"environment", model.Argument{Type: "environment", Name: "API_KEY"}},
+		// Type values are case-sensitive: "Positional" is not "positional"
+		{"uppercase_positional", model.Argument{Type: "Positional"}},
+	}
+
+	for _, tc := range invalidTypeCases {
+		t.Run("Invalid_"+tc.name, func(t *testing.T) {
+			server := createValidServerWithArgument(tc.arg)
+			// ValidateServerJSON returns all validation results; using FirstError() to preserve existing test behavior
+			// In future, consider using result.Issues for comprehensive error reporting
+			result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+			err := result.FirstError()
+			require.Error(t, err, "Expected error for invalid argument type: %+v", tc.arg)
+			assert.Contains(t, err.Error(), "argument type must be 'positional' or 'named'")
+		})
+	}
+}
+
+func TestValidateArgument_PositionalValueOrHint(t *testing.T) {
+	positionalCases := []struct {
+		name        string
+		arg         model.Argument
+		expectError bool
+	}{
+		{
+			"missing_value_and_value_hint",
+			model.Argument{Type: model.ArgumentTypePositional},
+			true,
+		},
+		{
+			"value_only",
+			model.Argument{
+				InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "input.txt"}},
+				Type:               model.ArgumentTypePositional,
+			},
+			false,
+		},
+		{
+			"value_hint_only",
+			model.Argument{Type: model.ArgumentTypePositional, ValueHint: "file_path"},
+			false,
+		},
+		{
+			"value_and_value_hint",
+			model.Argument{
+				InputWithVariables: model.InputWithVariables{Input: model.Input{Value: "input.txt"}},
+				Type:               model.ArgumentTypePositional,
+				ValueHint:          "file_path",
+			},
+			false,
+		},
+	}
+
+	for _, tc := range positionalCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := createValidServerWithArgument(tc.arg)
+			// ValidateServerJSON returns all validation results; using FirstError() to preserve existing test behavior
+			// In future, consider using result.Issues for comprehensive error reporting
+			result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+			err := result.FirstError()
+			if tc.expectError {
+				require.Error(t, err, "Expected error for positional argument without value or valueHint: %+v", tc.arg)
+				assert.Contains(t, err.Error(), "positional argument must provide a value or a valueHint")
+			} else {
+				assert.NoError(t, err, "Expected valid positional argument %+v", tc.arg)
+			}
+		})
+	}
+
+	// The same check must apply to arguments under packageArguments
+	t.Run("missing_value_and_value_hint_in_package_arguments", func(t *testing.T) {
+		server := createValidServerWithPackageArgument(model.Argument{Type: model.ArgumentTypePositional})
+		// ValidateServerJSON returns all validation results; using FirstError() to preserve existing test behavior
+		// In future, consider using result.Issues for comprehensive error reporting
+		result := validators.ValidateServerJSON(&server, validators.ValidationSchemaVersionAndSemantic)
+		err := result.FirstError()
+		require.Error(t, err, "Expected error for positional package argument without value or valueHint")
+		assert.Contains(t, err.Error(), "positional argument must provide a value or a valueHint")
+	})
 }
 
 // Helper function to create a valid server with a specific argument for testing
@@ -1978,6 +2078,15 @@ func createValidServerWithArgument(arg model.Argument) apiv0.ServerJSON {
 			},
 		},
 	}
+}
+
+// createValidServerWithPackageArgument is createValidServerWithArgument with the
+// argument under packageArguments instead of runtimeArguments
+func createValidServerWithPackageArgument(arg model.Argument) apiv0.ServerJSON {
+	server := createValidServerWithArgument(arg)
+	server.Packages[0].RuntimeArguments = nil
+	server.Packages[0].PackageArguments = []model.Argument{arg}
+	return server
 }
 
 func TestValidateTitle(t *testing.T) {


### PR DESCRIPTION
## Summary

Publish accepts arguments that violate the schema. `validateArgument` only checks the named branch, so a `type` that is empty or outside the enum passes through, and a positional argument with neither `value` nor `valueHint` also passes. The scan in #1546 counted 52 entries with bad argument types and 8 bare positional ones, my own paging of /v0/servers found even more of the first kind. One I checked by hand: `io.github.Jordan-Horner/symbols@1.0.1` (empty type under packageArguments), another is `com.keyboardcrumbs/mcp@1.0.1` (type "literal", still active). Every published schema version requires `type` to be "positional" or "named" and positional args to carry `value` or `valueHint`. Relates to #1546, the empty repository case is #1555's, and version "latest" is already handled since #413.

## Change

`validateArgument` becomes a switch. Named branch unchanged. Positional now requires `value` or `valueHint`. Unknown or empty `type` is rejected. Two new errors in constants.go, references `invalid-argument-type` and `positional-argument-value-or-hint-required`.

Why not full schema validation at publish: the enhanced validation design doc gates that behind the anyOf error consolidation (Phase 3), raw anyOf failures on arguments come out as a noisy multi-error cluster. These two checks give one clean message each and are one case arm each, easy to delete at Phase 5 when schema-first lands. Until then publish and edit just agree with what /v0/validate already reports.

Heads up on two consequences: editing a stored server that still carries one of these legacy arguments will 422 until the argument is fixed, and the importer skips invalid servers with a warning, so a re-seed from a live dump drops those entries instead of failing. Also #1339 adds a check inside the named branch of the same function, whichever lands second has a small conflict to resolve there, happy to do it from my side.

## Test

Tests first, they fail on main, the handler regression actually publishes an empty-type argument with 200 on main and gets 422 with the fix. On the branch: go test ./internal/... all green including the handler tests against postgres, golangci-lint v2.13.1 (what CI pins) 0 issues, make validate passes. Two existing fixtures had positional args with neither value nor valueHint, they got a valueHint since no published schema version ever allowed that shape. New error paths and references are pinned in validation_detailed_test.go.

## AI Disclosure

AI assistance (Claude) was used for issue research and during development. All changes were reviewed and tested by the author.
