### PR TITLE
fix: fail safely in registry admin scripts

### DIFF
--- a/tools/admin/auth.sh
+++ b/tools/admin/auth.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Simple OIDC authentication helper using gcloud
 
+set -euo pipefail
+
 REGISTRY_URL="${REGISTRY_URL:-https://registry.modelcontextprotocol.io}"
 
 if ! gcloud projects list &> /dev/null; then

--- a/tools/admin/auth.sh
+++ b/tools/admin/auth.sh
@@ -13,16 +13,20 @@ fi
 OIDC_TOKEN=$(gcloud auth print-identity-token)
 
 # Exchange for registry token
-RESPONSE=$(curl -s -X POST "${REGISTRY_URL}/v0/auth/oidc" \
+RESPONSE=$(curl -sS -X POST "${REGISTRY_URL}/v0/auth/oidc" \
   -H "Content-Type: application/json" \
   -d "{\"oidc_token\": \"${OIDC_TOKEN}\"}")
 
 # Check if successful
-REGISTRY_TOKEN=$(echo "$RESPONSE" | jq -r '.registry_token // empty')
+if ! REGISTRY_TOKEN=$(printf '%s\n' "$RESPONSE" | jq -r '.registry_token // empty' 2>/dev/null); then
+    REGISTRY_TOKEN=""
+fi
 
 if [ -z "$REGISTRY_TOKEN" ]; then
     echo "Error: Authentication failed" >&2
-    echo "$RESPONSE" | jq '.' >&2
+    if ! printf '%s\n' "$RESPONSE" | jq '.' >&2 2>/dev/null; then
+        printf '%s\n' "$RESPONSE" >&2
+    fi
     exit 1
 fi
 

--- a/tools/admin/takedown.sh
+++ b/tools/admin/takedown.sh
@@ -34,6 +34,10 @@ fi
 
 # Require an explicit choice, so that a forgotten VERSION cannot silently take
 # down every version of a server.
+if [ -n "$ALL_VERSIONS" ] && [ "$ALL_VERSIONS" != "true" ]; then
+    echo "Error: ALL_VERSIONS must be exactly true when set." >&2
+    exit 1
+fi
 if [ -n "$VERSION" ] && [ -n "$ALL_VERSIONS" ]; then
     echo "Error: set either VERSION or ALL_VERSIONS, not both." >&2
     exit 1


### PR DESCRIPTION
The takedown script previously treated any nonempty `ALL_VERSIONS` value, including `false`, as permission to delete every version. Require exactly `true` when the variable is set, and reject other values before sending a request.

Enable strict shell error handling in the auth helper so a failed identity-token command stops execution before exchanging an empty token.

Validation: `bash -n` and `git diff --check` passed. Mocked command checks confirmed that `false`, `1`, and `TRUE` are rejected before network access, and that identity-token retrieval failure stops before the token exchange. The updated scripts also completed the authorized takedown associated with #1563; public API reads confirmed the deleted record and removal from default results.
