### PR TITLE
feat: add io.github.tareq7/muslim-prayer-mcp server

### DIFF
--- a/servers/io.github.tareq7/muslim-prayer-mcp.json
+++ b/servers/io.github.tareq7/muslim-prayer-mcp.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tareq7/muslim-prayer-mcp",
+  "title": "Muslim Prayer Reminder MCP",
+  "description": "Production-ready Muslim prayer reminder MCP on Cloudflare Workers with Streamable HTTP, automatic location-based calculation authority calibration, mandatory theological disclosure, and deterministic host middleware.",
+  "repository": {
+    "url": "https://github.com/tareq7/muslim-prayer-mcp",
+    "source": "github"
+  },
+  "version": "1.0.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "muslim-prayer-mcp",
+      "version": "1.0.1",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://muslim-prayer-mcp.najetareqz.workers.dev/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation and Context
Adds \io.github.tareq7/muslim-prayer-mcp\ to the official Model Context Protocol Registry.

\muslim-prayer-mcp\ is a production-ready Muslim prayer reminder MCP server running on Cloudflare Workers edge, exposing both Streamable HTTP and stdio NPX transport. It features sub-millisecond astronomical solar calculations (Adhan engine), automatic location-based calculation authority calibration (Palestinian Awqaf, Umm al-Qura, Dubai, Qatar, Kuwait, ISNA, MWL, etc.), and mandatory theological disclosure for LLMs.

- **Repository**: https://github.com/tareq7/muslim-prayer-mcp
- **NPM Package**: https://www.npmjs.com/package/muslim-prayer-mcp
- **Documentation**: https://tareq7.github.io/muslim-prayer-mcp/
- **Remote Endpoint**: \https://muslim-prayer-mcp.najetareqz.workers.dev/mcp\

## How Has This Been Tested?
- Verified with 44 automated test suites covering astronomical calculation across 10 benchmark global cities, DST transitions, high-latitude polar rules, and JSON-RPC 2.0 conformance.
- Validated live on Cloudflare Workers edge with live Streamable HTTP probe.
- Conforms to MCP Server Schema specification (\2025-12-11/server.schema.json\).

## Breaking Changes
None.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed