### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,28 +3,28 @@ updates:
   - package-ecosystem: gomod
     directory: /
     groups:
-      opentelemetry:
+      go-dependencies:
         patterns:
-          - "go.opentelemetry.io/*"
+          - "*"
     schedule:
       interval: weekly
   - package-ecosystem: gomod
     directory: /deploy
     groups:
-      opentelemetry:
+      deploy-go-dependencies:
         patterns:
-          - "go.opentelemetry.io/*"
+          - "*"
     schedule:
       interval: weekly
   - package-ecosystem: github-actions
     directory: /
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
     schedule:
       interval: weekly
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: docker
+    directory: /
     schedule:
-        interval: "weekly"
+      interval: weekly


### PR DESCRIPTION
## Summary

- group all root Go module updates into one weekly PR
- group all deployment Go module updates into a separate weekly PR
- keep GitHub Actions updates in their own weekly group
- leave Docker updates independent

## Validation

- parsed `.github/dependabot.yml` successfully as YAML
- `git diff --check` passes