### PR TITLE
docs: pin and verify mcp-publisher in the GitHub Actions publishing workflow

### DIFF
--- a/docs/modelcontextprotocol-io/github-actions.mdx
+++ b/docs/modelcontextprotocol-io/github-actions.mdx
@@ -11,6 +11,8 @@ sidebarTitle: GitHub Actions
 
 In your server project directory, create a `.github/workflows/publish-mcp.yml` file. Here is an example for npm-based local server, but the MCP Registry publishing steps are the same for all package types:
 
+**Important: Pin the version and verify the signature.** When running a downloaded binary in a job holding your publishing credential, always pin to an explicit released version (never `latest`, which is mutable) and verify the signature before extracting. Look up the latest `mcp-publisher` version on [the releases page](https://github.com/modelcontextprotocol/registry/releases).
+
 <CodeGroup>
 
 ```yaml OIDC authentication (recommended)
@@ -54,9 +56,25 @@ jobs:
 
       ### Publish MCP server:
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz"
+          curl -fsSL -o mcp-publisher.tar.gz.sigstore.json \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz.sigstore.json"
+          cosign verify-blob \
+            --bundle mcp-publisher.tar.gz.sigstore.json \
+            --certificate-identity-regexp="^https://github.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v[0-9]" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            mcp-publisher.tar.gz
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz mcp-publisher.tar.gz.sigstore.json
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc
@@ -115,9 +133,25 @@ jobs:
 
       ### Publish MCP server:
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz"
+          curl -fsSL -o mcp-publisher.tar.gz.sigstore.json \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz.sigstore.json"
+          cosign verify-blob \
+            --bundle mcp-publisher.tar.gz.sigstore.json \
+            --certificate-identity-regexp="^https://github.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v[0-9]" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            mcp-publisher.tar.gz
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz mcp-publisher.tar.gz.sigstore.json
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github --token ${{ secrets.MCP_GITHUB_TOKEN }}
@@ -172,9 +206,25 @@ jobs:
 
       ### Publish MCP server:
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          export OS=$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz"
+          curl -fsSL -o mcp-publisher.tar.gz.sigstore.json \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${OS}.tar.gz.sigstore.json"
+          cosign verify-blob \
+            --bundle mcp-publisher.tar.gz.sigstore.json \
+            --certificate-identity-regexp="^https://github.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v[0-9]" \
+            --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+            mcp-publisher.tar.gz
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          rm mcp-publisher.tar.gz mcp-publisher.tar.gz.sigstore.json
 
       # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       # TODO: Replace `example.com` with your domain name


### PR DESCRIPTION
Fixes #1505

## Problem

The GitHub Actions publishing guide has three copies (OIDC, PAT, DNS variants) of the same install step, which downloads `mcp-publisher` from `releases/latest` and pipes it straight into `tar`, inside the job that holds the publishing credential. As the issue lays out: `latest` is mutable, so two runs of an unchanged workflow either side of a release execute different bytes; the repository already signs every release asset (goreleaser `signs:` in `.goreleaser.yaml` runs `cosign sign-blob --bundle`), but the guide never checks the signature; and the unverified binary runs with the credential.

## Change

All three variants now:

- pin the version through a single `MCP_PUBLISHER_VERSION` env var (currently `v1.8.1`), with a sentence above the first snippet on why and where to find the current release;
- download the tarball and its `.sigstore.json` bundle to disk;
- run `cosign verify-blob` before extracting, using the same SHA-pinned `sigstore/cosign-installer` the release workflow itself uses;
- extract, then remove the temporary files.

The identity check is:

```
--certificate-identity-regexp="^https://github.com/modelcontextprotocol/registry/\.github/workflows/release\.yml@refs/tags/v[0-9]"
--certificate-oidc-issuer="https://token.actions.githubusercontent.com"
```

I derived it from the actual v1.8.1 bundle rather than from the workflow file alone: decoding the certificate in `mcp-publisher_linux_amd64.tar.gz.sigstore.json` gives the SAN `https://github.com/modelcontextprotocol/registry/.github/workflows/release.yml@refs/tags/v1.8.1` and the GitHub Actions OIDC issuer. The regexp is anchored to `release.yml` on a tag ref, so a bundle signed by any other workflow or branch in this repository is rejected.

`docs/modelcontextprotocol-io/quickstart.mdx` (one-off local install) is left as-is; the threat model there is different and the issue is about the credential-holding CI job.

## Validation

The three workflow blocks parse as YAML and each contains the new `Install Cosign` and pinned install steps. I have not run the workflow end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qnxf2u2kSBxRM1AT7kD8BD