### PR TITLE
ci: detect more invalid server publish paths

### DIFF
--- a/.github/workflows/close-invalid-publish-prs.yml
+++ b/.github/workflows/close-invalid-publish-prs.yml
@@ -127,6 +127,8 @@ jobs:
           for f in "${FILES[@]}"; do
             if [[ "$f" == servers/* \
                || "$f" == data/servers/* \
+               || "$f" == data/data/servers/* \
+               || "$f" =~ ^data/[^/]*server\.json$ \
                || "$f" == "data/seed.json" \
                || "$f" == "server.json" \
                || "$f" == "servers.json" ]]; then

--- a/.github/workflows/detect-invalid-publish-prs.yml
+++ b/.github/workflows/detect-invalid-publish-prs.yml
@@ -63,6 +63,8 @@ jobs:
                 for f in "${FILES[@]}"; do
                   if [[ "$f" == servers/* \
                      || "$f" == data/servers/* \
+                     || "$f" == data/data/servers/* \
+                     || "$f" =~ ^data/[^/]*server\.json$ \
                      || "$f" == "data/seed.json" \
                      || "$f" == "server.json" \
                      || "$f" == "servers.json" ]]; then


### PR DESCRIPTION
## Summary

- detect publish attempts under `data/data/servers/`
- detect server-looking JSON files directly under `data/`
- keep the stage-one and privileged stage-two classifiers in sync

## Testing

- verified both new patterns against PRs #1600 and #1589
- verified ordinary files such as `data/example.json` remain unmatched
- ran `git diff --check`