### PR TITLE
docs: carry two modelcontextprotocol.io fixes back upstream

### DIFF
--- a/docs/modelcontextprotocol-io/faq.mdx
+++ b/docs/modelcontextprotocol-io/faq.mdx
@@ -52,7 +52,7 @@ There is a 4KB size limit (4096 bytes of JSON). Publishing will fail if this lim
 
 ### What if I need to report a spam or malicious server?
 
-1. Report it as abuse to the underlying package registry (e.g. NPM, PyPi, DockerHub, etc.); and
+1. Report it as abuse to the underlying package registry (e.g. NPM, PyPI, DockerHub, etc.); and
 2. Raise a GitHub issue on the registry repo with a title beginning `Abuse report: `
 
 ### What if I need to report a security vulnerability in the registry itself?

--- a/docs/modelcontextprotocol-io/remote-servers.mdx
+++ b/docs/modelcontextprotocol-io/remote-servers.mdx
@@ -29,7 +29,7 @@ A remote server **MUST** be publicly accessible at its specified URL.
 
 ## Transport Type
 
-Remote servers can use the Streamable HTTP transport (recommended) or the SSE transport. Remote servers can also support both transports simultaneously at different URLs.
+Remote servers should use the Streamable HTTP transport. The SSE transport is [deprecated](/specification/draft/deprecated), so publish an `"sse"` remote only to support existing clients. Remote servers can also support both transports simultaneously at different URLs.
 
 Specify the transport by setting the `type` property of the `remotes` entry to either `"streamable-http"` or `"sse"`:
 


### PR DESCRIPTION
Both were already fixed on https://modelcontextprotocol.io; this copy is behind.

- `faq.mdx`: capitalize PyPI correctly in the abuse reporting steps. https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3153
- `remote-servers.mdx`: recommend Streamable HTTP and link the deprecated features page. The 2026-07-28 draft reclassifies the HTTP+SSE transport as deprecated under the feature lifecycle policy, so SSE should no longer be presented as an equal option. https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3064

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
