### PR TITLE
Add Kilawatt Cloud MCP Server

### DIFF
--- a/data/data/servers/kilawatt-mcp-server.json⁠
+++ b/data/data/servers/kilawatt-mcp-server.json⁠
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.kilawattcloud/kilawatt-mcp-server",
+  "description": "Zero-quota GPU compute orchestration and dry-run node allocation for Kilawatt Cloud.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/KilaWattCloud/kilawatt-mcp-server"
+  },
+  "website": "https://kilawattcloud.dev"
+}


### PR DESCRIPTION
Add JSON schema for Kilawatt MCP server configuration

Motivation and Context
Adds Kilawatt Cloud (`kilawatt-mcp-server`) to the official MCP registry to enable zero-quota GPU orchestration and dry-run compute allocations directly within MCP-compatible clients (Cursor, Claude Desktop).

How Has This Been Tested?
Validated against the `server.schema.json` format locally. Verified metadata fields, repository pointers (`https://github.com/KilaWattCloud/kilawatt-mcp-server`), and namespace format (`io.github.kilawattcloud`).

Breaking Changes
None

Types of changes
- [x] New feature (non-breaking change which adds functionality)

Checklist
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
